### PR TITLE
Implement agy-mcp: async, restart-resilient MCP server for the Antigravity CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,34 @@ name: ci
 on:
   push:
   pull_request:
+permissions:
+  contents: read
+env:
+  GO_VERSION: '1.26'
+  # Pinned to match the local toolchain so local runs and CI use the same
+  # linter version (and the same ruleguard behavior).
+  GOLANGCI_LINT_VERSION: 'v2.11.4'
 jobs:
   build:
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26'
+          go-version: ${{ env.GO_VERSION }}
       - run: go build ./...
       - run: go vet ./...
-      - run: go test ./...
+      - run: go test ./... -race
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: ci
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work.sum
 *~
 .idea/
 .vscode/
+.serena/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,77 @@
+# Copied from github.com/tphakala/go-flac (which adapts birdnet-go's config) to
+# keep one linting standard across projects, including the rules/*.go ruleguard
+# matchers. agy-mcp-specific adaptation:
+#   - gocritic hugeParam is disabled: StartRequest, config.Config and
+#     jobstore.Meta are passed by value on purpose (StartJob mutates its own
+#     copy of the request), and these calls are not on a hot path, so the
+#     by-pointer suggestion would only leak mutation into callers.
+#   - modernize stays disabled: it panics on Go 1.26 + atomic types in
+#     golangci-lint v2.11.4 (known bug)
+version: "2"
+output:
+  sort-order:
+    - linter
+    - severity
+    - file
+linters:
+  enable:
+    - bodyclose
+    - copyloopvar
+    - dupl
+    - durationcheck
+    - errname
+    - errorlint
+    - exhaustive
+    - fatcontext
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - iface
+    - ineffassign
+    - misspell
+    - nilerr
+    - nilnil
+    - predeclared
+    - prealloc
+    - revive
+    - staticcheck
+    - testifylint
+    - thelper
+    - unconvert
+    - wastedassign
+  disable:
+    - unused
+  settings:
+    gocognit:
+      min-complexity: 50
+    gocritic:
+      # gocritic auto-enables the ruleguard check when settings.ruleguard.rules
+      # is set; the rules/*.go matchers carry the //go:build ruleguard tag so
+      # the normal toolchain ignores them.
+      disabled-checks:
+        - commentFormatting
+        - commentedOutCode
+        - hugeParam
+      enabled-tags:
+        - style
+        - diagnostic
+        - performance
+      settings:
+        ruleguard:
+          rules: "rules/*.go"
+    revive:
+      rules:
+        - name: unused-parameter
+          disabled: true
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: true
+    exhaustive:
+      default-signifies-exhaustive: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  uniq-by-line: true
+  new: false

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Session continuation rides `agy`'s own durable conversation store (`--conversati
 ## Transports
 
 - **stdio** (default): zero-config, add one line to your MCP client config.
-- **Streamable HTTP** (opt-in): `agy-mcp serve --http :PORT` runs the same core as a long-lived daemon for multi-client use.
+- **Streamable HTTP** (opt-in): `agy-mcp -http 127.0.0.1:8765` runs the same core as a long-lived daemon for multi-client use. It is unauthenticated and intended for localhost only; do not bind it to a public interface.
 
 ## Requirements
 
@@ -34,3 +34,51 @@ Session continuation rides `agy`'s own durable conversation store (`--conversati
 ## License
 
 MIT. See [LICENSE](LICENSE).
+
+## Install
+
+```bash
+go install github.com/tphakala/agy-mcp@latest
+```
+
+Requires the `agy` binary on `PATH` (or set `AGY_MCP_AGY_PATH`).
+
+## Use with Claude Code (stdio)
+
+```bash
+claude mcp add agy -- agy-mcp
+```
+
+Or add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "agy": { "command": "agy-mcp" }
+  }
+}
+```
+
+## Tools
+
+- `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?)` -> `{ job_id, conversation_id, state }`
+- `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id? }`
+- `agy_cancel(job_id)` -> `{ state }`
+- `list_models()` -> `{ models }`
+- `list_sessions(dir?)` -> `{ sessions }`
+
+## HTTP mode
+
+```bash
+agy-mcp -http 127.0.0.1:8765
+```
+
+HTTP mode is opt-in and unauthenticated. Bind it to localhost only; do not expose it on a public interface.
+
+## Configuration
+
+| Env | Default | Meaning |
+|-----|---------|---------|
+| `AGY_MCP_AGY_PATH` | `agy` on PATH | path to the agy binary |
+| `AGY_MCP_STATE_DIR` | `$XDG_STATE_HOME/agy-mcp` | job state directory |
+| `AGY_MCP_DEFAULT_MODEL` | agy default | default model |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Session continuation rides `agy`'s own durable conversation store (`--conversati
 
 ## Requirements
 
+- Linux. The job supervisor relies on process groups, `/proc`, and the kernel boot id, so the server is Linux only for now. Cross-platform support is a possible future enhancement.
 - The `agy` binary on `PATH` (or configured explicitly).
 - Go 1.26+ to build.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An MCP (Model Context Protocol) server that wraps the [Antigravity CLI](https://antigravity.google) (`agy`), so any MCP client (Claude Code, Cursor, Cline, and others) can run `agy` prompts, peer reviews, and follow-up turns as native tools.
 
-> Status: early development. The design is being finalized before implementation.
+> Status: initial implementation complete (stdio and HTTP transports, async job lifecycle, model and session discovery). Pending a one-off verification against the real agy before a tagged release.
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Session continuation rides `agy`'s own durable conversation store (`--conversati
 ## Transports
 
 - **stdio** (default): zero-config, add one line to your MCP client config.
-- **Streamable HTTP** (opt-in): `agy-mcp -http 127.0.0.1:8765` runs the same core as a long-lived daemon for multi-client use. It is unauthenticated and intended for localhost only; do not bind it to a public interface.
+- **Streamable HTTP** (opt-in): `agy-mcp -http 127.0.0.1:8765` runs the same core as a long-lived daemon for multi-client use. It is unauthenticated, so the bind is restricted to loopback (`localhost`, `127.0.0.1`, `::1`); a non-loopback address is refused at startup.
 
 ## Requirements
 
@@ -74,7 +74,7 @@ Or add to your MCP client config:
 agy-mcp -http 127.0.0.1:8765
 ```
 
-HTTP mode is opt-in and unauthenticated. Bind it to localhost only; do not expose it on a public interface.
+HTTP mode is opt-in and unauthenticated, so it only accepts a loopback bind address (`localhost`, `127.0.0.1`, or `::1`). A non-loopback address (including `:8765`, which binds all interfaces) is refused at startup, so it cannot be accidentally exposed.
 
 ## Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,13 @@
 module github.com/tphakala/agy-mcp
 
 go 1.26
+
+require (
+	github.com/google/jsonschema-go v0.4.3 // indirect
+	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/tphakala/agy-mcp
 
 go 1.26
 
+require github.com/modelcontextprotocol/go-sdk v1.6.1
+
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
-	github.com/modelcontextprotocol/go-sdk v1.6.1 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/tphakala/agy-mcp
 
 go 1.26
 
-require github.com/modelcontextprotocol/go-sdk v1.6.1
+require (
+	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/quasilyte/go-ruleguard/dsl v0.3.23
+)
 
 require (
 	github.com/google/jsonschema-go v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
@@ -12,3 +16,5 @@ golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
 github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,63 @@
+// Package config resolves agy-mcp runtime configuration from environment and defaults.
+package config
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// Config holds resolved runtime settings.
+type Config struct {
+	AgyPath        string        // path to the agy binary
+	SupervisorExe  string        // path to the agy-mcp binary used as the run-job supervisor
+	StateDir       string        // root of the on-disk job store
+	DefaultModel   string        // empty means let agy use its configured default
+	DefaultTimeout time.Duration // hard per-job timeout
+	MaxConcurrency int           // global cap on concurrent jobs
+	JobTTL         time.Duration // age after which finished jobs are GC'd
+}
+
+// Resolve builds a Config from environment variables and defaults.
+func Resolve() (Config, error) {
+	c := Config{
+		DefaultModel:   os.Getenv("AGY_MCP_DEFAULT_MODEL"),
+		DefaultTimeout: 30 * time.Minute,
+		MaxConcurrency: 4,
+		JobTTL:         24 * time.Hour,
+	}
+
+	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {
+		c.AgyPath = p
+	} else {
+		p, err := exec.LookPath("agy")
+		if err != nil {
+			return Config{}, fmt.Errorf("agy not found on PATH; set AGY_MCP_AGY_PATH: %w", err)
+		}
+		c.AgyPath = p
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve own executable: %w", err)
+	}
+	c.SupervisorExe = self
+
+	stateRoot := os.Getenv("AGY_MCP_STATE_DIR")
+	if stateRoot == "" {
+		xdg := os.Getenv("XDG_STATE_HOME")
+		if xdg == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return Config{}, fmt.Errorf("resolve home: %w", err)
+			}
+			xdg = filepath.Join(home, ".local", "state")
+		}
+		stateRoot = filepath.Join(xdg, "agy-mcp")
+	}
+	c.StateDir = stateRoot
+
+	return c, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestResolveDefaults(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "/tmp/xdgstate")
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	// Put a fake agy on PATH.
+	dir := t.TempDir()
+	agy := filepath.Join(dir, "agy")
+	if err := os.WriteFile(agy, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	c, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if c.AgyPath != agy {
+		t.Errorf("AgyPath = %q, want %q", c.AgyPath, agy)
+	}
+	if c.StateDir != "/tmp/xdgstate/agy-mcp" {
+		t.Errorf("StateDir = %q", c.StateDir)
+	}
+	if c.DefaultTimeout != 30*time.Minute {
+		t.Errorf("DefaultTimeout = %v", c.DefaultTimeout)
+	}
+	if c.MaxConcurrency != 4 {
+		t.Errorf("MaxConcurrency = %d", c.MaxConcurrency)
+	}
+}
+
+func TestResolveAgyPathOverride(t *testing.T) {
+	t.Setenv("AGY_MCP_AGY_PATH", "/opt/custom/agy")
+	c, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if c.AgyPath != "/opt/custom/agy" {
+		t.Errorf("AgyPath = %q", c.AgyPath)
+	}
+}

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -72,6 +72,25 @@ func (s *Store) Load(id string) (Meta, error) {
 	return m, json.Unmarshal(b, &m)
 }
 
+// UpdateMeta atomically rewrites a job's meta.json by writing a temp file and
+// renaming it into place, so a concurrent reader (such as the freshly spawned
+// supervisor) never observes a partially written file.
+func (s *Store) UpdateMeta(m Meta) error {
+	dir := s.jobDir(m.ID)
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(dir, "meta.json.tmp")
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(dir, "meta.json"))
+}
+
+// Remove deletes a job's directory and everything in it.
+func (s *Store) Remove(id string) error { return os.RemoveAll(s.jobDir(id)) }
+
 // Dir returns the on-disk directory for a job (out, err, exit_code live here).
 func (s *Store) Dir(id string) string { return s.jobDir(id) }
 
@@ -109,26 +128,4 @@ func (s *Store) List() ([]string, error) {
 		}
 	}
 	return ids, nil
-}
-
-// GC removes finished jobs whose StartedAt is older than ttl. Returns removed IDs.
-func (s *Store) GC(ttl time.Duration) ([]string, error) {
-	ids, err := s.List()
-	if err != nil {
-		return nil, err
-	}
-	cutoff := time.Now().Add(-ttl)
-	var removed []string
-	for _, id := range ids {
-		m, err := s.Load(id)
-		if err != nil {
-			continue
-		}
-		if m.StartedAt.Before(cutoff) {
-			if err := os.RemoveAll(s.jobDir(id)); err == nil {
-				removed = append(removed, id)
-			}
-		}
-	}
-	return removed, nil
 }

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -13,17 +13,18 @@ import (
 
 // Meta describes a job. It is written once at creation and is immutable.
 type Meta struct {
-	ID             string    `json:"id"`
-	AgyPath        string    `json:"agy_path"`
-	Args           []string  `json:"args"`
-	Cwd            string    `json:"cwd"`
-	Model          string    `json:"model,omitempty"`
-	ConversationID string    `json:"conversation_id,omitempty"`
-	Prompt         string    `json:"prompt"`
-	StartedAt      time.Time `json:"started_at"`
-	PID            int       `json:"pid"`
-	BootID         string    `json:"boot_id"`
-	CwdUUIDBefore  string    `json:"cwd_uuid_before,omitempty"`
+	ID             string        `json:"id"`
+	AgyPath        string        `json:"agy_path"`
+	Args           []string      `json:"args"`
+	Cwd            string        `json:"cwd"`
+	Model          string        `json:"model,omitempty"`
+	ConversationID string        `json:"conversation_id,omitempty"`
+	Prompt         string        `json:"prompt"`
+	StartedAt      time.Time     `json:"started_at"`
+	PID            int           `json:"pid"`
+	BootID         string        `json:"boot_id"`
+	CwdUUIDBefore  string        `json:"cwd_uuid_before,omitempty"`
+	Timeout        time.Duration `json:"timeout,omitempty"`
 }
 
 // Store is a directory-backed collection of jobs.

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -27,6 +27,17 @@ type Meta struct {
 	Timeout        time.Duration `json:"timeout,omitempty"`
 }
 
+// Exit-code sentinels the supervisor writes to the exit_code file and the
+// manager interprets when deriving status. The 128+signal values follow the
+// shell convention; 124 follows GNU timeout's convention for a timed-out
+// command.
+const (
+	ExitTimeout   = 124 // hard timeout fired; the agy process group was terminated
+	ExitSpawnFail = 127 // the supervisor could not start agy
+	ExitSIGINT    = 130 // agy exited via SIGINT (128+2); treated as a cancel
+	ExitSIGTERM   = 143 // agy terminated by SIGTERM (128+15); cancel or timeout kill
+)
+
 // Store is a directory-backed collection of jobs.
 type Store struct{ root string }
 

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -40,6 +40,9 @@ const (
 	ExitSIGTERM   = 143 // agy terminated by SIGTERM (128+15); cancel or timeout kill
 )
 
+// ErrInvalidID is returned when a job id is not a safe path segment.
+var ErrInvalidID = errors.New("invalid job id")
+
 // Store is a directory-backed collection of jobs.
 type Store struct{ root string }
 
@@ -48,8 +51,25 @@ func New(dir string) *Store { return &Store{root: filepath.Join(dir, "jobs")} }
 
 func (s *Store) jobDir(id string) string { return filepath.Join(s.root, id) }
 
+// validJobID reports whether id is a safe single path segment, with no path
+// separators or parent-directory traversal, so it can never escape the store
+// root when joined into a filesystem path. Server-generated ids always pass;
+// this guards against a malicious client-supplied job_id reaching the store.
+func validJobID(id string) bool {
+	if id == "" || id == "." || id == ".." {
+		return false
+	}
+	if strings.ContainsAny(id, `/\`) {
+		return false
+	}
+	return filepath.Base(id) == id
+}
+
 // Create writes meta.json for a new job and returns its directory.
 func (s *Store) Create(m Meta) (string, error) {
+	if !validJobID(m.ID) {
+		return "", ErrInvalidID
+	}
 	dir := s.jobDir(m.ID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
@@ -67,6 +87,9 @@ func (s *Store) Create(m Meta) (string, error) {
 // Load reads a job's Meta.
 func (s *Store) Load(id string) (Meta, error) {
 	var m Meta
+	if !validJobID(id) {
+		return m, ErrInvalidID
+	}
 	b, err := os.ReadFile(filepath.Join(s.jobDir(id), "meta.json"))
 	if err != nil {
 		return m, err
@@ -81,6 +104,9 @@ func (s *Store) Load(id string) (Meta, error) {
 // renaming it into place, so a concurrent reader (such as the freshly spawned
 // supervisor) never observes a partially written file.
 func (s *Store) UpdateMeta(m Meta) error {
+	if !validJobID(m.ID) {
+		return ErrInvalidID
+	}
 	dir := s.jobDir(m.ID)
 	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -90,22 +116,37 @@ func (s *Store) UpdateMeta(m Meta) error {
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, filepath.Join(dir, "meta.json"))
+	if err := os.Rename(tmp, filepath.Join(dir, "meta.json")); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // Remove deletes a job's directory and everything in it.
-func (s *Store) Remove(id string) error { return os.RemoveAll(s.jobDir(id)) }
+func (s *Store) Remove(id string) error {
+	if !validJobID(id) {
+		return ErrInvalidID
+	}
+	return os.RemoveAll(s.jobDir(id))
+}
 
 // Dir returns the on-disk directory for a job (out, err, exit_code live here).
 func (s *Store) Dir(id string) string { return s.jobDir(id) }
 
 // WriteExitCode writes the completion sentinel.
 func (s *Store) WriteExitCode(id string, code int) error {
+	if !validJobID(id) {
+		return ErrInvalidID
+	}
 	return os.WriteFile(filepath.Join(s.jobDir(id), "exit_code"), []byte(strconv.Itoa(code)), 0o644)
 }
 
 // ExitCode returns the recorded exit code and whether it is present.
 func (s *Store) ExitCode(id string) (int, bool) {
+	if !validJobID(id) {
+		return 0, false
+	}
 	b, err := os.ReadFile(filepath.Join(s.jobDir(id), "exit_code"))
 	if err != nil {
 		return 0, false

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -1,0 +1,121 @@
+// Package jobstore persists agy-mcp job state to disk so jobs survive a
+// manager restart.
+package jobstore
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Meta describes a job. It is written once at creation and is immutable.
+type Meta struct {
+	ID             string    `json:"id"`
+	AgyPath        string    `json:"agy_path"`
+	Args           []string  `json:"args"`
+	Cwd            string    `json:"cwd"`
+	Model          string    `json:"model,omitempty"`
+	ConversationID string    `json:"conversation_id,omitempty"`
+	Prompt         string    `json:"prompt"`
+	StartedAt      time.Time `json:"started_at"`
+	PID            int       `json:"pid"`
+	BootID         string    `json:"boot_id"`
+}
+
+// Store is a directory-backed collection of jobs.
+type Store struct{ root string }
+
+// New returns a Store rooted at dir/jobs.
+func New(dir string) *Store { return &Store{root: filepath.Join(dir, "jobs")} }
+
+func (s *Store) jobDir(id string) string { return filepath.Join(s.root, id) }
+
+// Create writes meta.json for a new job and returns its directory.
+func (s *Store) Create(m Meta) (string, error) {
+	dir := s.jobDir(m.ID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// Load reads a job's Meta.
+func (s *Store) Load(id string) (Meta, error) {
+	var m Meta
+	b, err := os.ReadFile(filepath.Join(s.jobDir(id), "meta.json"))
+	if err != nil {
+		return m, err
+	}
+	return m, json.Unmarshal(b, &m)
+}
+
+// Dir returns the on-disk directory for a job (out, err, exit_code live here).
+func (s *Store) Dir(id string) string { return s.jobDir(id) }
+
+// WriteExitCode writes the completion sentinel.
+func (s *Store) WriteExitCode(id string, code int) error {
+	return os.WriteFile(filepath.Join(s.jobDir(id), "exit_code"), []byte(strconv.Itoa(code)), 0o644)
+}
+
+// ExitCode returns the recorded exit code and whether it is present.
+func (s *Store) ExitCode(id string) (int, bool) {
+	b, err := os.ReadFile(filepath.Join(s.jobDir(id), "exit_code"))
+	if err != nil {
+		return 0, false
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		return 0, false
+	}
+	return code, true
+}
+
+// List returns all known job IDs.
+func (s *Store) List() ([]string, error) {
+	entries, err := os.ReadDir(s.root)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() {
+			ids = append(ids, e.Name())
+		}
+	}
+	return ids, nil
+}
+
+// GC removes finished jobs whose StartedAt is older than ttl. Returns removed IDs.
+func (s *Store) GC(ttl time.Duration) ([]string, error) {
+	ids, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	cutoff := time.Now().Add(-ttl)
+	var removed []string
+	for _, id := range ids {
+		m, err := s.Load(id)
+		if err != nil {
+			continue
+		}
+		if m.StartedAt.Before(cutoff) {
+			if err := os.RemoveAll(s.jobDir(id)); err == nil {
+				removed = append(removed, id)
+			}
+		}
+	}
+	return removed, nil
+}

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -4,6 +4,8 @@ package jobstore
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -115,7 +117,7 @@ func (s *Store) ExitCode(id string) (int, bool) {
 // List returns all known job IDs.
 func (s *Store) List() ([]string, error) {
 	entries, err := os.ReadDir(s.root)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -23,6 +23,7 @@ type Meta struct {
 	StartedAt      time.Time `json:"started_at"`
 	PID            int       `json:"pid"`
 	BootID         string    `json:"boot_id"`
+	CwdUUIDBefore  string    `json:"cwd_uuid_before,omitempty"`
 }
 
 // Store is a directory-backed collection of jobs.

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -71,7 +71,10 @@ func (s *Store) Load(id string) (Meta, error) {
 	if err != nil {
 		return m, err
 	}
-	return m, json.Unmarshal(b, &m)
+	if err := json.Unmarshal(b, &m); err != nil {
+		return m, err
+	}
+	return m, nil
 }
 
 // UpdateMeta atomically rewrites a job's meta.json by writing a temp file and

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -3,6 +3,7 @@ package jobstore
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
@@ -32,6 +33,32 @@ func TestCreateAndLoadMeta(t *testing.T) {
 	if got.PID != 4242 || got.AgyPath != "/usr/bin/agy" {
 		t.Fatalf("round-trip mismatch: %+v", got)
 	}
+	if got.Cwd != "/work" || got.BootID != "boot-abc" {
+		t.Fatalf("round-trip cwd/bootid mismatch: %+v", got)
+	}
+	if !slices.Equal(got.Args, m.Args) {
+		t.Fatalf("round-trip args = %v, want %v", got.Args, m.Args)
+	}
+	if !got.StartedAt.Equal(m.StartedAt) {
+		t.Fatalf("round-trip startedAt = %v, want %v", got.StartedAt, m.StartedAt)
+	}
+}
+
+func TestUpdateMetaRoundTrip(t *testing.T) {
+	s := New(t.TempDir())
+	if _, err := s.Create(Meta{ID: "j"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateMeta(Meta{ID: "j", PID: 99, AgyPath: "/x"}); err != nil {
+		t.Fatalf("UpdateMeta: %v", err)
+	}
+	got, err := s.Load("j")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PID != 99 || got.AgyPath != "/x" {
+		t.Fatalf("UpdateMeta round-trip = %+v", got)
+	}
 }
 
 func TestExitCodeSentinel(t *testing.T) {
@@ -51,19 +78,19 @@ func TestExitCodeSentinel(t *testing.T) {
 	}
 }
 
-func TestListAndGC(t *testing.T) {
+func TestListAndRemove(t *testing.T) {
 	s := New(t.TempDir())
-	_, _ = s.Create(Meta{ID: "old", StartedAt: time.Unix(0, 0)})
-	_, _ = s.Create(Meta{ID: "new", StartedAt: time.Now()})
+	_, _ = s.Create(Meta{ID: "a", StartedAt: time.Unix(0, 0)})
+	_, _ = s.Create(Meta{ID: "b", StartedAt: time.Now()})
 	ids, err := s.List()
 	if err != nil || len(ids) != 2 {
 		t.Fatalf("List = %v, %v", ids, err)
 	}
-	removed, err := s.GC(time.Hour)
-	if err != nil {
-		t.Fatal(err)
+	if err := s.Remove("a"); err != nil {
+		t.Fatalf("Remove: %v", err)
 	}
-	if len(removed) != 1 || removed[0] != "old" {
-		t.Fatalf("GC removed = %v", removed)
+	ids, _ = s.List()
+	if len(ids) != 1 || ids[0] != "b" {
+		t.Fatalf("after Remove, List = %v", ids)
 	}
 }

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -1,12 +1,31 @@
 package jobstore
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
 	"testing"
 	"time"
 )
+
+func TestRejectsUnsafeJobID(t *testing.T) {
+	s := New(t.TempDir())
+	for _, id := range []string{"", ".", "..", "../escape", "a/b", `a\b`} {
+		if _, err := s.Create(Meta{ID: id}); !errors.Is(err, ErrInvalidID) {
+			t.Errorf("Create(%q) err = %v, want ErrInvalidID", id, err)
+		}
+		if _, err := s.Load(id); !errors.Is(err, ErrInvalidID) {
+			t.Errorf("Load(%q) err = %v, want ErrInvalidID", id, err)
+		}
+		if err := s.Remove(id); !errors.Is(err, ErrInvalidID) {
+			t.Errorf("Remove(%q) err = %v, want ErrInvalidID", id, err)
+		}
+		if _, ok := s.ExitCode(id); ok {
+			t.Errorf("ExitCode(%q) ok = true, want false", id)
+		}
+	}
+}
 
 func TestCreateAndLoadMeta(t *testing.T) {
 	s := New(t.TempDir())

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -1,0 +1,69 @@
+package jobstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCreateAndLoadMeta(t *testing.T) {
+	s := New(t.TempDir())
+	m := Meta{
+		ID:        "job123",
+		AgyPath:   "/usr/bin/agy",
+		Args:      []string{"-p", "hi"},
+		Cwd:       "/work",
+		StartedAt: time.Unix(1000, 0).UTC(),
+		PID:       4242,
+		BootID:    "boot-abc",
+	}
+	dir, err := s.Create(m)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "meta.json")); err != nil {
+		t.Fatalf("meta.json missing: %v", err)
+	}
+	got, err := s.Load("job123")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.PID != 4242 || got.AgyPath != "/usr/bin/agy" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestExitCodeSentinel(t *testing.T) {
+	s := New(t.TempDir())
+	if _, err := s.Create(Meta{ID: "j"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.ExitCode("j"); ok {
+		t.Fatal("exit code should be absent before completion")
+	}
+	if err := s.WriteExitCode("j", 0); err != nil {
+		t.Fatal(err)
+	}
+	code, ok := s.ExitCode("j")
+	if !ok || code != 0 {
+		t.Fatalf("ExitCode = %d,%v", code, ok)
+	}
+}
+
+func TestListAndGC(t *testing.T) {
+	s := New(t.TempDir())
+	_, _ = s.Create(Meta{ID: "old", StartedAt: time.Unix(0, 0)})
+	_, _ = s.Create(Meta{ID: "new", StartedAt: time.Now()})
+	ids, err := s.List()
+	if err != nil || len(ids) != 2 {
+		t.Fatalf("List = %v, %v", ids, err)
+	}
+	removed, err := s.GC(time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "old" {
+		t.Fatalf("GC removed = %v", removed)
+	}
+}

--- a/internal/manager/cancel.go
+++ b/internal/manager/cancel.go
@@ -1,0 +1,28 @@
+package manager
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// Cancel asks the job's supervisor to terminate its agy child. The supervisor
+// forwards SIGTERM to agy and writes the exit-code sentinel, so the job ends in
+// a definite "cancelled" state. If the supervisor is already gone, Cancel is a
+// no-op success (Status will report the terminal state from disk).
+func (m *Manager) Cancel(id string) error {
+	meta, err := m.store.Load(id)
+	if err != nil {
+		return err
+	}
+	if meta.PID <= 0 {
+		return nil
+	}
+	if err := syscall.Kill(meta.PID, syscall.SIGTERM); err != nil {
+		// ESRCH means the supervisor already exited; treat as success.
+		if err == syscall.ESRCH {
+			return nil
+		}
+		return fmt.Errorf("signal supervisor: %w", err)
+	}
+	return nil
+}

--- a/internal/manager/cancel.go
+++ b/internal/manager/cancel.go
@@ -1,25 +1,30 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
 	"syscall"
 )
 
 // Cancel asks the job's supervisor to terminate its agy child. The supervisor
 // forwards SIGTERM to agy and writes the exit-code sentinel, so the job ends in
-// a definite "cancelled" state. If the supervisor is already gone, Cancel is a
-// no-op success (Status will report the terminal state from disk).
+// a definite "cancelled" state. If the supervisor is no longer alive (already
+// exited, or a stale PID from a previous boot), Cancel is a no-op success and
+// Status reports the terminal state from disk.
 func (m *Manager) Cancel(id string) error {
 	meta, err := m.store.Load(id)
 	if err != nil {
 		return err
 	}
-	if meta.PID <= 0 {
+	// Confirm the recorded PID is still our supervisor (boot id plus /proc comm)
+	// before signaling, so a recycled PID is never sent SIGTERM.
+	if !m.processAlive(meta) {
 		return nil
 	}
 	if err := syscall.Kill(meta.PID, syscall.SIGTERM); err != nil {
-		// ESRCH means the supervisor already exited; treat as success.
-		if err == syscall.ESRCH {
+		// ESRCH means the supervisor exited between the liveness check and the
+		// signal; treat it as success.
+		if errors.Is(err, syscall.ESRCH) {
 			return nil
 		}
 		return fmt.Errorf("signal supervisor: %w", err)

--- a/internal/manager/cancel_test.go
+++ b/internal/manager/cancel_test.go
@@ -1,0 +1,51 @@
+package manager
+
+import (
+	"os"
+	execpkg "os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+type execCmd = execpkg.Cmd
+
+func newExecCmd(name string, args ...string) *execCmd { return execpkg.Command(name, args...) }
+
+func exec_Command_sleep(t *testing.T) *execCmd {
+	t.Helper()
+	return newExecCmd("sleep", "30")
+}
+
+func TestCancelSignalsSupervisor(t *testing.T) {
+	m := newTestManager(t)
+	// Spawn a real sleeper process we can signal.
+	cmd := exec_Command_sleep(t)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Process.Kill() }()
+
+	dir, _ := m.store.Create(jobstore.Meta{
+		ID: "j", PID: cmd.Process.Pid, BootID: readBootID(), StartedAt: time.Now(),
+	})
+	_ = dir
+
+	if err := m.Cancel("j"); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	// The sleeper should receive SIGTERM and exit; wait for it.
+	_ = cmd.Wait()
+
+	// Simulate the supervisor's sentinel write that Cancel triggers in production.
+	_ = m.store.WriteExitCode("j", 143)
+	st, _ := m.Status("j")
+	if st.State != "cancelled" {
+		t.Fatalf("state = %q, want cancelled", st.State)
+	}
+	_ = os.Remove(filepath.Join(m.store.Dir("j"), "out"))
+	_ = syscall.Kill // keep import
+}

--- a/internal/manager/cancel_test.go
+++ b/internal/manager/cancel_test.go
@@ -1,51 +1,47 @@
 package manager
 
 import (
-	"os"
 	execpkg "os/exec"
-	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
+	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
-type execCmd = execpkg.Cmd
-
-func newExecCmd(name string, args ...string) *execCmd { return execpkg.Command(name, args...) }
-
-func exec_Command_sleep(t *testing.T) *execCmd {
-	t.Helper()
-	return newExecCmd("sleep", "30")
-}
-
 func TestCancelSignalsSupervisor(t *testing.T) {
-	m := newTestManager(t)
+	// The liveness guard requires the target's /proc comm to match the
+	// configured supervisor basename, so stand in "sleep" as the supervisor.
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, SupervisorExe: "sleep"})
+
 	// Spawn a real sleeper process we can signal.
-	cmd := exec_Command_sleep(t)
+	cmd := execpkg.Command("sleep", "30")
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = cmd.Process.Kill() }()
 
-	dir, _ := m.store.Create(jobstore.Meta{
+	if _, err := m.store.Create(jobstore.Meta{
 		ID: "j", PID: cmd.Process.Pid, BootID: readBootID(), StartedAt: time.Now(),
-	})
-	_ = dir
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := m.Cancel("j"); err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}
-	// The sleeper should receive SIGTERM and exit; wait for it.
-	_ = cmd.Wait()
-
-	// Simulate the supervisor's sentinel write that Cancel triggers in production.
-	_ = m.store.WriteExitCode("j", 143)
-	st, _ := m.Status("j")
-	if st.State != "cancelled" {
-		t.Fatalf("state = %q, want cancelled", st.State)
+	// Cancel must have actually signaled the sleeper, which then exits non-zero.
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("Cancel did not terminate the target process")
 	}
-	_ = os.Remove(filepath.Join(m.store.Dir("j"), "out"))
-	_ = syscall.Kill // keep import
+
+	// In production the supervisor writes the sentinel on SIGTERM; simulate that
+	// here. This test exercises the manager's signal-and-status path; the
+	// supervisor binary's own terminate-and-sentinel logic is covered by the
+	// supervisor tests.
+	_ = m.store.WriteExitCode("j", jobstore.ExitSIGTERM)
+	st, _ := m.Status("j")
+	if st.State != StateCancelled {
+		t.Fatalf("state = %q, want %q", st.State, StateCancelled)
+	}
 }

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -1,10 +1,61 @@
 package manager
 
-type gate struct{ sem chan struct{} }
+import "sync"
+
+// gate enforces a global concurrency cap and per-key (conversation/cwd)
+// serialization so concurrent agy sessions cannot trigger the known
+// session-lock hang.
+type gate struct {
+	mu       sync.Mutex
+	max      int
+	inFlight int
+	keys     map[string]bool
+}
 
 func newGate(max int) *gate {
 	if max <= 0 {
 		max = 1
 	}
-	return &gate{sem: make(chan struct{}, max)}
+	return &gate{max: max, keys: map[string]bool{}}
+}
+
+// tryAcquire reserves a slot. An empty key skips per-key serialization but still
+// counts against the global cap.
+func (g *gate) tryAcquire(key string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.inFlight >= g.max {
+		return false
+	}
+	if key != "" && g.keys[key] {
+		return false
+	}
+	g.inFlight++
+	if key != "" {
+		g.keys[key] = true
+	}
+	return true
+}
+
+func (g *gate) release(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.inFlight > 0 {
+		g.inFlight--
+	}
+	if key != "" {
+		delete(g.keys, key)
+	}
+}
+
+// keyFor returns the serialization key for a request, or "" for a fresh run
+// (no conversation, no continue) which needs no per-key lock.
+func keyFor(req StartRequest) string {
+	if req.ConversationID != "" {
+		return "conv:" + req.ConversationID
+	}
+	if req.ContinueLatest && req.Cwd != "" {
+		return "cwd:" + req.Cwd
+	}
+	return ""
 }

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -12,11 +12,11 @@ type gate struct {
 	keys     map[string]bool
 }
 
-func newGate(max int) *gate {
-	if max <= 0 {
-		max = 1
+func newGate(maxJobs int) *gate {
+	if maxJobs <= 0 {
+		maxJobs = 1
 	}
-	return &gate{max: max, keys: map[string]bool{}}
+	return &gate{max: maxJobs, keys: map[string]bool{}}
 }
 
 // tryAcquire reserves a slot. An empty key skips per-key serialization but still

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -1,0 +1,10 @@
+package manager
+
+type gate struct{ sem chan struct{} }
+
+func newGate(max int) *gate {
+	if max <= 0 {
+		max = 1
+	}
+	return &gate{sem: make(chan struct{}, max)}
+}

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -50,6 +50,12 @@ func (g *gate) release(key string) {
 
 // keyFor returns the serialization key for a request, or "" for a fresh run
 // (no conversation, no continue) which needs no per-key lock.
+//
+// Fresh runs return "" today because the snapshot-diff UUID capture in
+// conversation.go is not wired into Status yet. If that lazy capture is ever
+// enabled, fresh runs sharing a cwd MUST be serialized too (return
+// "cwd:"+req.Cwd here), otherwise two new conversations created in the same
+// directory could misattribute their UUIDs (design spec section 5.4).
 func keyFor(req StartRequest) string {
 	if req.ConversationID != "" {
 		return "conv:" + req.ConversationID

--- a/internal/manager/concurrency_test.go
+++ b/internal/manager/concurrency_test.go
@@ -1,0 +1,29 @@
+package manager
+
+import "testing"
+
+func TestKeyForRequest(t *testing.T) {
+	if k := keyFor(StartRequest{ConversationID: "abc"}); k != "conv:abc" {
+		t.Errorf("key = %q", k)
+	}
+	if k := keyFor(StartRequest{ContinueLatest: true, Cwd: "/w"}); k != "cwd:/w" {
+		t.Errorf("key = %q", k)
+	}
+	if k := keyFor(StartRequest{Cwd: "/w"}); k != "" {
+		t.Errorf("fresh run should have no serialization key, got %q", k)
+	}
+}
+
+func TestGateBlocksSameKey(t *testing.T) {
+	g := newGate(4)
+	if !g.tryAcquire("conv:x") {
+		t.Fatal("first acquire should succeed")
+	}
+	if g.tryAcquire("conv:x") {
+		t.Fatal("second acquire on same key must fail while first is held")
+	}
+	g.release("conv:x")
+	if !g.tryAcquire("conv:x") {
+		t.Fatal("acquire after release should succeed")
+	}
+}

--- a/internal/manager/concurrency_test.go
+++ b/internal/manager/concurrency_test.go
@@ -27,3 +27,18 @@ func TestGateBlocksSameKey(t *testing.T) {
 		t.Fatal("acquire after release should succeed")
 	}
 }
+
+func TestGateGlobalCap(t *testing.T) {
+	g := newGate(2)
+	if !g.tryAcquire("conv:a") || !g.tryAcquire("conv:b") {
+		t.Fatal("two distinct keys should fill the cap")
+	}
+	// The cap is full even though the third key is distinct.
+	if g.tryAcquire("conv:c") {
+		t.Fatal("acquire past the global cap must fail")
+	}
+	g.release("conv:a")
+	if !g.tryAcquire("conv:c") {
+		t.Fatal("acquire after a release should succeed")
+	}
+}

--- a/internal/manager/conversation.go
+++ b/internal/manager/conversation.go
@@ -1,0 +1,40 @@
+package manager
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func loadCache(cacheFile string) map[string]string {
+	b, err := os.ReadFile(cacheFile)
+	if err != nil {
+		return map[string]string{}
+	}
+	var raw map[string]string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return map[string]string{}
+	}
+	return raw
+}
+
+// resolveLatest returns the most recent conversation UUID for cwd, if any.
+func resolveLatest(cacheFile, cwd string) (string, bool) {
+	id, ok := loadCache(cacheFile)[cwd]
+	return id, ok && id != ""
+}
+
+// snapshotCwd records the cwd's UUID before a run.
+func snapshotCwd(cacheFile, cwd string) string {
+	return loadCache(cacheFile)[cwd]
+}
+
+// captureNewUUID returns the cwd's UUID after a run, but only if it changed from
+// the pre-run snapshot. A failed run leaves the cache untouched, so this avoids
+// misattributing the failure to a previous conversation.
+func captureNewUUID(cacheFile, cwd, before string) (string, bool) {
+	after := loadCache(cacheFile)[cwd]
+	if after != "" && after != before {
+		return after, true
+	}
+	return "", false
+}

--- a/internal/manager/conversation_test.go
+++ b/internal/manager/conversation_test.go
@@ -1,0 +1,61 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeCache(t *testing.T, dir string, kv map[string]string) string {
+	t.Helper()
+	b := []byte("{")
+	first := true
+	for k, v := range kv {
+		if !first {
+			b = append(b, ',')
+		}
+		first = false
+		b = append(b, []byte(`"`+k+`":"`+v+`"`)...)
+	}
+	b = append(b, '}')
+	p := filepath.Join(dir, "last_conversations.json")
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestResolveLatestForCwd(t *testing.T) {
+	dir := t.TempDir()
+	cache := writeCache(t, dir, map[string]string{"/w": "uuid-existing"})
+	id, ok := resolveLatest(cache, "/w")
+	if !ok || id != "uuid-existing" {
+		t.Fatalf("resolveLatest = %q,%v", id, ok)
+	}
+	if _, ok := resolveLatest(cache, "/missing"); ok {
+		t.Fatal("missing cwd should not resolve")
+	}
+}
+
+func TestCaptureNewUUIDByDiff(t *testing.T) {
+	dir := t.TempDir()
+	cache := writeCache(t, dir, map[string]string{"/w": "old"})
+	before := snapshotCwd(cache, "/w") // "old"
+	// Simulate agy creating a new conversation for /w.
+	_ = writeCache(t, dir, map[string]string{"/w": "new"})
+	got, changed := captureNewUUID(cache, "/w", before)
+	if !changed || got != "new" {
+		t.Fatalf("capture = %q,%v", got, changed)
+	}
+}
+
+func TestCaptureNoChangeOnFailedRun(t *testing.T) {
+	dir := t.TempDir()
+	cache := writeCache(t, dir, map[string]string{"/w": "old"})
+	before := snapshotCwd(cache, "/w")
+	// agy failed -> cache unchanged.
+	got, changed := captureNewUUID(cache, "/w", before)
+	if changed || got != "" {
+		t.Fatalf("should not capture stale id: %q,%v", got, changed)
+	}
+}

--- a/internal/manager/conversation_test.go
+++ b/internal/manager/conversation_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,16 +9,10 @@ import (
 
 func writeCache(t *testing.T, dir string, kv map[string]string) string {
 	t.Helper()
-	b := []byte("{")
-	first := true
-	for k, v := range kv {
-		if !first {
-			b = append(b, ',')
-		}
-		first = false
-		b = append(b, []byte(`"`+k+`":"`+v+`"`)...)
+	b, err := json.Marshal(kv)
+	if err != nil {
+		t.Fatal(err)
 	}
-	b = append(b, '}')
 	p := filepath.Join(dir, "last_conversations.json")
 	if err := os.WriteFile(p, b, 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -10,8 +10,12 @@ import (
 
 func TestGarbageCollectRemovesExpired(t *testing.T) {
 	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
-	_, _ = m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)})
-	_, _ = m.store.Create(jobstore.Meta{ID: "fresh", StartedAt: time.Now()})
+	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.store.Create(jobstore.Meta{ID: "fresh", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
 	removed, err := m.GarbageCollect()
 	if err != nil {
 		t.Fatal(err)
@@ -23,8 +27,13 @@ func TestGarbageCollectRemovesExpired(t *testing.T) {
 
 func TestGarbageCollectDisabledWhenTTLZero(t *testing.T) {
 	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4}) // JobTTL 0
-	_, _ = m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-100 * time.Hour)})
-	removed, _ := m.GarbageCollect()
+	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-100 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(removed) != 0 {
 		t.Fatalf("TTL 0 should disable GC, removed %v", removed)
 	}

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -1,0 +1,31 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+func TestGarbageCollectRemovesExpired(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	_, _ = m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)})
+	_, _ = m.store.Create(jobstore.Meta{ID: "fresh", StartedAt: time.Now()})
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "old" {
+		t.Fatalf("removed = %v, want [old]", removed)
+	}
+}
+
+func TestGarbageCollectDisabledWhenTTLZero(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4}) // JobTTL 0
+	_, _ = m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-100 * time.Hour)})
+	removed, _ := m.GarbageCollect()
+	if len(removed) != 0 {
+		t.Fatalf("TTL 0 should disable GC, removed %v", removed)
+	}
+}

--- a/internal/manager/job_test.go
+++ b/internal/manager/job_test.go
@@ -1,0 +1,90 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+)
+
+// fakeSupervisor writes a script that mimics `agy-mcp run-job <dir>`:
+// it writes out="done" and exit_code=0 for the given job dir.
+func fakeSupervisor(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "fake-sup")
+	script := "#!/usr/bin/env bash\n" +
+		"dir=\"$2\"\n" +
+		"printf 'done' > \"$dir/out\"\n" +
+		"printf '0' > \"$dir/exit_code\"\n"
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
+	state := t.TempDir()
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  fakeSupervisor(t),
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+
+	job, err := m.StartJob(StartRequest{Prompt: "review main.go", Model: "Gemini 3.1 Pro (High)"})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	if job.ID == "" {
+		t.Fatal("empty job id")
+	}
+
+	// meta.json must exist and contain the prompt and agy args.
+	meta, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if meta.Prompt != "review main.go" {
+		t.Errorf("prompt = %q", meta.Prompt)
+	}
+	if !hasArg(meta.Args, "--model", "Gemini 3.1 Pro (High)") {
+		t.Errorf("args missing model: %v", meta.Args)
+	}
+	if !contains(meta.Args, "-p") || !contains(meta.Args, "--dangerously-skip-permissions") {
+		t.Errorf("args missing required flags: %v", meta.Args)
+	}
+
+	// The fake supervisor writes out/exit_code; wait briefly for it.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := m.store.ExitCode(job.ID); ok {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, ok := m.store.ExitCode(job.ID); !ok {
+		t.Fatal("supervisor did not write exit_code")
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasArg(ss []string, flag, val string) bool {
+	for i := 0; i+1 < len(ss); i++ {
+		if ss[i] == flag && ss[i+1] == val {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -31,7 +32,7 @@ func (m *Manager) processAlive(meta jobstore.Meta) bool {
 		return false
 	}
 	// Defense in depth: confirm the process is still our supervisor by name.
-	comm, err := os.ReadFile(filepath.Join("/proc", itoa(meta.PID), "comm"))
+	comm, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(meta.PID), "comm"))
 	if err != nil {
 		return false
 	}

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -1,0 +1,14 @@
+package manager
+
+import (
+	"os"
+	"strings"
+)
+
+func readBootID() string {
+	b, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -2,8 +2,17 @@ package manager
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
+
+// supervisorComm is the process name (/proc/<pid>/comm) of a live job
+// supervisor. It is a package variable so a test can repoint liveness at a
+// stand-in process if needed.
+var supervisorComm = "agy-mcp"
 
 func readBootID() string {
 	b, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
@@ -11,4 +20,26 @@ func readBootID() string {
 		return ""
 	}
 	return strings.TrimSpace(string(b))
+}
+
+// processAlive reports whether the job's recorded supervisor PID is still a
+// live agy-mcp process from the current boot.
+func processAlive(meta jobstore.Meta) bool {
+	if meta.PID <= 0 {
+		return false
+	}
+	// A PID from a previous boot is meaningless (PID recycling).
+	if meta.BootID != "" && meta.BootID != readBootID() {
+		return false
+	}
+	if err := syscall.Kill(meta.PID, 0); err != nil {
+		return false
+	}
+	// Defense in depth: confirm the process is still our supervisor.
+	comm, err := os.ReadFile(filepath.Join("/proc", itoa(meta.PID), "comm"))
+	if err != nil {
+		return false
+	}
+	name := strings.TrimSpace(string(comm))
+	return name == supervisorComm
 }

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -5,18 +5,24 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
-func readBootID() string {
+// bootID reads the kernel boot id once and caches it. The value is stable for
+// the lifetime of the process, so liveness checks (which run per poll) do not
+// re-read /proc each time.
+var bootID = sync.OnceValue(func() string {
 	b, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(b))
-}
+})
+
+func readBootID() string { return bootID() }
 
 // processAlive reports whether the job's recorded supervisor PID is still a
 // live supervisor process from the current boot.

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -38,7 +38,7 @@ func (m *Manager) processAlive(meta jobstore.Meta) bool {
 		return false
 	}
 	// Defense in depth: confirm the process is still our supervisor by name.
-	comm, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(meta.PID), "comm"))
+	comm, err := os.ReadFile("/proc/" + strconv.Itoa(meta.PID) + "/comm")
 	if err != nil {
 		return false
 	}

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -9,11 +9,6 @@ import (
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
-// supervisorComm is the process name (/proc/<pid>/comm) of a live job
-// supervisor. It is a package variable so a test can repoint liveness at a
-// stand-in process if needed.
-var supervisorComm = "agy-mcp"
-
 func readBootID() string {
 	b, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
 	if err != nil {
@@ -23,8 +18,8 @@ func readBootID() string {
 }
 
 // processAlive reports whether the job's recorded supervisor PID is still a
-// live agy-mcp process from the current boot.
-func processAlive(meta jobstore.Meta) bool {
+// live supervisor process from the current boot.
+func (m *Manager) processAlive(meta jobstore.Meta) bool {
 	if meta.PID <= 0 {
 		return false
 	}
@@ -35,11 +30,22 @@ func processAlive(meta jobstore.Meta) bool {
 	if err := syscall.Kill(meta.PID, 0); err != nil {
 		return false
 	}
-	// Defense in depth: confirm the process is still our supervisor.
+	// Defense in depth: confirm the process is still our supervisor by name.
 	comm, err := os.ReadFile(filepath.Join("/proc", itoa(meta.PID), "comm"))
 	if err != nil {
 		return false
 	}
 	name := strings.TrimSpace(string(comm))
-	return name == supervisorComm
+	return name == expectedComm(m.cfg.SupervisorExe)
+}
+
+// expectedComm returns the process name as the kernel records it in
+// /proc/<pid>/comm for the given supervisor executable: the basename truncated
+// to the kernel's 15-character comm limit.
+func expectedComm(exe string) string {
+	base := filepath.Base(exe)
+	if len(base) > 15 {
+		base = base[:15]
+	}
+	return base
 }

--- a/internal/manager/liveness_test.go
+++ b/internal/manager/liveness_test.go
@@ -1,0 +1,13 @@
+package manager
+
+import "testing"
+
+func TestExpectedComm(t *testing.T) {
+	if got := expectedComm("/usr/local/bin/agy-mcp"); got != "agy-mcp" {
+		t.Errorf("expectedComm basename = %q, want agy-mcp", got)
+	}
+	// Kernel /proc/comm is capped at 15 chars; a longer basename is truncated.
+	if got := expectedComm("/x/agy-mcp-v1.2.3-linux-amd64"); got != "agy-mcp-v1.2.3-" {
+		t.Errorf("expectedComm truncation = %q (len %d)", got, len(got))
+	}
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -71,6 +71,12 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		timeout = m.cfg.DefaultTimeout
 	}
 
+	req.Cwd = cwd
+	key := keyFor(req)
+	if !m.gate.tryAcquire(key) {
+		return Job{}, fmt.Errorf("a conflicting agy job for this conversation or directory is already running")
+	}
+
 	args := buildAgyArgs(req, model, timeout)
 	meta := jobstore.Meta{
 		ID:             id,
@@ -85,6 +91,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 	dir, err := m.store.Create(meta)
 	if err != nil {
+		m.gate.release(key)
 		return Job{}, err
 	}
 
@@ -97,6 +104,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	if err := cmd.Start(); err != nil {
+		m.gate.release(key)
 		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
 	}
 	// Record the supervisor PID for liveness/cancel, then release it.
@@ -106,7 +114,26 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 	_ = cmd.Process.Release()
 
+	// The gate slot is released by a background watchdog when the job reaches a
+	// terminal state (or after a bounded safety window).
+	go m.releaseWhenDone(key, id, timeout)
+
 	return Job{ID: id, ConversationID: req.ConversationID, State: "running"}, nil
+}
+
+func (m *Manager) releaseWhenDone(key, id string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout + time.Minute)
+	for time.Now().Before(deadline) {
+		if st, err := m.Status(id); err == nil {
+			switch st.State {
+			case "done", "failed", "cancelled":
+				m.gate.release(key)
+				return
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	m.gate.release(key) // safety release after the watchdog window
 }
 
 func buildAgyArgs(req StartRequest, model string, timeout time.Duration) []string {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -72,6 +72,16 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 
 	req.Cwd = cwd
+
+	// Resolve continue_latest to a concrete conversation id before computing the
+	// gate key and args, so serialization, the agy --conversation flag, and the
+	// returned conversation id are all deterministic and consistent.
+	if req.ContinueLatest {
+		if cid, ok := resolveLatest(agyCachePath(), cwd); ok {
+			req.ConversationID = cid
+		}
+	}
+
 	key := keyFor(req)
 	if !m.gate.tryAcquire(key) {
 		return Job{}, fmt.Errorf("a conflicting agy job for this conversation or directory is already running")
@@ -88,6 +98,12 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		Prompt:         req.Prompt,
 		StartedAt:      time.Now().UTC(),
 		BootID:         readBootID(),
+	}
+	// For a genuinely fresh run (no conversation, no continue), snapshot the
+	// cwd's current conversation id so a later diff can capture the new
+	// conversation agy creates.
+	if req.ConversationID == "" && !req.ContinueLatest {
+		meta.CwdUUIDBefore = snapshotCwd(agyCachePath(), cwd)
 	}
 	dir, err := m.store.Create(meta)
 	if err != nil {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 type Manager struct {
 	cfg   config.Config
 	store *jobstore.Store
-	gate  *gate // concurrency control (Task 8)
+	gate  *gate // serializes conflicting jobs and caps total concurrency
 }
 
 // New constructs a Manager.
@@ -38,7 +37,7 @@ type StartRequest struct {
 	Model          string   // optional; falls back to cfg.DefaultModel
 	Dirs           []string // repeated --add-dir
 	ConversationID string   // optional; --conversation <id>
-	ContinueLatest bool     // resolve cwd's latest conversation before run (Task 11)
+	ContinueLatest bool     // resolve cwd's latest conversation before the run
 	Cwd            string   // optional; defaults to process cwd
 	Timeout        time.Duration
 }
@@ -124,27 +123,60 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		m.gate.release(key)
 		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
 	}
-	// Record the supervisor PID for liveness/cancel, then release it.
+	// Record the supervisor PID (for liveness and cancel) with an atomic rewrite,
+	// so the just-spawned supervisor never reads a half-written meta.json.
 	meta.PID = cmd.Process.Pid
-	if b, e := jobMetaBytes(meta); e == nil {
-		_ = os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644)
+	if err := m.store.UpdateMeta(meta); err != nil {
+		// Without a persisted PID the supervisor would be untrackable
+		// (uncancellable, and reported as not-alive). Fail closed: terminate it.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		go func() { _ = cmd.Wait() }()
+		m.gate.release(key)
+		return Job{}, fmt.Errorf("record supervisor pid: %w", err)
 	}
-	_ = cmd.Process.Release()
+	// Reap the supervisor in the background so a finished job does not leave a
+	// zombie. The supervisor is detached (its own process group) and survives
+	// the manager regardless, so reaping does not couple their lifetimes; if the
+	// manager dies first, init adopts and reaps the supervisor.
+	go func() { _ = cmd.Wait() }()
 
 	// The gate slot is released by a background watchdog when the job reaches a
 	// terminal state (or after a bounded safety window).
 	go m.releaseWhenDone(key, id, timeout)
 
-	return Job{ID: id, ConversationID: req.ConversationID, State: "running"}, nil
+	return Job{ID: id, ConversationID: req.ConversationID, State: StateRunning}, nil
 }
 
-// GarbageCollect removes finished jobs older than the configured TTL. It is
-// safe to call at startup. A non-positive TTL disables collection.
+// GarbageCollect removes jobs older than the configured TTL. A job whose
+// supervisor is still alive (including one that survived a manager restart) is
+// never removed, even past the TTL, so a live job is never deleted out from
+// under its supervisor. A non-positive TTL disables collection.
 func (m *Manager) GarbageCollect() ([]string, error) {
 	if m.cfg.JobTTL <= 0 {
 		return nil, nil
 	}
-	return m.store.GC(m.cfg.JobTTL)
+	ids, err := m.store.List()
+	if err != nil {
+		return nil, err
+	}
+	cutoff := time.Now().Add(-m.cfg.JobTTL)
+	var removed []string
+	for _, id := range ids {
+		meta, err := m.store.Load(id)
+		if err != nil {
+			continue
+		}
+		if !meta.StartedAt.Before(cutoff) {
+			continue // too recent to collect
+		}
+		if _, terminal := m.store.ExitCode(id); !terminal && m.processAlive(meta) {
+			continue // still running; keep it
+		}
+		if err := m.store.Remove(id); err == nil {
+			removed = append(removed, id)
+		}
+	}
+	return removed, nil
 }
 
 func (m *Manager) releaseWhenDone(key, id string, timeout time.Duration) {
@@ -152,7 +184,7 @@ func (m *Manager) releaseWhenDone(key, id string, timeout time.Duration) {
 	for time.Now().Before(deadline) {
 		if st, err := m.Status(id); err == nil {
 			switch st.State {
-			case "done", "failed", "cancelled":
+			case StateDone, StateFailed, StateCancelled:
 				m.gate.release(key)
 				return
 			}
@@ -184,8 +216,4 @@ func newID() (string, error) {
 	}
 	// Time prefix keeps IDs roughly sortable.
 	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), hex.EncodeToString(b[:])), nil
-}
-
-func jobMetaBytes(m jobstore.Meta) ([]byte, error) {
-	return jsonMarshalIndent(m)
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -137,6 +137,15 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	return Job{ID: id, ConversationID: req.ConversationID, State: "running"}, nil
 }
 
+// GarbageCollect removes finished jobs older than the configured TTL. It is
+// safe to call at startup. A non-positive TTL disables collection.
+func (m *Manager) GarbageCollect() ([]string, error) {
+	if m.cfg.JobTTL <= 0 {
+		return nil, nil
+	}
+	return m.store.GC(m.cfg.JobTTL)
+}
+
 func (m *Manager) releaseWhenDone(key, id string, timeout time.Duration) {
 	deadline := time.Now().Add(timeout + time.Minute)
 	for time.Now().Before(deadline) {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -1,0 +1,138 @@
+// Package manager owns agy job lifecycle: spawning, status, cancel, and the
+// model/session queries. It is transport-agnostic.
+package manager
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// Manager coordinates jobs backed by an on-disk store.
+type Manager struct {
+	cfg   config.Config
+	store *jobstore.Store
+	gate  *gate // concurrency control (Task 8)
+}
+
+// New constructs a Manager.
+func New(c config.Config) *Manager {
+	return &Manager{
+		cfg:   c,
+		store: jobstore.New(c.StateDir),
+		gate:  newGate(c.MaxConcurrency),
+	}
+}
+
+// StartRequest describes a run to start.
+type StartRequest struct {
+	Prompt         string
+	Model          string   // optional; falls back to cfg.DefaultModel
+	Dirs           []string // repeated --add-dir
+	ConversationID string   // optional; --conversation <id>
+	ContinueLatest bool     // resolve cwd's latest conversation before run (Task 11)
+	Cwd            string   // optional; defaults to process cwd
+	Timeout        time.Duration
+}
+
+// Job is the handle returned to callers.
+type Job struct {
+	ID             string
+	ConversationID string
+	State          string // "running"
+}
+
+// StartJob persists meta and spawns the detached supervisor.
+func (m *Manager) StartJob(req StartRequest) (Job, error) {
+	id, err := newID()
+	if err != nil {
+		return Job{}, err
+	}
+	cwd := req.Cwd
+	if cwd == "" {
+		if wd, err := os.Getwd(); err == nil {
+			cwd = wd
+		}
+	}
+	model := req.Model
+	if model == "" {
+		model = m.cfg.DefaultModel
+	}
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = m.cfg.DefaultTimeout
+	}
+
+	args := buildAgyArgs(req, model, timeout)
+	meta := jobstore.Meta{
+		ID:             id,
+		AgyPath:        m.cfg.AgyPath,
+		Args:           args,
+		Cwd:            cwd,
+		Model:          model,
+		ConversationID: req.ConversationID,
+		Prompt:         req.Prompt,
+		StartedAt:      time.Now().UTC(),
+		BootID:         readBootID(),
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		return Job{}, err
+	}
+
+	cmd := exec.Command(m.cfg.SupervisorExe, "run-job", dir)
+	cmd.Env = os.Environ()
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Detach stdio: supervisor must not inherit the manager's stdout (the
+	// JSON-RPC stream in stdio mode).
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
+	}
+	// Record the supervisor PID for liveness/cancel, then release it.
+	meta.PID = cmd.Process.Pid
+	if b, e := jobMetaBytes(meta); e == nil {
+		_ = os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644)
+	}
+	_ = cmd.Process.Release()
+
+	return Job{ID: id, ConversationID: req.ConversationID, State: "running"}, nil
+}
+
+func buildAgyArgs(req StartRequest, model string, timeout time.Duration) []string {
+	args := []string{"--dangerously-skip-permissions", "--print-timeout", timeout.String()}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	for _, d := range req.Dirs {
+		args = append(args, "--add-dir", d)
+	}
+	if req.ConversationID != "" {
+		args = append(args, "--conversation", req.ConversationID)
+	}
+	args = append(args, "-p", req.Prompt)
+	return args
+}
+
+func newID() (string, error) {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	// Time prefix keeps IDs roughly sortable.
+	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), hex.EncodeToString(b[:])), nil
+}
+
+func jobMetaBytes(m jobstore.Meta) ([]byte, error) {
+	return jsonMarshalIndent(m)
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -99,10 +99,11 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		BootID:         readBootID(),
 		Timeout:        timeout,
 	}
-	// For a genuinely fresh run (no conversation, no continue), snapshot the
-	// cwd's current conversation id so a later diff can capture the new
-	// conversation agy creates.
-	if req.ConversationID == "" && !req.ContinueLatest {
+	// Whenever the run has no resolved conversation id (a fresh run, or a
+	// continue_latest that found no prior conversation), agy will create a new
+	// conversation. Snapshot the cwd's current conversation id so a later diff
+	// can capture the one agy creates.
+	if req.ConversationID == "" {
 		meta.CwdUUIDBefore = snapshotCwd(agyCachePath(), cwd)
 	}
 	dir, err := m.store.Create(meta)
@@ -134,15 +135,15 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		m.gate.release(key)
 		return Job{}, fmt.Errorf("record supervisor pid: %w", err)
 	}
-	// Reap the supervisor in the background so a finished job does not leave a
-	// zombie. The supervisor is detached (its own process group) and survives
-	// the manager regardless, so reaping does not couple their lifetimes; if the
-	// manager dies first, init adopts and reaps the supervisor.
-	go func() { _ = cmd.Wait() }()
-
-	// The gate slot is released by a background watchdog when the job reaches a
-	// terminal state (or after a bounded safety window).
-	go m.releaseWhenDone(key, id, timeout)
+	// Wait for the supervisor in the background. cmd.Wait returns exactly when
+	// the supervisor (and thus the job) exits, so this both reaps it (no zombie)
+	// and releases the gate slot at the precise moment the job ends, with no
+	// disk polling. The supervisor is detached and survives manager death; if
+	// the manager dies first, init adopts and reaps it.
+	go func() {
+		_ = cmd.Wait()
+		m.gate.release(key)
+	}()
 
 	return Job{ID: id, ConversationID: req.ConversationID, State: StateRunning}, nil
 }
@@ -177,21 +178,6 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 		}
 	}
 	return removed, nil
-}
-
-func (m *Manager) releaseWhenDone(key, id string, timeout time.Duration) {
-	deadline := time.Now().Add(timeout + time.Minute)
-	for time.Now().Before(deadline) {
-		if st, err := m.Status(id); err == nil {
-			switch st.State {
-			case StateDone, StateFailed, StateCancelled:
-				m.gate.release(key)
-				return
-			}
-		}
-		time.Sleep(time.Second)
-	}
-	m.gate.release(key) // safety release after the watchdog window
 }
 
 func buildAgyArgs(req StartRequest, model string, timeout time.Duration) []string {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -98,6 +98,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		Prompt:         req.Prompt,
 		StartedAt:      time.Now().UTC(),
 		BootID:         readBootID(),
+		Timeout:        timeout,
 	}
 	// For a genuinely fresh run (no conversation, no continue), snapshot the
 	// cwd's current conversation id so a later diff can capture the new

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -17,7 +17,7 @@ func (m *Manager) ListModels(ctx context.Context) ([]string, error) {
 
 func parseModels(raw string) []string {
 	var models []string
-	for _, line := range strings.Split(raw, "\n") {
+	for line := range strings.Lines(raw) {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -1,0 +1,28 @@
+package manager
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// ListModels runs `agy models` and returns the available model names.
+func (m *Manager) ListModels(ctx context.Context) ([]string, error) {
+	out, err := exec.CommandContext(ctx, m.cfg.AgyPath, "models").Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseModels(string(out)), nil
+}
+
+func parseModels(raw string) []string {
+	var models []string
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		models = append(models, line)
+	}
+	return models
+}

--- a/internal/manager/models_test.go
+++ b/internal/manager/models_test.go
@@ -1,0 +1,17 @@
+package manager
+
+import "testing"
+
+func TestParseModels(t *testing.T) {
+	raw := "Gemini 3.5 Flash (Medium)\nGemini 3.1 Pro (High)\n\nClaude Opus 4.6 (Thinking)\n"
+	got := parseModels(raw)
+	want := []string{"Gemini 3.5 Flash (Medium)", "Gemini 3.1 Pro (High)", "Claude Opus 4.6 (Thinking)"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d]=%q want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -41,9 +41,13 @@ func readSessions(cacheFile, filterDir string) ([]Session, error) {
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return nil, err
 	}
+	cleanFilter := ""
+	if filterDir != "" {
+		cleanFilter = filepath.Clean(filterDir)
+	}
 	var out []Session
 	for ws, id := range raw {
-		if filterDir != "" && ws != filterDir {
+		if cleanFilter != "" && filepath.Clean(ws) != cleanFilter {
 			continue
 		}
 		out = append(out, Session{Workspace: ws, ConversationID: id})

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -1,0 +1,51 @@
+package manager
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Session pairs a workspace path with its most recent agy conversation UUID.
+type Session struct {
+	Workspace      string `json:"workspace"`
+	ConversationID string `json:"conversation_id"`
+}
+
+// agyCachePath returns the path to last_conversations.json, honoring HOME.
+func agyCachePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".gemini", "antigravity-cli", "cache", "last_conversations.json")
+}
+
+// ListSessions returns known conversations, optionally filtered to one dir.
+func (m *Manager) ListSessions(dir string) ([]Session, error) {
+	return readSessions(agyCachePath(), dir)
+}
+
+func readSessions(cacheFile, filterDir string) ([]Session, error) {
+	b, err := os.ReadFile(cacheFile)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var raw map[string]string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return nil, err
+	}
+	var out []Session
+	for ws, id := range raw {
+		if filterDir != "" && ws != filterDir {
+			continue
+		}
+		out = append(out, Session{Workspace: ws, ConversationID: id})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Workspace < out[j].Workspace })
+	return out, nil
+}

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -2,6 +2,8 @@ package manager
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -29,7 +31,7 @@ func (m *Manager) ListSessions(dir string) ([]Session, error) {
 
 func readSessions(cacheFile, filterDir string) ([]Session, error) {
 	b, err := os.ReadFile(cacheFile)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/manager/sessions_test.go
+++ b/internal/manager/sessions_test.go
@@ -1,0 +1,32 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListSessionsFromCache(t *testing.T) {
+	cache := t.TempDir()
+	data := `{"/home/u/proj":"uuid-1","/home/u/other":"uuid-2"}`
+	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := readSessions(filepath.Join(cache, "last_conversations.json"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions", len(sessions))
+	}
+}
+
+func TestListSessionsFilteredByDir(t *testing.T) {
+	cache := t.TempDir()
+	data := `{"/home/u/proj":"uuid-1","/home/u/other":"uuid-2"}`
+	_ = os.WriteFile(filepath.Join(cache, "last_conversations.json"), []byte(data), 0o644)
+	sessions, _ := readSessions(filepath.Join(cache, "last_conversations.json"), "/home/u/proj")
+	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
+		t.Fatalf("got %+v", sessions)
+	}
+}

--- a/internal/manager/sessions_test.go
+++ b/internal/manager/sessions_test.go
@@ -24,8 +24,13 @@ func TestListSessionsFromCache(t *testing.T) {
 func TestListSessionsFilteredByDir(t *testing.T) {
 	cache := t.TempDir()
 	data := `{"/home/u/proj":"uuid-1","/home/u/other":"uuid-2"}`
-	_ = os.WriteFile(filepath.Join(cache, "last_conversations.json"), []byte(data), 0o644)
-	sessions, _ := readSessions(filepath.Join(cache, "last_conversations.json"), "/home/u/proj")
+	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := readSessions(filepath.Join(cache, "last_conversations.json"), "/home/u/proj")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
 		t.Fatalf("got %+v", sessions)
 	}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -43,7 +43,7 @@ func (m *Manager) Status(id string) (Status, error) {
 	}
 
 	// No sentinel: decide running vs interrupted.
-	if processAlive(meta) {
+	if m.processAlive(meta) {
 		st.State = "running"
 		return st, nil
 	}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -35,6 +35,9 @@ func (m *Manager) Status(id string) (Status, error) {
 			st.Result = readFile(filepath.Join(dir, "out"))
 		} else if code == 143 || code == 130 {
 			st.State = "cancelled"
+		} else if code == 124 {
+			st.State = "failed"
+			st.Error = "job exceeded its timeout and was terminated"
 		} else {
 			st.State = "failed"
 			st.Error = errorSummary(dir, code)

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -88,7 +88,7 @@ func errorSummary(dir string, code int) string {
 	if len(tail) > 2000 {
 		tail = tail[len(tail)-2000:]
 		// Advance to a valid UTF-8 boundary so a multi-byte rune is not split.
-		for len(tail) > 0 && !utf8.RuneStart(tail[0]) {
+		for tail != "" && !utf8.RuneStart(tail[0]) {
 			tail = tail[1:]
 		}
 	}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -1,0 +1,78 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Status is the observable state of a job.
+type Status struct {
+	State          string // running | done | failed | cancelled
+	Elapsed        time.Duration
+	Result         string // present when done: captured stdout
+	Error          string // present when failed: stderr tail + exit code
+	ConversationID string
+}
+
+// Status derives a job's status from the on-disk store.
+func (m *Manager) Status(id string) (Status, error) {
+	meta, err := m.store.Load(id)
+	if err != nil {
+		return Status{}, err
+	}
+	dir := m.store.Dir(id)
+	st := Status{
+		Elapsed:        time.Since(meta.StartedAt),
+		ConversationID: meta.ConversationID,
+	}
+
+	if code, ok := m.store.ExitCode(id); ok {
+		if code == 0 {
+			st.State = "done"
+			st.Result = readFile(filepath.Join(dir, "out"))
+		} else if code == 143 || code == 130 {
+			st.State = "cancelled"
+		} else {
+			st.State = "failed"
+			st.Error = errorSummary(dir, code)
+		}
+		return st, nil
+	}
+
+	// No sentinel: decide running vs interrupted.
+	if processAlive(meta) {
+		st.State = "running"
+		return st, nil
+	}
+	// Process is gone without a sentinel. If output was captured, recover it.
+	out := readFile(filepath.Join(dir, "out"))
+	if out != "" {
+		st.State = "done"
+		st.Result = out
+	} else {
+		st.State = "failed"
+		st.Error = "job process exited without writing a result (interrupted)"
+	}
+	return st, nil
+}
+
+func readFile(p string) string {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(string(b), "\n")
+}
+
+func errorSummary(dir string, code int) string {
+	tail := readFile(filepath.Join(dir, "err"))
+	if len(tail) > 2000 {
+		tail = tail[len(tail)-2000:]
+	}
+	return strings.TrimSpace("exit " + itoa(code) + ": " + tail)
+}
+
+func itoa(i int) string { return strconv.Itoa(i) }

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,6 +11,11 @@ import (
 
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
+
+// maxReadBytes caps how much of a job's out/err file is read into memory, so a
+// runaway agy emitting huge output cannot OOM the server. Reviews are text and
+// far smaller than this; anything larger is truncated.
+const maxReadBytes = 32 << 20 // 32 MiB
 
 // Job states reported by Status. These are shared with StartJob and the gate
 // watchdog so the producer and consumer of a job's state cannot drift apart.
@@ -76,7 +82,12 @@ func (m *Manager) Status(id string) (Status, error) {
 }
 
 func readFile(p string) string {
-	b, err := os.ReadFile(p)
+	f, err := os.Open(p)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	b, err := io.ReadAll(io.LimitReader(f, maxReadBytes))
 	if err != nil {
 		return ""
 	}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -6,6 +6,18 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// Job states reported by Status. These are shared with StartJob and the gate
+// watchdog so the producer and consumer of a job's state cannot drift apart.
+const (
+	StateRunning   = "running"
+	StateDone      = "done"
+	StateFailed    = "failed"
+	StateCancelled = "cancelled"
 )
 
 // Status is the observable state of a job.
@@ -30,16 +42,17 @@ func (m *Manager) Status(id string) (Status, error) {
 	}
 
 	if code, ok := m.store.ExitCode(id); ok {
-		if code == 0 {
-			st.State = "done"
+		switch code {
+		case 0:
+			st.State = StateDone
 			st.Result = readFile(filepath.Join(dir, "out"))
-		} else if code == 143 || code == 130 {
-			st.State = "cancelled"
-		} else if code == 124 {
-			st.State = "failed"
+		case jobstore.ExitSIGTERM, jobstore.ExitSIGINT:
+			st.State = StateCancelled
+		case jobstore.ExitTimeout:
+			st.State = StateFailed
 			st.Error = "job exceeded its timeout and was terminated"
-		} else {
-			st.State = "failed"
+		default:
+			st.State = StateFailed
 			st.Error = errorSummary(dir, code)
 		}
 		return st, nil
@@ -47,16 +60,16 @@ func (m *Manager) Status(id string) (Status, error) {
 
 	// No sentinel: decide running vs interrupted.
 	if m.processAlive(meta) {
-		st.State = "running"
+		st.State = StateRunning
 		return st, nil
 	}
 	// Process is gone without a sentinel. If output was captured, recover it.
 	out := readFile(filepath.Join(dir, "out"))
 	if out != "" {
-		st.State = "done"
+		st.State = StateDone
 		st.Result = out
 	} else {
-		st.State = "failed"
+		st.State = StateFailed
 		st.Error = "job process exited without writing a result (interrupted)"
 	}
 	return st, nil
@@ -74,8 +87,10 @@ func errorSummary(dir string, code int) string {
 	tail := readFile(filepath.Join(dir, "err"))
 	if len(tail) > 2000 {
 		tail = tail[len(tail)-2000:]
+		// Advance to a valid UTF-8 boundary so a multi-byte rune is not split.
+		for len(tail) > 0 && !utf8.RuneStart(tail[0]) {
+			tail = tail[1:]
+		}
 	}
-	return strings.TrimSpace("exit " + itoa(code) + ": " + tail)
+	return strings.TrimSpace("exit " + strconv.Itoa(code) + ": " + tail)
 }
-
-func itoa(i int) string { return strconv.Itoa(i) }

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,10 +47,10 @@ func TestStatusTimedOut(t *testing.T) {
 	m := newTestManager(t)
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("partial"), 0o644)
-	_ = m.store.WriteExitCode("j", 124)
+	_ = m.store.WriteExitCode("j", jobstore.ExitTimeout)
 
 	st, _ := m.Status("j")
-	if st.State != "failed" || st.Error == "" {
+	if st.State != StateFailed || !strings.Contains(st.Error, "timeout") {
 		t.Fatalf("status = %+v, want failed with a timeout error", st)
 	}
 }

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -42,6 +42,18 @@ func TestStatusFailed(t *testing.T) {
 	}
 }
 
+func TestStatusTimedOut(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("partial"), 0o644)
+	_ = m.store.WriteExitCode("j", 124)
+
+	st, _ := m.Status("j")
+	if st.State != "failed" || st.Error == "" {
+		t.Fatalf("status = %+v, want failed with a timeout error", st)
+	}
+}
+
 func TestStatusInterruptedAfterReboot(t *testing.T) {
 	m := newTestManager(t)
 	// BootID differs from current -> the recorded PID is from a previous boot.

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -1,0 +1,58 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4})
+}
+
+func TestStatusDone(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("the review"), 0o644)
+	_ = m.store.WriteExitCode("j", 0)
+
+	st, err := m.Status("j")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != "done" || st.Result != "the review" {
+		t.Fatalf("status = %+v", st)
+	}
+}
+
+func TestStatusFailed(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("boom"), 0o644)
+	_ = m.store.WriteExitCode("j", 5)
+
+	st, _ := m.Status("j")
+	if st.State != "failed" || st.Error == "" {
+		t.Fatalf("status = %+v", st)
+	}
+}
+
+func TestStatusInterruptedAfterReboot(t *testing.T) {
+	m := newTestManager(t)
+	// BootID differs from current -> the recorded PID is from a previous boot.
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), PID: 999999, BootID: "old-boot"})
+	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("partial"), 0o644)
+
+	st, _ := m.Status("j")
+	if st.State != "done" { // no sentinel, but output present and process cannot be alive
+		t.Fatalf("state = %q, want done (recovered output)", st.State)
+	}
+	if st.Result != "partial" {
+		t.Fatalf("result = %q", st.Result)
+	}
+}

--- a/internal/manager/util.go
+++ b/internal/manager/util.go
@@ -1,5 +1,0 @@
-package manager
-
-import "encoding/json"
-
-func jsonMarshalIndent(v any) ([]byte, error) { return json.MarshalIndent(v, "", "  ") }

--- a/internal/manager/util.go
+++ b/internal/manager/util.go
@@ -1,0 +1,5 @@
+package manager
+
+import "encoding/json"
+
+func jsonMarshalIndent(v any) ([]byte, error) { return json.MarshalIndent(v, "", "  ") }

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -1,0 +1,18 @@
+package mcptools
+
+import (
+	"context"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+func parseDuration(s string) (time.Duration, error) { return time.ParseDuration(s) }
+
+// ServeStdio runs the server over stdio until the client disconnects or ctx is
+// cancelled. stdout is the JSON-RPC stream; callers must keep all logging on
+// stderr.
+func ServeStdio(ctx context.Context, mgr *manager.Manager) error {
+	return NewServer(mgr).Run(ctx, &mcp.StdioTransport{})
+}

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -2,14 +2,13 @@ package mcptools
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/agy-mcp/internal/manager"
 )
-
-func parseDuration(s string) (time.Duration, error) { return time.ParseDuration(s) }
 
 // ServeStdio runs the server over stdio until the client disconnects or ctx is
 // cancelled. stdout is the JSON-RPC stream; callers must keep all logging on
@@ -26,14 +25,27 @@ func HTTPHandler(mgr *manager.Manager) http.Handler {
 	}, nil)
 }
 
-// ServeHTTP runs the Streamable HTTP server on addr until ctx is cancelled.
+// ServeHTTP runs the Streamable HTTP server on addr until ctx is cancelled, then
+// shuts down gracefully so in-flight responses can drain.
 func ServeHTTP(ctx context.Context, mgr *manager.Manager, addr string) error {
-	srv := &http.Server{Addr: addr, Handler: HTTPHandler(mgr)}
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           HTTPHandler(mgr),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	// Derive a cancelable context so the shutdown goroutine cannot leak if
+	// ListenAndServe returns on its own (for example, a bind failure).
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
 		<-ctx.Done()
-		_ = srv.Close()
+		shutCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		_ = srv.Shutdown(shutCtx)
 	}()
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	err := srv.ListenAndServe()
+	cancel() // unblock the shutdown goroutine when ListenAndServe returns first
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 	return nil

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -2,6 +2,7 @@ package mcptools
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -15,4 +16,25 @@ func parseDuration(s string) (time.Duration, error) { return time.ParseDuration(
 // stderr.
 func ServeStdio(ctx context.Context, mgr *manager.Manager) error {
 	return NewServer(mgr).Run(ctx, &mcp.StdioTransport{})
+}
+
+// HTTPHandler returns an http.Handler that serves the agy tools over the
+// Streamable HTTP transport. The same manager backs every session.
+func HTTPHandler(mgr *manager.Manager) http.Handler {
+	return mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+		return NewServer(mgr)
+	}, nil)
+}
+
+// ServeHTTP runs the Streamable HTTP server on addr until ctx is cancelled.
+func ServeHTTP(ctx context.Context, mgr *manager.Manager, addr string) error {
+	srv := &http.Server{Addr: addr, Handler: HTTPHandler(mgr)}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Close()
+	}()
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -1,0 +1,37 @@
+package mcptools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+func TestHTTPServeListsTools(t *testing.T) {
+	mgr := manager.New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, DefaultTimeout: time.Minute})
+	handler := HTTPHandler(mgr)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "t", Version: "0"}, nil)
+	ctx := context.Background()
+	cs, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer cs.Close()
+
+	tools, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	if len(tools.Tools) < 5 {
+		t.Fatalf("expected >=5 tools, got %d", len(tools.Tools))
+	}
+	_ = http.StatusOK
+}

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -1,8 +1,6 @@
 package mcptools
 
 import (
-	"context"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -19,12 +17,12 @@ func TestHTTPServeListsTools(t *testing.T) {
 	defer ts.Close()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "t", Version: "0"}, nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	cs, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	tools, err := cs.ListTools(ctx, nil)
 	if err != nil {
@@ -33,5 +31,4 @@ func TestHTTPServeListsTools(t *testing.T) {
 	if len(tools.Tools) < 5 {
 		t.Fatalf("expected >=5 tools, got %d", len(tools.Tools))
 	}
-	_ = http.StatusOK
 }

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -105,12 +105,13 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		if err := mgr.Cancel(in.JobID); err != nil {
 			return nil, cancelOutput{}, err
 		}
-		st, err := mgr.Status(in.JobID)
-		if err != nil {
-			// Cancel itself succeeded; the job state is just no longer readable.
-			return nil, cancelOutput{State: "unknown"}, nil
+		// Cancel itself succeeded; report the resulting state, or "unknown" if the
+		// job state is no longer readable.
+		state := "unknown"
+		if st, err := mgr.Status(in.JobID); err == nil {
+			state = st.State
 		}
-		return nil, cancelOutput{State: st.State}, nil
+		return nil, cancelOutput{State: state}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -1,0 +1,138 @@
+// Package mcptools adapts the manager core to MCP tools.
+package mcptools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// runInput is the input for agy_run.
+type runInput struct {
+	Prompt         string   `json:"prompt" jsonschema:"the prompt to send to agy"`
+	Model          string   `json:"model,omitempty" jsonschema:"agy model name; defaults to agy's configured default"`
+	Dirs           []string `json:"dirs,omitempty" jsonschema:"extra workspace directories (--add-dir)"`
+	ConversationID string   `json:"conversation_id,omitempty" jsonschema:"continue a specific conversation"`
+	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd"`
+	Cwd            string   `json:"cwd,omitempty" jsonschema:"working directory for the run"`
+	Timeout        string   `json:"timeout,omitempty" jsonschema:"max run duration, e.g. 20m"`
+}
+
+type runOutput struct {
+	JobID          string `json:"job_id"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	State          string `json:"state"`
+}
+
+type statusInput struct {
+	JobID string `json:"job_id" jsonschema:"the job id returned by agy_run"`
+}
+
+type statusOutput struct {
+	State          string `json:"state"`
+	Elapsed        string `json:"elapsed"`
+	Result         string `json:"result,omitempty"`
+	Error          string `json:"error,omitempty"`
+	ConversationID string `json:"conversation_id,omitempty"`
+}
+
+type cancelInput struct {
+	JobID string `json:"job_id" jsonschema:"the job id to cancel"`
+}
+type cancelOutput struct {
+	State string `json:"state"`
+}
+
+type emptyInput struct{}
+
+type modelsOutput struct {
+	Models []string `json:"models"`
+}
+
+type sessionsInput struct {
+	Dir string `json:"dir,omitempty" jsonschema:"filter to one workspace directory"`
+}
+type sessionsOutput struct {
+	Sessions []manager.Session `json:"sessions"`
+}
+
+// NewServer builds an MCP server with all agy tools registered.
+func NewServer(mgr *manager.Manager) *mcp.Server {
+	s := mcp.NewServer(&mcp.Implementation{Name: "agy-mcp", Version: "0.1.0"}, nil)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agy_run",
+		Description: "Start an agy prompt (e.g. a peer review) as an async job. Returns a job_id to poll with agy_status.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runInput) (*mcp.CallToolResult, runOutput, error) {
+		req := manager.StartRequest{
+			Prompt: in.Prompt, Model: in.Model, Dirs: in.Dirs,
+			ConversationID: in.ConversationID, ContinueLatest: in.ContinueLatest, Cwd: in.Cwd,
+		}
+		if in.Timeout != "" {
+			d, err := parseDuration(in.Timeout)
+			if err != nil {
+				return nil, runOutput{}, fmt.Errorf("invalid timeout %q: %w", in.Timeout, err)
+			}
+			req.Timeout = d
+		}
+		job, err := mgr.StartJob(req)
+		if err != nil {
+			return nil, runOutput{}, err
+		}
+		return nil, runOutput{JobID: job.ID, ConversationID: job.ConversationID, State: job.State}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "agy_status",
+		Description: "Poll an agy job. Returns running, done (with result), failed, or cancelled.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in statusInput) (*mcp.CallToolResult, statusOutput, error) {
+		st, err := mgr.Status(in.JobID)
+		if err != nil {
+			return nil, statusOutput{}, err
+		}
+		return nil, statusOutput{
+			State: st.State, Elapsed: st.Elapsed.Round(1e9).String(),
+			Result: st.Result, Error: st.Error, ConversationID: st.ConversationID,
+		}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "agy_cancel", Description: "Cancel a running agy job.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in cancelInput) (*mcp.CallToolResult, cancelOutput, error) {
+		if err := mgr.Cancel(in.JobID); err != nil {
+			return nil, cancelOutput{}, err
+		}
+		st, _ := mgr.Status(in.JobID)
+		return nil, cancelOutput{State: st.State}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "list_models", Description: "List available agy models.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ emptyInput) (*mcp.CallToolResult, modelsOutput, error) {
+		models, err := mgr.ListModels(ctx)
+		if err != nil {
+			return nil, modelsOutput{}, err
+		}
+		if models == nil {
+			models = []string{}
+		}
+		return nil, modelsOutput{Models: models}, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "list_sessions", Description: "List known agy conversations (workspace to conversation id).",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in sessionsInput) (*mcp.CallToolResult, sessionsOutput, error) {
+		sessions, err := mgr.ListSessions(in.Dir)
+		if err != nil {
+			return nil, sessionsOutput{}, err
+		}
+		if sessions == nil {
+			sessions = []manager.Session{}
+		}
+		return nil, sessionsOutput{Sessions: sessions}, nil
+	})
+
+	return s
+}

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -4,6 +4,7 @@ package mcptools
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/agy-mcp/internal/manager"
@@ -71,7 +72,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 			ConversationID: in.ConversationID, ContinueLatest: in.ContinueLatest, Cwd: in.Cwd,
 		}
 		if in.Timeout != "" {
-			d, err := parseDuration(in.Timeout)
+			d, err := time.ParseDuration(in.Timeout)
 			if err != nil {
 				return nil, runOutput{}, fmt.Errorf("invalid timeout %q: %w", in.Timeout, err)
 			}
@@ -104,7 +105,11 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		if err := mgr.Cancel(in.JobID); err != nil {
 			return nil, cancelOutput{}, err
 		}
-		st, _ := mgr.Status(in.JobID)
+		st, err := mgr.Status(in.JobID)
+		if err != nil {
+			// Cancel itself succeeded; the job state is just no longer readable.
+			return nil, cancelOutput{State: "unknown"}, nil
+		}
 		return nil, cancelOutput{State: st.State}, nil
 	})
 

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -1,0 +1,80 @@
+package mcptools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+func writeFakeSupervisor(t *testing.T, agy string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "fake-sup")
+	// Mimics `agy-mcp run-job <dir>`: runs the fake agy, captures stdout to out,
+	// writes exit_code.
+	script := "#!/usr/bin/env bash\n" +
+		"dir=\"$2\"\n" +
+		"\"" + agy + "\" -p x > \"$dir/out\" 2> \"$dir/err\"\n" +
+		"printf '%s' \"$?\" > \"$dir/exit_code\"\n"
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestAgyRunAndStatusOverMCP(t *testing.T) {
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
+	sup := writeFakeSupervisor(t, agy)
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: t.TempDir(),
+		DefaultTimeout: time.Minute, MaxConcurrency: 4}
+	mgr := manager.New(c)
+
+	srv := NewServer(mgr)
+	ct, st := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := srv.Connect(ctx, st, nil); err != nil { // server side
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer cs.Close()
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "agy_run",
+		Arguments: map[string]any{"prompt": "review"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run: err=%v res=%+v", err, res)
+	}
+	jobID := res.StructuredContent.(map[string]any)["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		s, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name: "agy_status", Arguments: map[string]any{"job_id": jobID}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		sc := s.StructuredContent.(map[string]any)
+		if sc["state"] == "done" {
+			if sc["result"] != "REVIEW OK" {
+				t.Fatalf("result = %v", sc["result"])
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("job did not reach done")
+}

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -1,7 +1,6 @@
 package mcptools
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func TestAgyRunAndStatusOverMCP(t *testing.T) {
 
 	srv := NewServer(mgr)
 	ct, st := mcp.NewInMemoryTransports()
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := srv.Connect(ctx, st, nil); err != nil { // server side
 		t.Fatalf("server connect: %v", err)
 	}
@@ -46,7 +45,7 @@ func TestAgyRunAndStatusOverMCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client connect: %v", err)
 	}
-	defer cs.Close()
+	defer func() { _ = cs.Close() }()
 
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "agy_run",

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4,6 +4,7 @@ package supervisor
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -37,17 +38,17 @@ func Run(jobDir string) error {
 	if err != nil {
 		return err
 	}
-	defer outF.Close()
+	defer func() { _ = outF.Close() }()
 	errF, err := os.Create(filepath.Join(jobDir, "err"))
 	if err != nil {
 		return err
 	}
-	defer errF.Close()
+	defer func() { _ = errF.Close() }()
 	devnull, err := os.Open(os.DevNull)
 	if err != nil {
 		return err
 	}
-	defer devnull.Close()
+	defer func() { _ = devnull.Close() }()
 
 	cmd := exec.Command(m.AgyPath, m.Args...)
 	cmd.Dir = m.Cwd
@@ -107,7 +108,7 @@ func Run(jobDir string) error {
 
 	code := 0
 	if waitErr != nil {
-		if ee, ok := waitErr.(*exec.ExitError); ok {
+		if ee, ok := errors.AsType[*exec.ExitError](waitErr); ok {
 			code = ee.ExitCode()
 			if code < 0 {
 				code = jobstore.ExitSIGTERM // terminated by signal

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,0 +1,93 @@
+// Package supervisor runs a single agy process on behalf of agy-mcp and writes
+// the exit-code sentinel, so a job survives the death of the manager.
+package supervisor
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// Run executes the agy process described by jobDir/meta.json. It captures
+// stdout to jobDir/out and stderr to jobDir/err, redirects agy stdin from
+// /dev/null, and writes jobDir/exit_code on completion (including on cancel).
+// Run returns an error only for setup failures, not for a non-zero agy exit.
+func Run(jobDir string) error {
+	var m jobstore.Meta
+	b, err := os.ReadFile(filepath.Join(jobDir, "meta.json"))
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+
+	outF, err := os.Create(filepath.Join(jobDir, "out"))
+	if err != nil {
+		return err
+	}
+	defer outF.Close()
+	errF, err := os.Create(filepath.Join(jobDir, "err"))
+	if err != nil {
+		return err
+	}
+	defer errF.Close()
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		return err
+	}
+	defer devnull.Close()
+
+	cmd := exec.Command(m.AgyPath, m.Args...)
+	cmd.Dir = m.Cwd
+	cmd.Env = os.Environ() // agy needs HOME/PATH and its OAuth/API credentials
+	cmd.Stdin = devnull
+	cmd.Stdout = outF
+	cmd.Stderr = errF
+	// Put agy in its own process group so we can signal it and its children.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		_ = writeExit(jobDir, 127)
+		return err
+	}
+
+	// Forward SIGTERM (sent by the manager on cancel) to the agy process group.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM)
+	defer signal.Stop(sig)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-sig:
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		case <-done:
+		}
+	}()
+
+	waitErr := cmd.Wait()
+	close(done)
+
+	code := 0
+	if waitErr != nil {
+		if ee, ok := waitErr.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+			if code < 0 {
+				code = 143 // terminated by signal
+			}
+		} else {
+			code = 1
+		}
+	}
+	return writeExit(jobDir, code)
+}
+
+func writeExit(jobDir string, code int) error {
+	return os.WriteFile(filepath.Join(jobDir, "exit_code"), []byte(strconv.Itoa(code)), 0o644)
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -59,7 +59,7 @@ func Run(jobDir string) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
-		_ = writeExit(jobDir, 127)
+		_ = writeExit(jobDir, jobstore.ExitSpawnFail)
 		return err
 	}
 
@@ -92,7 +92,13 @@ func Run(jobDir string) error {
 		select {
 		case <-done:
 		case <-time.After(killGrace):
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			// Do not signal a process group that may have already been reaped
+			// (and whose pgid could be recycled) once Wait has returned.
+			select {
+			case <-done:
+			default:
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
 		}
 	}()
 
@@ -104,20 +110,23 @@ func Run(jobDir string) error {
 		if ee, ok := waitErr.(*exec.ExitError); ok {
 			code = ee.ExitCode()
 			if code < 0 {
-				code = 143 // terminated by signal
+				code = jobstore.ExitSIGTERM // terminated by signal
 			}
 		} else {
 			code = 1
 		}
 	}
-	// If the hard timeout fired, record the timeout sentinel (124) regardless of
-	// the signal-derived exit code, so Status can report a timeout distinctly
-	// from a user cancel. (timedOut is closed before the kill, so it is always
-	// observable by the time Wait returns.)
-	select {
-	case <-timedOut:
-		code = 124
-	default:
+	// If the hard timeout fired, record the timeout sentinel so Status can report
+	// a timeout distinctly from a user cancel. Guard on waitErr so a job that
+	// finished naturally at the exact instant the timer fired is not mislabeled
+	// as a timeout (a natural success has waitErr == nil). timedOut is closed
+	// before the kill, so it is observable by the time Wait returns.
+	if waitErr != nil {
+		select {
+		case <-timedOut:
+			code = jobstore.ExitTimeout
+		default:
+		}
 	}
 	return writeExit(jobDir, code)
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -10,9 +10,14 @@ import (
 	"path/filepath"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
+
+// killGrace is how long the supervisor waits after SIGTERM before escalating to
+// SIGKILL when terminating the agy process group on cancel or timeout.
+const killGrace = 10 * time.Second
 
 // Run executes the agy process described by jobDir/meta.json. It captures
 // stdout to jobDir/out and stderr to jobDir/err, redirects agy stdin from
@@ -58,16 +63,36 @@ func Run(jobDir string) error {
 		return err
 	}
 
-	// Forward SIGTERM (sent by the manager on cancel) to the agy process group.
+	// Terminate the agy process group on either an external SIGTERM (cancel from
+	// the manager) or the hard timeout, escalating to SIGKILL after a grace
+	// window. The hard timeout is the spec's guarantee that a hung agy (which can
+	// stall at 0 CPU and ignore its own --print-timeout) can never block forever.
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGTERM)
 	defer signal.Stop(sig)
 	done := make(chan struct{})
+	timedOut := make(chan struct{})
+
 	go func() {
+		var deadline <-chan time.Time
+		if m.Timeout > 0 {
+			t := time.NewTimer(m.Timeout)
+			defer t.Stop()
+			deadline = t.C
+		}
 		select {
-		case <-sig:
-			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 		case <-done:
+			return
+		case <-sig:
+			// Cancel requested by the manager.
+		case <-deadline:
+			close(timedOut)
+		}
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		select {
+		case <-done:
+		case <-time.After(killGrace):
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		}
 	}()
 
@@ -84,6 +109,15 @@ func Run(jobDir string) error {
 		} else {
 			code = 1
 		}
+	}
+	// If the hard timeout fired, record the timeout sentinel (124) regardless of
+	// the signal-derived exit code, so Status can report a timeout distinctly
+	// from a user cancel. (timedOut is closed before the kill, so it is always
+	// observable by the time Wait returns.)
+	select {
+	case <-timedOut:
+		code = 124
+	default:
 	}
 	return writeExit(jobDir, code)
 }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,0 +1,52 @@
+package supervisor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+func writeMeta(t *testing.T, dir string, m jobstore.Meta) {
+	t.Helper()
+	b, _ := json.MarshalIndent(m, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSupervisorCapturesOutputAndSentinel(t *testing.T) {
+	dir := t.TempDir()
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "review text", Stderr: "warn", Exit: 0})
+	writeMeta(t, dir, jobstore.Meta{ID: "j", AgyPath: agy, Args: []string{"-p", "x"}, StartedAt: time.Now()})
+
+	if err := Run(dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out, _ := os.ReadFile(filepath.Join(dir, "out"))
+	if strings.TrimSpace(string(out)) != "review text" {
+		t.Fatalf("out = %q", out)
+	}
+	code, err := os.ReadFile(filepath.Join(dir, "exit_code"))
+	if err != nil || strings.TrimSpace(string(code)) != "0" {
+		t.Fatalf("exit_code = %q, err=%v", code, err)
+	}
+}
+
+func TestSupervisorRecordsNonZeroExit(t *testing.T) {
+	dir := t.TempDir()
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stderr: "fail", Exit: 7})
+	writeMeta(t, dir, jobstore.Meta{ID: "j", AgyPath: agy, StartedAt: time.Now()})
+	if err := Run(dir); err != nil {
+		t.Fatalf("Run should not error on non-zero agy exit: %v", err)
+	}
+	code, _ := os.ReadFile(filepath.Join(dir, "exit_code"))
+	if strings.TrimSpace(string(code)) != "7" {
+		t.Fatalf("exit_code = %q, want 7", code)
+	}
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -50,3 +50,25 @@ func TestSupervisorRecordsNonZeroExit(t *testing.T) {
 		t.Fatalf("exit_code = %q, want 7", code)
 	}
 }
+
+func TestSupervisorHardTimeoutKillsAgy(t *testing.T) {
+	dir := t.TempDir()
+	// A fake agy that would sleep far longer than the hard timeout.
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "should not finish", SleepSecs: 30})
+	writeMeta(t, dir, jobstore.Meta{
+		ID: "j", AgyPath: agy, Args: []string{"-p", "x"},
+		StartedAt: time.Now(), Timeout: 500 * time.Millisecond,
+	})
+
+	start := time.Now()
+	if err := Run(dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Fatalf("Run took %v; the hard timeout did not kill agy", elapsed)
+	}
+	code, _ := os.ReadFile(filepath.Join(dir, "exit_code"))
+	if strings.TrimSpace(string(code)) != "124" {
+		t.Fatalf("exit_code = %q, want 124 (timeout)", code)
+	}
+}

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -1,0 +1,46 @@
+// Package testutil provides test doubles for agy-mcp.
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FakeAgy configures a stand-in agy binary for tests.
+type FakeAgy struct {
+	Stdout    string // printed to stdout, then process exits
+	Stderr    string // printed to stderr
+	Exit      int    // exit code
+	SleepSecs int    // seconds to sleep before printing (simulate a long run)
+}
+
+// WriteFakeAgy writes an executable shell script that mimics agy's print mode
+// and returns its path. The script is created under t.TempDir(). The configured
+// stdout and stderr are written to sibling payload files and reproduced
+// faithfully via cat, so arbitrary byte content (newlines, shell metacharacters)
+// survives intact.
+func WriteFakeAgy(t *testing.T, cfg FakeAgy) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-agy")
+	outPath := filepath.Join(dir, "fake-agy.out")
+	errPath := filepath.Join(dir, "fake-agy.err")
+	if err := os.WriteFile(outPath, []byte(cfg.Stdout), 0o644); err != nil {
+		t.Fatalf("write fake agy stdout: %v", err)
+	}
+	if err := os.WriteFile(errPath, []byte(cfg.Stderr), 0o644); err != nil {
+		t.Fatalf("write fake agy stderr: %v", err)
+	}
+	script := fmt.Sprintf(`#!/usr/bin/env bash
+sleep %d
+cat %q
+cat %q 1>&2
+exit %d
+`, cfg.SleepSecs, outPath, errPath, cfg.Exit)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake agy: %v", err)
+	}
+	return path
+}

--- a/internal/testutil/fakeagy_test.go
+++ b/internal/testutil/fakeagy_test.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestFakeAgyEmitsStdoutAndExit(t *testing.T) {
+	path := WriteFakeAgy(t, FakeAgy{Stdout: "hello world", Exit: 0})
+	out, err := exec.Command(path, "-p", "ignored").Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "hello world" {
+		t.Fatalf("stdout = %q, want %q", got, "hello world")
+	}
+}
+
+func TestFakeAgyNonZeroExit(t *testing.T) {
+	path := WriteFakeAgy(t, FakeAgy{Stderr: "boom", Exit: 3})
+	err := exec.Command(path).Run()
+	ee, ok := err.(*exec.ExitError)
+	if !ok || ee.ExitCode() != 3 {
+		t.Fatalf("exit = %v, want code 3", err)
+	}
+}

--- a/internal/testutil/fakeagy_test.go
+++ b/internal/testutil/fakeagy_test.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"errors"
 	"os/exec"
 	"strings"
 	"testing"
@@ -20,8 +21,7 @@ func TestFakeAgyEmitsStdoutAndExit(t *testing.T) {
 func TestFakeAgyNonZeroExit(t *testing.T) {
 	path := WriteFakeAgy(t, FakeAgy{Stderr: "boom", Exit: 3})
 	err := exec.Command(path).Run()
-	ee, ok := err.(*exec.ExitError)
-	if !ok || ee.ExitCode() != 3 {
+	if ee, ok := errors.AsType[*exec.ExitError](err); !ok || ee.ExitCode() != 3 {
 		t.Fatalf("exit = %v, want code 3", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -62,7 +63,7 @@ func main() {
 	}
 
 	log.Print("agy-mcp serving over stdio")
-	if err := mcptools.ServeStdio(ctx, mgr); err != nil && err != io.EOF {
+	if err := mcptools.ServeStdio(ctx, mgr); err != nil && !errors.Is(err, io.EOF) {
 		fmt.Fprintf(os.Stderr, "stdio serve: %v\n", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -35,13 +35,22 @@ func main() {
 		return
 	}
 
+	if err := serve(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// serve resolves configuration, runs startup garbage collection, and serves the
+// MCP tools over stdio (default) or Streamable HTTP. It returns an error rather
+// than calling os.Exit so deferred cleanup (the signal stop) still runs.
+func serve() error {
 	httpAddr := flag.String("http", "", "serve over Streamable HTTP on this address (e.g. 127.0.0.1:8765) instead of stdio; unauthenticated, bind localhost only")
 	flag.Parse()
 
 	cfg, err := config.Resolve()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "config: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("config: %w", err)
 	}
 	mgr := manager.New(cfg)
 	if removed, err := mgr.GarbageCollect(); err != nil {
@@ -56,15 +65,14 @@ func main() {
 	if *httpAddr != "" {
 		log.Printf("agy-mcp serving Streamable HTTP on %s", *httpAddr)
 		if err := mcptools.ServeHTTP(ctx, mgr, *httpAddr); err != nil {
-			fmt.Fprintf(os.Stderr, "http serve: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("http serve: %w", err)
 		}
-		return
+		return nil
 	}
 
 	log.Print("agy-mcp serving over stdio")
 	if err := mcptools.ServeStdio(ctx, mgr); err != nil && !errors.Is(err, io.EOF) {
-		fmt.Fprintf(os.Stderr, "stdio serve: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("stdio serve: %w", err)
 	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -43,6 +43,11 @@ func main() {
 		os.Exit(1)
 	}
 	mgr := manager.New(cfg)
+	if removed, err := mgr.GarbageCollect(); err != nil {
+		log.Printf("startup GC: %v", err)
+	} else if len(removed) > 0 {
+		log.Printf("startup GC removed %d expired job(s)", len(removed))
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/main.go
+++ b/main.go
@@ -1,0 +1,64 @@
+// Command agy-mcp is an MCP server wrapping the Antigravity CLI (agy).
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/mcptools"
+	"github.com/tphakala/agy-mcp/internal/supervisor"
+)
+
+func main() {
+	// stdout is reserved for the JSON-RPC stream in stdio mode. Force the
+	// standard logger to stderr so a stray log line cannot corrupt the protocol.
+	log.SetOutput(os.Stderr)
+
+	if len(os.Args) >= 2 && os.Args[1] == "run-job" {
+		if len(os.Args) != 3 {
+			fmt.Fprintln(os.Stderr, "usage: agy-mcp run-job <jobDir>")
+			os.Exit(2)
+		}
+		if err := supervisor.Run(os.Args[2]); err != nil {
+			fmt.Fprintf(os.Stderr, "run-job: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	httpAddr := flag.String("http", "", "serve over Streamable HTTP on this address (e.g. 127.0.0.1:8765) instead of stdio; unauthenticated, bind localhost only")
+	flag.Parse()
+
+	cfg, err := config.Resolve()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		os.Exit(1)
+	}
+	mgr := manager.New(cfg)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if *httpAddr != "" {
+		log.Printf("agy-mcp serving Streamable HTTP on %s", *httpAddr)
+		if err := mcptools.ServeHTTP(ctx, mgr, *httpAddr); err != nil {
+			fmt.Fprintf(os.Stderr, "http serve: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	log.Print("agy-mcp serving over stdio")
+	if err := mcptools.ServeStdio(ctx, mgr); err != nil && err != io.EOF {
+		fmt.Fprintf(os.Stderr, "stdio serve: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -63,6 +64,9 @@ func serve() error {
 	defer stop()
 
 	if *httpAddr != "" {
+		if err := checkLoopbackAddr(*httpAddr); err != nil {
+			return err
+		}
 		log.Printf("agy-mcp serving Streamable HTTP on %s", *httpAddr)
 		if err := mcptools.ServeHTTP(ctx, mgr, *httpAddr); err != nil {
 			return fmt.Errorf("http serve: %w", err)
@@ -75,4 +79,25 @@ func serve() error {
 		return fmt.Errorf("stdio serve: %w", err)
 	}
 	return nil
+}
+
+// checkLoopbackAddr rejects any HTTP bind address that is not loopback. The
+// HTTP mode is unauthenticated, so binding a non-loopback interface would
+// expose it; this refuses to do so rather than relying on the user reading the
+// docs.
+func checkLoopbackAddr(addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr // no port; treat the whole value as the host
+	}
+	if host == "" {
+		return fmt.Errorf("http address %q binds all interfaces; specify a loopback host (e.g. 127.0.0.1:8765) for the unauthenticated HTTP mode", addr)
+	}
+	if host == "localhost" {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("http address %q must be loopback only (localhost, 127.0.0.1, or ::1) for the unauthenticated HTTP mode", addr)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 	"github.com/tphakala/agy-mcp/internal/testutil"
@@ -35,5 +38,45 @@ func TestRunJobSubcommandEndToEnd(t *testing.T) {
 	out, _ := os.ReadFile(filepath.Join(jobDir, "out"))
 	if strings.TrimSpace(string(out)) != "E2E OK" {
 		t.Fatalf("out = %q", out)
+	}
+}
+
+// Cancel end to end: SIGTERM the supervisor subprocess and confirm it forwards
+// the signal to agy and writes the SIGTERM sentinel, which Status maps to
+// "cancelled".
+func TestRunJobCancelViaSignal(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "agy-mcp")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	// A fake agy that sleeps far longer than the test; with no timeout in meta,
+	// only an external cancel signal can stop it.
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", SleepSecs: 60})
+	jobDir := t.TempDir()
+	meta := jobstore.Meta{ID: filepath.Base(jobDir), AgyPath: agy, Args: []string{"-p", "x"}}
+	b, _ := jsonMarshalForTest(meta)
+	_ = os.WriteFile(filepath.Join(jobDir, "meta.json"), b, 0o644)
+
+	cmd := exec.Command(bin, "run-job", jobDir)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Give the supervisor time to start agy and install its SIGTERM handler.
+	time.Sleep(time.Second)
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	_ = cmd.Wait()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(filepath.Join(jobDir, "exit_code")); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	code, _ := os.ReadFile(filepath.Join(jobDir, "exit_code"))
+	if strings.TrimSpace(string(code)) != strconv.Itoa(jobstore.ExitSIGTERM) {
+		t.Fatalf("exit_code = %q, want %d (SIGTERM cancel)", code, jobstore.ExitSIGTERM)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+func jsonMarshalForTest(v any) ([]byte, error) { return json.MarshalIndent(v, "", "  ") }
+
+// Build the binary once and use it as its own supervisor against a fake agy.
+func TestRunJobSubcommandEndToEnd(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "agy-mcp")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "E2E OK", Exit: 0})
+
+	jobDir := t.TempDir()
+	meta := jobstore.Meta{ID: filepath.Base(jobDir), AgyPath: agy, Args: []string{"-p", "x"}}
+	b, _ := jsonMarshalForTest(meta)
+	_ = os.WriteFile(filepath.Join(jobDir, "meta.json"), b, 0o644)
+
+	cmd := exec.Command(bin, "run-job", jobDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run-job: %v\n%s", err, out)
+	}
+	out, _ := os.ReadFile(filepath.Join(jobDir, "out"))
+	if strings.TrimSpace(string(out)) != "E2E OK" {
+		t.Fatalf("out = %q", out)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -80,3 +80,16 @@ func TestRunJobCancelViaSignal(t *testing.T) {
 		t.Fatalf("exit_code = %q, want %d (SIGTERM cancel)", code, jobstore.ExitSIGTERM)
 	}
 }
+
+func TestCheckLoopbackAddr(t *testing.T) {
+	for _, addr := range []string{"127.0.0.1:8765", "localhost:8765", "[::1]:8765", "127.0.0.1:0"} {
+		if err := checkLoopbackAddr(addr); err != nil {
+			t.Errorf("checkLoopbackAddr(%q) = %v, want nil", addr, err)
+		}
+	}
+	for _, addr := range []string{":8765", "0.0.0.0:8765", "192.168.1.10:8765", "example.com:8765"} {
+		if err := checkLoopbackAddr(addr); err == nil {
+			t.Errorf("checkLoopbackAddr(%q) = nil, want error", addr)
+		}
+	}
+}

--- a/rules/builtins.go
+++ b/rules/builtins.go
@@ -1,0 +1,201 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// MinMaxBuiltin detects manual min/max implementations using if statements
+// or ternary-like patterns and suggests using the built-in min/max functions.
+//
+// Old patterns:
+//
+//	// If-based min
+//	if a < b {
+//	    result = a
+//	} else {
+//	    result = b
+//	}
+//
+//	// math.Min/Max for integers
+//	result := int(math.Min(float64(a), float64(b)))
+//
+// New pattern (Go 1.21+):
+//
+//	result := min(a, b)
+//	result := max(a, b)
+//
+// Benefits:
+//   - Cleaner, more readable code
+//   - Works with any ordered type
+//   - No type conversion needed
+//
+// See: https://pkg.go.dev/builtin#min
+// See: https://pkg.go.dev/builtin#max
+func MinMaxBuiltin(m dsl.Matcher) {
+	// math.Min with float64 conversion for integers
+	m.Match(
+		`int(math.Min(float64($a), float64($b)))`,
+	).
+		Report("use min($a, $b) instead of int(math.Min(float64(...))) (Go 1.21+)").
+		Suggest("min($a, $b)")
+
+	m.Match(
+		`int64(math.Min(float64($a), float64($b)))`,
+	).
+		Report("use min($a, $b) instead of int64(math.Min(float64(...))) (Go 1.21+)").
+		Suggest("min($a, $b)")
+
+	m.Match(
+		`int32(math.Min(float64($a), float64($b)))`,
+	).
+		Report("use min($a, $b) instead of int32(math.Min(float64(...))) (Go 1.21+)").
+		Suggest("min($a, $b)")
+
+	// math.Max with float64 conversion for integers
+	m.Match(
+		`int(math.Max(float64($a), float64($b)))`,
+	).
+		Report("use max($a, $b) instead of int(math.Max(float64(...))) (Go 1.21+)").
+		Suggest("max($a, $b)")
+
+	m.Match(
+		`int64(math.Max(float64($a), float64($b)))`,
+	).
+		Report("use max($a, $b) instead of int64(math.Max(float64(...))) (Go 1.21+)").
+		Suggest("max($a, $b)")
+
+	m.Match(
+		`int32(math.Max(float64($a), float64($b)))`,
+	).
+		Report("use max($a, $b) instead of int32(math.Max(float64(...))) (Go 1.21+)").
+		Suggest("max($a, $b)")
+}
+
+// ClearBuiltin detects loop-based map/slice clearing patterns and suggests
+// using the built-in clear() function.
+//
+// Old patterns:
+//
+//	// Map clearing
+//	for k := range m {
+//	    delete(m, k)
+//	}
+//
+//	// Slice zeroing
+//	for i := range s {
+//	    s[i] = 0  // or nil, "", etc.
+//	}
+//
+// New pattern (Go 1.21+):
+//
+//	clear(m)  // Deletes all map entries
+//	clear(s)  // Sets all slice elements to zero value
+//
+// Benefits:
+//   - Cleaner, more readable code
+//   - More efficient (optimized implementation)
+//   - Works with maps and slices
+//
+// See: https://pkg.go.dev/builtin#clear
+func ClearBuiltin(m dsl.Matcher) {
+	// Map clearing pattern: for k := range m { delete(m, k) }
+	m.Match(
+		`for $k := range $m { delete($m, $k) }`,
+	).
+		Report("use clear($m) instead of loop-based map clearing (Go 1.21+)").
+		Suggest("clear($m)")
+
+	// Map clearing with underscore value: for k, _ := range m { delete(m, k) }
+	m.Match(
+		`for $k, _ := range $m { delete($m, $k) }`,
+	).
+		Report("use clear($m) instead of loop-based map clearing (Go 1.21+)").
+		Suggest("clear($m)")
+}
+
+// RangeOverInteger detects traditional for loops that iterate from 0 to n
+// and suggests using the Go 1.22+ range-over-integer syntax.
+//
+// Old pattern:
+//
+//	for i := 0; i < n; i++ {
+//	    process(i)
+//	}
+//
+// New pattern (Go 1.22+):
+//
+//	for i := range n {
+//	    process(i)
+//	}
+//
+// Benefits:
+//   - More concise and readable
+//   - Intent is clearer (iterate n times)
+//   - Less error-prone (no off-by-one mistakes)
+//
+// Note: Only matches loops starting from 0 with < comparison and i++.
+// Loops with different starting values, comparisons, or increments
+// are intentionally not flagged.
+//
+// See: https://go.dev/doc/go1.22#language
+func RangeOverInteger(m dsl.Matcher) {
+	// Pattern: for i := 0; i < n; i++
+	// Exclude benchmark loops (b.N) which should use b.Loop() instead
+	m.Match(
+		`for $i := 0; $i < $n; $i++ { $*body }`,
+	).
+		Where(
+			!m["n"].Text.Matches(`.*\.N$`) &&
+				!m["n"].Text.Matches(`\.(NumField|NumMethod|NumIn|NumOut)\(\)$`),
+		).
+		Report("use for $i := range $n instead of for $i := 0; $i < $n; $i++ (Go 1.22+)").
+		Suggest("for $i := range $n { $body }")
+}
+
+// AppendWithoutValues detects append calls with no values which have no effect.
+//
+// Broken pattern:
+//
+//	slice = append(slice)  // No effect
+//
+// See: https://pkg.go.dev/builtin#append
+// Note: Go 1.22 vet tool also warns about this pattern.
+func AppendWithoutValues(m dsl.Matcher) {
+	m.Match(
+		`append($s)`,
+	).
+		Report("append with single argument has no effect; did you forget the values to append?")
+}
+
+// NewWithExpression detects the slice-literal hack for getting a pointer to a value
+// and suggests using Go 1.26's enhanced new() built-in.
+//
+// Old pattern (slice hack):
+//
+//	field := &[]string{"hello"}[0]
+//	field := &[]int{42}[0]
+//	field := &[]time.Duration{5 * time.Second}[0]
+//
+// New pattern (Go 1.26+):
+//
+//	field := new("hello")
+//	field := new(42)
+//	field := new(5 * time.Second)
+//
+// Benefits:
+//   - Eliminates the obscure slice-literal-index hack
+//   - Clearer intent: "pointer to this value"
+//   - No intermediate slice allocation
+//   - Works with any expression, including function calls
+//
+// See: https://go.dev/doc/go1.26#language
+func NewWithExpression(m dsl.Matcher) {
+	// Pattern: &[]T{v}[0] - the well-known slice hack for pointer-to-value
+	// Note: Report-only, no autofix. The replacement new($val) must preserve the type of $typ,
+	// which requires new($typ($val)) for type conversions. Since we can't reliably determine
+	// when a type conversion is needed, we report without suggesting an autofix.
+	m.Match(
+		`&[]$typ{$val}[0]`,
+	).
+		Report("consider using new($typ($val)) instead of &[]$typ{$val}[0] (Go 1.26+); verify type compatibility")
+}

--- a/rules/crypto.go
+++ b/rules/crypto.go
@@ -1,0 +1,177 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// DeprecatedCipherModes detects deprecated cipher modes from crypto/cipher.
+//
+// Deprecated modes (Go 1.24):
+//   - cipher.NewOFB
+//   - cipher.NewCFBEncrypter
+//   - cipher.NewCFBDecrypter
+//
+// These modes are not authenticated and are vulnerable to active attacks.
+// Use AEAD modes (GCM, CCM) or CTR mode instead.
+//
+// Old patterns:
+//
+//	stream := cipher.NewOFB(block, iv)
+//	stream := cipher.NewCFBEncrypter(block, iv)
+//	stream := cipher.NewCFBDecrypter(block, iv)
+//
+// Recommended alternatives:
+//
+//	// For authenticated encryption (preferred):
+//	aead, _ := cipher.NewGCM(block)
+//	ciphertext := aead.Seal(nil, nonce, plaintext, additionalData)
+//
+//	// For stream cipher without authentication:
+//	stream := cipher.NewCTR(block, iv)
+//
+// See: https://pkg.go.dev/crypto/cipher#NewGCM
+// See: https://pkg.go.dev/crypto/cipher#NewCTR
+func DeprecatedCipherModes(m dsl.Matcher) {
+	m.Match(
+		`cipher.NewOFB($block, $iv)`,
+	).
+		Report("cipher.NewOFB is deprecated in Go 1.24: OFB mode is not authenticated and vulnerable to active attacks; use cipher.NewGCM (AEAD) or cipher.NewCTR instead")
+
+	m.Match(
+		`cipher.NewCFBEncrypter($block, $iv)`,
+	).
+		Report("cipher.NewCFBEncrypter is deprecated in Go 1.24: CFB mode is not authenticated and vulnerable to active attacks; use cipher.NewGCM (AEAD) or cipher.NewCTR instead")
+
+	m.Match(
+		`cipher.NewCFBDecrypter($block, $iv)`,
+	).
+		Report("cipher.NewCFBDecrypter is deprecated in Go 1.24: CFB mode is not authenticated and vulnerable to active attacks; use cipher.NewGCM (AEAD) or cipher.NewCTR instead")
+}
+
+// WeakRSAKeySize detects RSA key generation with sizes less than 2048 bits.
+//
+// Go 1.24 enforces minimum 1024-bit RSA keys, but 2048 bits is the modern recommendation.
+//
+// Weak pattern:
+//
+//	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+//
+// Recommended:
+//
+//	key, _ := rsa.GenerateKey(rand.Reader, 2048)  // Minimum recommended
+//	key, _ := rsa.GenerateKey(rand.Reader, 4096)  // For long-term security
+//
+// See: https://pkg.go.dev/crypto/rsa#GenerateKey
+func WeakRSAKeySize(m dsl.Matcher) {
+	// Flag 1024-bit keys (allowed but weak)
+	m.Match(
+		`rsa.GenerateKey($rand, 1024)`,
+	).
+		Report("RSA 1024-bit keys are considered weak; use at least 2048 bits for modern security")
+
+	// Flag explicitly small keys (will error in Go 1.24+)
+	m.Match(
+		`rsa.GenerateKey($rand, 512)`,
+		`rsa.GenerateKey($rand, 768)`,
+	).
+		Report("RSA keys smaller than 1024 bits are rejected in Go 1.24+; use at least 2048 bits")
+}
+
+// DeprecatedElliptic detects deprecated crypto/elliptic usage and suggests
+// using crypto/ecdh instead.
+//
+// Deprecated pattern:
+//
+//	import "crypto/elliptic"
+//	curve := elliptic.P256()
+//	key, _ := elliptic.GenerateKey(curve, rand.Reader)
+//
+// New pattern (Go 1.21+):
+//
+//	import "crypto/ecdh"
+//	key, _ := ecdh.P256().GenerateKey(rand.Reader)
+//
+// Benefits:
+//   - Modern, safer API
+//   - Better encapsulation of key material
+//   - Cleaner interface
+//
+// See: https://pkg.go.dev/crypto/ecdh
+func DeprecatedElliptic(m dsl.Matcher) {
+	m.Match(
+		`elliptic.GenerateKey($curve, $rand)`,
+	).
+		Report("elliptic.GenerateKey is deprecated; use crypto/ecdh package instead (Go 1.21+)")
+
+	m.Match(
+		`elliptic.Marshal($curve, $x, $y)`,
+	).
+		Report("elliptic.Marshal is deprecated; use crypto/ecdh package instead (Go 1.21+)")
+
+	m.Match(
+		`elliptic.Unmarshal($curve, $data)`,
+	).
+		Report("elliptic.Unmarshal is deprecated; use crypto/ecdh package instead (Go 1.21+)")
+}
+
+// DeprecatedRSAMultiPrime detects deprecated rsa.GenerateMultiPrimeKey.
+//
+// Deprecated pattern:
+//
+//	key, _ := rsa.GenerateMultiPrimeKey(rand.Reader, nprimes, bits)
+//
+// Use instead:
+//
+//	key, _ := rsa.GenerateKey(rand.Reader, bits)
+//
+// Multi-prime RSA keys are rarely needed and the function is deprecated.
+//
+// See: https://pkg.go.dev/crypto/rsa#GenerateKey
+func DeprecatedRSAMultiPrime(m dsl.Matcher) {
+	m.Match(
+		`rsa.GenerateMultiPrimeKey($rand, $nprimes, $bits)`,
+	).
+		Report("rsa.GenerateMultiPrimeKey is deprecated; use rsa.GenerateKey for standard 2-prime RSA (Go 1.21+)")
+}
+
+// DeprecatedPKCS1v15 detects deprecated PKCS#1 v1.5 encryption functions
+// which are vulnerable to Bleichenbacher padding oracle attacks.
+//
+// Deprecated patterns (Go 1.26):
+//
+//	ciphertext, _ := rsa.EncryptPKCS1v15(rand.Reader, pub, plaintext)
+//	plaintext, _ := rsa.DecryptPKCS1v15(rand.Reader, priv, ciphertext)
+//	rsa.DecryptPKCS1v15SessionKey(rand.Reader, priv, ciphertext, key)
+//
+// Recommended alternatives:
+//
+//	// OAEP encryption (preferred):
+//	ciphertext, _ := rsa.EncryptOAEP(sha256.New(), rand.Reader, pub, plaintext, nil)
+//	plaintext, _ := rsa.DecryptOAEP(sha256.New(), rand.Reader, priv, ciphertext, nil)
+//
+//	// OAEP with separate MGF1 hash (Go 1.26+):
+//	ciphertext, _ := rsa.EncryptOAEPWithOptions(rand.Reader, pub, plaintext,
+//	    &rsa.OAEPOptions{Hash: crypto.SHA256, MGFHash: crypto.SHA1})
+//
+// PKCS#1 v1.5 encryption is vulnerable to Bleichenbacher's chosen-ciphertext
+// attack, which can allow an attacker to decrypt ciphertexts by observing
+// padding errors. OAEP provides provable security against this class of attack.
+//
+// See: https://pkg.go.dev/crypto/rsa#EncryptOAEP
+// See: https://pkg.go.dev/crypto/rsa#EncryptOAEPWithOptions
+func DeprecatedPKCS1v15(m dsl.Matcher) {
+	m.Match(
+		`rsa.EncryptPKCS1v15($rand, $pub, $msg)`,
+	).
+		Report("rsa.EncryptPKCS1v15 is deprecated in Go 1.26: PKCS#1 v1.5 encryption is vulnerable to Bleichenbacher attacks; use rsa.EncryptOAEP instead")
+
+	m.Match(
+		`rsa.DecryptPKCS1v15($rand, $priv, $ciphertext)`,
+	).
+		Report("rsa.DecryptPKCS1v15 is deprecated in Go 1.26: PKCS#1 v1.5 encryption is vulnerable to Bleichenbacher attacks; use rsa.DecryptOAEP instead")
+
+	m.Match(
+		`rsa.DecryptPKCS1v15SessionKey($rand, $priv, $ciphertext, $key)`,
+	).
+		Report("rsa.DecryptPKCS1v15SessionKey is deprecated in Go 1.26: PKCS#1 v1.5 encryption is vulnerable to Bleichenbacher attacks; use OAEP-based encryption instead")
+}

--- a/rules/errors.go
+++ b/rules/errors.go
@@ -1,0 +1,36 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// ErrorsAsType detects errors.As with a pointer target and suggests errors.AsType.
+//
+// The old pattern:
+//
+//	var pathErr *fs.PathError
+//	if errors.As(err, &pathErr) {
+//	    fmt.Println(pathErr.Path)
+//	}
+//
+// New pattern (Go 1.26+):
+//
+//	if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+//	    fmt.Println(pathErr.Path)
+//	}
+//
+// Benefits:
+//   - Type-safe: checked at compile time, no risk of passing wrong pointer type
+//   - Faster: avoids reflection internally
+//   - Reduces LOC: no separate variable declaration needed
+//   - Scopes the variable to the if block
+//
+// See: https://pkg.go.dev/errors#AsType
+func ErrorsAsType(m dsl.Matcher) {
+	// Pattern: errors.As(err, &target)
+	// This catches all errors.As calls with address-of second argument
+	m.Match(
+		`errors.As($err, &$target)`,
+	).
+		Report("use errors.AsType[$target]($err) instead of errors.As for type-safe, faster error assertion (Go 1.26+)")
+}

--- a/rules/net.go
+++ b/rules/net.go
@@ -1,0 +1,143 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// JoinHostPort detects fmt.Sprintf patterns for host:port and suggests net.JoinHostPort.
+//
+// The old pattern:
+//
+//	addr := fmt.Sprintf("%s:%d", host, port)
+//
+// Should be:
+//
+//	addr := net.JoinHostPort(host, strconv.Itoa(port))
+//
+// net.JoinHostPort properly handles IPv6 addresses by wrapping them in brackets,
+// which fmt.Sprintf does not. This is critical for network code correctness.
+//
+// Note: This rule only flags patterns with integer ports to reduce false positives.
+// String concatenation patterns like "host + : + port" are too common for non-network
+// use cases (cache keys, identifiers, etc.) and are not flagged.
+//
+// See: https://pkg.go.dev/net#JoinHostPort
+func JoinHostPort(m dsl.Matcher) {
+	// Only flag fmt.Sprintf with integer port - this is a strong signal for network addresses
+	// String ports could be cache keys, identifiers, etc.
+	m.Match(
+		`fmt.Sprintf("%s:%d", $host, $port)`,
+		`fmt.Sprintf("%v:%d", $host, $port)`,
+	).
+		Report("use net.JoinHostPort($host, strconv.Itoa($port)) instead of fmt.Sprintf for host:port (handles IPv6 correctly)")
+}
+
+// FilepathIsLocal detects simple path traversal checks that could use filepath.IsLocal.
+//
+// Old pattern (manual path traversal check):
+//
+//	if strings.Contains(userPath, "..") {
+//	    return errors.New("invalid path")
+//	}
+//	// Still vulnerable to other attacks
+//
+// New pattern (Go 1.20+):
+//
+//	if !filepath.IsLocal(userPath) {
+//	    return errors.New("invalid path")
+//	}
+//	f, _ := os.Open(userPath)
+//
+// filepath.IsLocal reports whether path is:
+//   - Not absolute
+//   - Not empty
+//   - Does not contain ".." elements
+//   - Does not start with "/"
+//   - On Windows: does not contain ":" or start with "\"
+//
+// Benefits:
+//   - Comprehensive path validation
+//   - Handles OS-specific path separators
+//   - Prevents directory traversal attacks
+//
+// See: https://pkg.go.dev/path/filepath#IsLocal
+func FilepathIsLocal(m dsl.Matcher) {
+	// Detect simple .. check that might be replaced by IsLocal
+	// Note: For URL paths, strings.Contains is still appropriate because filepath.IsLocal
+	// cleans paths internally (e.g., "path/../etc" → "etc" → valid).
+	m.Match(
+		`strings.Contains($path, "..")`,
+	).
+		Report("consider using filepath.IsLocal($path) for file path validation (Go 1.20+); for URL paths, strings.Contains is appropriate")
+}
+
+// DeprecatedReverseProxyDirector detects usage of httputil.ReverseProxy's
+// deprecated Director field and suggests using Rewrite instead.
+//
+// Deprecated pattern:
+//
+//	proxy := &httputil.ReverseProxy{
+//	    Director: func(req *http.Request) {
+//	        req.URL.Scheme = "https"
+//	        req.URL.Host = "backend:8080"
+//	    },
+//	}
+//
+// New pattern (Go 1.26+):
+//
+//	proxy := &httputil.ReverseProxy{
+//	    Rewrite: func(r *httputil.ProxyRequest) {
+//	        r.SetURL(targetURL)
+//	        r.SetXForwarded()
+//	    },
+//	}
+//
+// Security issue: When using Director, a malicious client can send a request
+// that designates security headers (e.g., X-Forwarded-For) as hop-by-hop
+// headers via the Connection header. The proxy strips hop-by-hop headers
+// AFTER Director runs, effectively removing headers that Director set.
+// Rewrite does not have this vulnerability because it operates on a copy
+// of the request where hop-by-hop headers have already been removed.
+//
+// See: https://pkg.go.dev/net/http/httputil#ReverseProxy
+// See: https://pkg.go.dev/net/http/httputil#ProxyRequest
+func DeprecatedReverseProxyDirector(m dsl.Matcher) {
+	m.Match(
+		`httputil.ReverseProxy{$*_, Director: $_, $*_}`,
+	).
+		Report("httputil.ReverseProxy.Director is deprecated in Go 1.26: Director is vulnerable to hop-by-hop header abuse; use Rewrite instead for safe header handling")
+
+	m.Match(
+		`$proxy.Director = $_`,
+	).
+		Where(m["proxy"].Type.Is("*httputil.ReverseProxy")).
+		Report("httputil.ReverseProxy.Director is deprecated in Go 1.26: Director is vulnerable to hop-by-hop header abuse; use Rewrite instead for safe header handling")
+}
+
+// ErrorBeforeUse detects potential nil pointer dereference before error check.
+//
+// Go 1.25 fixed a compiler bug (Go 1.21-1.24) where nil checks were incorrectly delayed.
+// Code that worked before may now correctly panic. This rule catches common patterns.
+//
+// Broken pattern:
+//
+//	f, err := os.Open(path)
+//	name := f.Name()  // PANICS if err != nil
+//	if err != nil { ... }
+//
+// Correct pattern:
+//
+//	f, err := os.Open(path)
+//	if err != nil { ... }
+//	name := f.Name()
+//
+// See: https://go.dev/doc/go1.25#compiler (nil check reordering fix)
+func ErrorBeforeUse(m dsl.Matcher) {
+	// os.Open/Create followed by method call before error check
+	m.Match(
+		`$f, $err := os.Open($path); $_ := $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.Create($path); $_ := $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.OpenFile($*_); $_ := $f.$method($*_); if $err != nil { $*_ }`,
+	).
+		Report("potential nil pointer: $f may be nil if $err != nil; check error before using $f.$method()")
+}

--- a/rules/random.go
+++ b/rules/random.go
@@ -1,0 +1,73 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// RandV2Migration detects math/rand usage and suggests migrating to math/rand/v2.
+//
+// Go 1.20 deprecated (global rand is auto-seeded since 1.20):
+//   - rand.Seed() - use rand.New(rand.NewSource(seed)) for reproducibility
+//   - rand.Read() - use crypto/rand.Read() for cryptographic purposes
+//
+// Go 1.22 introduced math/rand/v2 with improved APIs:
+//
+// Method renames:
+//   - rand.Intn(n) → rand.IntN(n)
+//   - rand.Int31() → rand.Int32()
+//   - rand.Int31n(n) → rand.Int32N(n)
+//   - rand.Int63() → rand.Int64()
+//   - rand.Int63n(n) → rand.Int64N(n)
+//
+// New features:
+//   - rand.N[T](max) - generic version for any integer type
+//   - Better random number generation algorithms
+//   - No need to seed (auto-seeded)
+//
+// Note: This rule flags math/rand usage to encourage migration.
+// The v2 API is cleaner and more consistent.
+//
+// See: https://pkg.go.dev/math/rand/v2
+func RandV2Migration(m dsl.Matcher) {
+	// rand.Intn → rand.IntN
+	m.Match(
+		`rand.Intn($n)`,
+	).
+		Report("consider using math/rand/v2: rand.IntN($n) instead of rand.Intn (Go 1.22+)")
+
+	// rand.Int31 → rand.Int32
+	m.Match(
+		`rand.Int31()`,
+	).
+		Report("consider using math/rand/v2: rand.Int32() instead of rand.Int31 (Go 1.22+)")
+
+	// rand.Int31n → rand.Int32N
+	m.Match(
+		`rand.Int31n($n)`,
+	).
+		Report("consider using math/rand/v2: rand.Int32N($n) instead of rand.Int31n (Go 1.22+)")
+
+	// rand.Int63 → rand.Int64
+	m.Match(
+		`rand.Int63()`,
+	).
+		Report("consider using math/rand/v2: rand.Int64() instead of rand.Int63 (Go 1.22+)")
+
+	// rand.Int63n → rand.Int64N
+	m.Match(
+		`rand.Int63n($n)`,
+	).
+		Report("consider using math/rand/v2: rand.Int64N($n) instead of rand.Int63n (Go 1.22+)")
+
+	// rand.Seed is deprecated (Go 1.20+, auto-seeded)
+	m.Match(
+		`rand.Seed($seed)`,
+	).
+		Report("rand.Seed is deprecated (Go 1.20+); global rand is auto-seeded; use rand.New(rand.NewSource($seed)) for reproducibility")
+
+	// rand.Read is deprecated (Go 1.20+)
+	m.Match(
+		`rand.Read($b)`,
+	).
+		Report("rand.Read is deprecated (Go 1.20+); use crypto/rand.Read for cryptographic purposes")
+}

--- a/rules/reflect.go
+++ b/rules/reflect.go
@@ -1,0 +1,293 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// ReflectTypeAssert detects v.Interface().(T) pattern and suggests reflect.TypeAssert.
+//
+// The old pattern (allocates):
+//
+//	val := v.Interface().(string)
+//	val, ok := v.Interface().(string)
+//
+// New pattern (Go 1.25+, no allocation):
+//
+//	val := reflect.TypeAssert[string](v)
+//	val, ok := reflect.TypeAssert[string](v)
+//
+// reflect.TypeAssert converts Value directly to typed value without intermediate
+// allocation via Interface(). This is more efficient for hot paths.
+//
+// See: https://pkg.go.dev/reflect#TypeAssert
+func ReflectTypeAssert(m dsl.Matcher) {
+	// Pattern: Type assertion on Interface() result
+	m.Match(
+		`$v.Interface().($typ)`,
+	).
+		Where(m["v"].Type.Is("reflect.Value")).
+		Report("use reflect.TypeAssert[$typ]($v) instead of $v.Interface().($typ) to avoid allocation (Go 1.25+)")
+}
+
+// ReflectPtrTo detects deprecated reflect.PtrTo and suggests reflect.PointerTo.
+//
+// Deprecated pattern:
+//
+//	ptrType := reflect.PtrTo(t)
+//
+// New pattern (Go 1.22+):
+//
+//	ptrType := reflect.PointerTo(t)
+//
+// reflect.PtrTo was deprecated in Go 1.22 in favor of the clearer name PointerTo.
+//
+// See: https://pkg.go.dev/reflect#PointerTo
+func ReflectPtrTo(m dsl.Matcher) {
+	m.Match(
+		`reflect.PtrTo($t)`,
+	).
+		Report("reflect.PtrTo is deprecated in Go 1.22; use reflect.PointerTo($t) instead").
+		Suggest("reflect.PointerTo($t)")
+}
+
+// ReflectTypeOf detects the common pattern of getting a reflect.Type via TypeOf
+// with a nil pointer and suggests using the cleaner reflect.TypeFor generic.
+//
+// Old pattern:
+//
+//	t := reflect.TypeOf((*MyType)(nil)).Elem()
+//
+// New pattern (Go 1.22+):
+//
+//	t := reflect.TypeFor[MyType]()
+//
+// Benefits:
+//   - More readable and concise
+//   - No need for nil pointer cast trick
+//   - Type is checked at compile time
+//
+// See: https://pkg.go.dev/reflect#TypeFor
+func ReflectTypeOf(m dsl.Matcher) {
+	m.Match(
+		`reflect.TypeOf((*$typ)(nil)).Elem()`,
+	).
+		Report("use reflect.TypeFor[$typ]() instead of reflect.TypeOf((*$typ)(nil)).Elem() (Go 1.22+)")
+}
+
+// DeprecatedReflectHeaders detects deprecated reflect.SliceHeader and
+// reflect.StringHeader usage and suggests using unsafe.Slice/unsafe.String.
+//
+// Deprecated patterns:
+//
+//	sh := (*reflect.SliceHeader)(unsafe.Pointer(&slice))
+//	hdr := (*reflect.StringHeader)(unsafe.Pointer(&str))
+//
+// New patterns (Go 1.21+):
+//
+//	// For creating slices from pointers:
+//	slice := unsafe.Slice(ptr, len)
+//
+//	// For creating strings from pointers:
+//	str := unsafe.String(ptr, len)
+//
+// Benefits:
+//   - Type-safe
+//   - No need for manual header manipulation
+//   - Less error-prone
+//
+// See: https://pkg.go.dev/unsafe#Slice
+// See: https://pkg.go.dev/unsafe#String
+func DeprecatedReflectHeaders(m dsl.Matcher) {
+	m.Match(
+		`reflect.SliceHeader{}`,
+		`reflect.SliceHeader{$*_}`,
+	).
+		Report("reflect.SliceHeader is deprecated in Go 1.21; use unsafe.Slice instead")
+
+	m.Match(
+		`reflect.StringHeader{}`,
+		`reflect.StringHeader{$*_}`,
+	).
+		Report("reflect.StringHeader is deprecated in Go 1.21; use unsafe.String instead")
+
+	// Casting to SliceHeader
+	m.Match(
+		`(*reflect.SliceHeader)($x)`,
+	).
+		Report("reflect.SliceHeader is deprecated in Go 1.21; use unsafe.Slice instead")
+
+	// Casting to StringHeader
+	m.Match(
+		`(*reflect.StringHeader)($x)`,
+	).
+		Report("reflect.StringHeader is deprecated in Go 1.21; use unsafe.String instead")
+}
+
+// ReflectFieldsIterator detects manual index-based iteration over struct fields
+// and suggests using the iterator methods added in Go 1.26.
+//
+// Old pattern:
+//
+//	for i := 0; i < t.NumField(); i++ {
+//	    f := t.Field(i)
+//	    // use f
+//	}
+//
+// New patterns (Go 1.26+):
+//
+//	for f := range t.Fields() {       // reflect.Type
+//	    // use f
+//	}
+//	for sf, v := range val.Fields() { // reflect.Value
+//	    // use sf (StructField) and v (Value)
+//	}
+//
+// Benefits:
+//   - Cleaner, more idiomatic Go iteration
+//   - No off-by-one risk
+//   - Consistent with Go 1.23+ iterator patterns
+//   - Reduces boilerplate
+//
+// See: https://pkg.go.dev/reflect#Type.Fields
+// See: https://pkg.go.dev/reflect#Value.Fields
+func ReflectFieldsIterator(m dsl.Matcher) {
+	// Type.NumField loop
+	m.Match(
+		`for $i := 0; $i < $t.NumField(); $i++ { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Fields() instead of index-based field iteration (Go 1.26+); if the loop index is also used for reflect.Value field access, range over the Value instead")
+
+	// Value.NumField loop
+	m.Match(
+		`for $i := 0; $i < $v.NumField(); $i++ { $*_ }`,
+	).
+		Where(m["v"].Type.Is("reflect.Value")).
+		Report("use range $v.Fields() instead of index-based field iteration (Go 1.26+)")
+
+	// range over NumField integer (Go 1.22+ style)
+	m.Match(
+		`for $i := range $t.NumField() { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Fields() instead of range $t.NumField() (Go 1.26+); if the loop index is also used for reflect.Value field access, range over the Value instead")
+
+	m.Match(
+		`for $i := range $v.NumField() { $*_ }`,
+	).
+		Where(m["v"].Type.Is("reflect.Value")).
+		Report("use range $v.Fields() instead of range $v.NumField() (Go 1.26+)")
+}
+
+// ReflectMethodsIterator detects manual index-based iteration over type methods
+// and suggests using the iterator methods added in Go 1.26.
+//
+// Old pattern:
+//
+//	for i := 0; i < t.NumMethod(); i++ {
+//	    m := t.Method(i)
+//	    // use m
+//	}
+//
+// New patterns (Go 1.26+):
+//
+//	for m := range t.Methods() {       // reflect.Type
+//	    // use m
+//	}
+//	for m, v := range val.Methods() {  // reflect.Value
+//	    // use m (Method) and v (Value)
+//	}
+//
+// Benefits:
+//   - Cleaner, more idiomatic Go iteration
+//   - No off-by-one risk
+//   - Consistent with Go 1.23+ iterator patterns
+//
+// See: https://pkg.go.dev/reflect#Type.Methods
+// See: https://pkg.go.dev/reflect#Value.Methods
+func ReflectMethodsIterator(m dsl.Matcher) {
+	// Type.NumMethod loop
+	m.Match(
+		`for $i := 0; $i < $t.NumMethod(); $i++ { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Methods() instead of index-based method iteration (Go 1.26+)")
+
+	// Value.NumMethod loop
+	m.Match(
+		`for $i := 0; $i < $v.NumMethod(); $i++ { $*_ }`,
+	).
+		Where(m["v"].Type.Is("reflect.Value")).
+		Report("use range $v.Methods() instead of index-based method iteration (Go 1.26+)")
+
+	// range over NumMethod integer
+	m.Match(
+		`for $i := range $t.NumMethod() { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Methods() instead of range $t.NumMethod() (Go 1.26+)")
+
+	m.Match(
+		`for $i := range $v.NumMethod() { $*_ }`,
+	).
+		Where(m["v"].Type.Is("reflect.Value")).
+		Report("use range $v.Methods() instead of range $v.NumMethod() (Go 1.26+)")
+}
+
+// ReflectInsOutsIterator detects manual index-based iteration over function
+// input and output parameters and suggests using the iterators added in Go 1.26.
+//
+// Old patterns:
+//
+//	for i := 0; i < t.NumIn(); i++ {
+//	    param := t.In(i)
+//	    // use param
+//	}
+//	for i := 0; i < t.NumOut(); i++ {
+//	    ret := t.Out(i)
+//	    // use ret
+//	}
+//
+// New patterns (Go 1.26+):
+//
+//	for param := range t.Ins() {
+//	    // use param
+//	}
+//	for ret := range t.Outs() {
+//	    // use ret
+//	}
+//
+// Benefits:
+//   - Cleaner, more idiomatic Go iteration
+//   - Consistent with Fields() and Methods() iterators
+//
+// See: https://pkg.go.dev/reflect#Type.Ins
+// See: https://pkg.go.dev/reflect#Type.Outs
+func ReflectInsOutsIterator(m dsl.Matcher) {
+	// NumIn loop
+	m.Match(
+		`for $i := 0; $i < $t.NumIn(); $i++ { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Ins() instead of index-based input parameter iteration (Go 1.26+)")
+
+	// NumOut loop
+	m.Match(
+		`for $i := 0; $i < $t.NumOut(); $i++ { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Outs() instead of index-based output parameter iteration (Go 1.26+)")
+
+	// range over NumIn/NumOut integer
+	m.Match(
+		`for $i := range $t.NumIn() { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Ins() instead of range $t.NumIn() (Go 1.26+)")
+
+	m.Match(
+		`for $i := range $t.NumOut() { $*_ }`,
+	).
+		Where(m["t"].Type.Is("reflect.Type")).
+		Report("use range $t.Outs() instead of range $t.NumOut() (Go 1.26+)")
+}

--- a/rules/runtime.go
+++ b/rules/runtime.go
@@ -1,0 +1,53 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// SetFinalizerDeprecated detects runtime.SetFinalizer and suggests runtime.AddCleanup.
+//
+// The old pattern:
+//
+//	runtime.SetFinalizer(obj, func(o *Type) { cleanup(o) })
+//
+// New pattern (Go 1.24+):
+//
+//	runtime.AddCleanup(obj, func(arg ArgType) { cleanup(arg) }, arg)
+//
+// Benefits of AddCleanup:
+//   - Multiple cleanups per object
+//   - Can attach to interior pointers
+//   - No cycle leaks (SetFinalizer can leak cycles)
+//   - Doesn't delay object freeing
+//   - Cleaner API with explicit cleanup argument
+//
+// See: https://pkg.go.dev/runtime#AddCleanup
+func SetFinalizerDeprecated(m dsl.Matcher) {
+	m.Match(
+		`runtime.SetFinalizer($obj, $fn)`,
+	).
+		Report("consider using runtime.AddCleanup instead of runtime.SetFinalizer (Go 1.24+): AddCleanup allows multiple cleanups, avoids cycle leaks, and doesn't delay object freeing")
+}
+
+// GorootDeprecated detects runtime.GOROOT() which is deprecated in Go 1.24.
+//
+// The old pattern:
+//
+//	root := runtime.GOROOT()
+//
+// New pattern:
+//
+//	// Use go env GOROOT from command line or exec
+//	cmd := exec.Command("go", "env", "GOROOT")
+//	output, _ := cmd.Output()
+//
+// Reason: runtime.GOROOT() may not reflect the actual GOROOT when the binary
+// is moved or when using toolchains.
+//
+// See: https://go.dev/doc/go1.24#runtime
+func GorootDeprecated(m dsl.Matcher) {
+	m.Match(
+		`runtime.GOROOT()`,
+	).
+		Report("runtime.GOROOT() is deprecated in Go 1.24; use 'go env GOROOT' instead")
+}

--- a/rules/slices.go
+++ b/rules/slices.go
@@ -1,0 +1,280 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// SortInts detects sort.Ints/sort.Strings/sort.Float64s and suggests slices.Sort.
+//
+// Old patterns:
+//
+//	sort.Ints(nums)
+//	sort.Strings(strs)
+//	sort.Float64s(floats)
+//
+// New pattern (Go 1.21+):
+//
+//	slices.Sort(nums)
+//	slices.Sort(strs)
+//	slices.Sort(floats)
+//
+// Benefits:
+//   - Generic, works with any ordered slice
+//   - Consistent API across types
+//   - Part of the new slices package
+//
+// See: https://pkg.go.dev/slices#Sort
+func SortInts(m dsl.Matcher) {
+	m.Match(
+		`sort.Ints($s)`,
+	).
+		Report("use slices.Sort($s) instead of sort.Ints (Go 1.21+)").
+		Suggest("slices.Sort($s)")
+
+	m.Match(
+		`sort.Strings($s)`,
+	).
+		Report("use slices.Sort($s) instead of sort.Strings (Go 1.21+)").
+		Suggest("slices.Sort($s)")
+
+	m.Match(
+		`sort.Float64s($s)`,
+	).
+		Report("use slices.Sort($s) instead of sort.Float64s (Go 1.21+)").
+		Suggest("slices.Sort($s)")
+
+	// sort.IntsAreSorted, etc.
+	m.Match(
+		`sort.IntsAreSorted($s)`,
+	).
+		Report("use slices.IsSorted($s) instead of sort.IntsAreSorted (Go 1.21+)").
+		Suggest("slices.IsSorted($s)")
+
+	m.Match(
+		`sort.StringsAreSorted($s)`,
+	).
+		Report("use slices.IsSorted($s) instead of sort.StringsAreSorted (Go 1.21+)").
+		Suggest("slices.IsSorted($s)")
+
+	m.Match(
+		`sort.Float64sAreSorted($s)`,
+	).
+		Report("use slices.IsSorted($s) instead of sort.Float64sAreSorted (Go 1.21+)").
+		Suggest("slices.IsSorted($s)")
+}
+
+// BytesClone detects manual byte slice cloning and suggests bytes.Clone.
+//
+// Old patterns:
+//
+//	clone := make([]byte, len(original))
+//	copy(clone, original)
+//
+//	clone := append([]byte(nil), original...)
+//	clone := append([]byte{}, original...)
+//
+// New pattern (Go 1.20+):
+//
+//	clone := bytes.Clone(original)
+//
+// Benefits:
+//   - More readable
+//   - Less error-prone
+//   - Single function call
+//
+// See: https://pkg.go.dev/bytes#Clone
+func BytesClone(m dsl.Matcher) {
+	// Pattern: append([]byte(nil), b...)
+	m.Match(
+		`append([]byte(nil), $b...)`,
+	).
+		Report("use bytes.Clone($b) instead of append([]byte(nil), $b...) (Go 1.20+)")
+
+	// Pattern: append([]byte{}, b...)
+	m.Match(
+		`append([]byte{}, $b...)`,
+	).
+		Report("use bytes.Clone($b) instead of append([]byte{}, $b...) (Go 1.20+)")
+
+	// Pattern: append(b[:0:0], b...)
+	m.Match(
+		`append($b[:0:0], $b...)`,
+	).
+		Where(m["b"].Type.Is("[]byte")).
+		Report("use bytes.Clone($b) instead of append($b[:0:0], $b...) (Go 1.20+)")
+}
+
+// SlicesClone detects manual slice cloning patterns and suggests slices.Clone.
+//
+// Old patterns:
+//
+//	clone := make([]T, len(original))
+//	copy(clone, original)
+//
+//	clone := append([]T(nil), original...)
+//
+// New pattern (Go 1.21+):
+//
+//	clone := slices.Clone(original)
+//
+// Benefits:
+//   - More readable
+//   - Less error-prone
+//   - Single function call
+//
+// See: https://pkg.go.dev/slices#Clone
+func SlicesClone(m dsl.Matcher) {
+	// Pattern: append([]T(nil), s...)
+	// This is a common idiom for cloning slices
+	// Note: Exclude []byte to avoid duplicate warnings with BytesClone rule
+	m.Match(
+		`append([]$typ(nil), $s...)`,
+	).
+		Where(m["typ"].Text != "byte").
+		Report("use slices.Clone($s) instead of append([]$typ(nil), $s...) (Go 1.21+)")
+
+	m.Match(
+		`append([]$typ{}, $s...)`,
+	).
+		Where(m["typ"].Text != "byte").
+		Report("use slices.Clone($s) instead of append([]$typ{}, $s...) (Go 1.21+)")
+
+	// append(s[:0:0], s...) pattern
+	// Exclude []byte slices - those are handled by BytesClone
+	m.Match(
+		`append($s[:0:0], $s...)`,
+	).
+		Where(!m["s"].Type.Is("[]byte")).
+		Report("use slices.Clone($s) instead of append($s[:0:0], $s...) (Go 1.21+)")
+}
+
+// BackwardIteration detects manual reverse iteration patterns and suggests slices.Backward.
+//
+// Old pattern:
+//
+//	for i := len(s) - 1; i >= 0; i-- {
+//	    process(s[i])
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	for i, v := range slices.Backward(s) {
+//	    process(v)
+//	}
+//
+// Benefits:
+//   - Clearer intent
+//   - Less error-prone (off-by-one errors)
+//   - Works with iterator composition
+//
+// See: https://pkg.go.dev/slices#Backward
+func BackwardIteration(m dsl.Matcher) {
+	// Pattern: for i := len(s) - 1; i >= 0; i--
+	m.Match(
+		`for $i := len($s) - 1; $i >= 0; $i-- { $*body }`,
+	).
+		Report("use slices.Backward($s) for reverse iteration (Go 1.23+)")
+
+	// Pattern: for i := len(s) - 1; i > -1; i--
+	m.Match(
+		`for $i := len($s) - 1; $i > -1; $i-- { $*body }`,
+	).
+		Report("use slices.Backward($s) for reverse iteration (Go 1.23+)")
+}
+
+// MapKeysCollection detects manual map key collection patterns and suggests maps.Keys.
+//
+// Old pattern:
+//
+//	keys := make([]string, 0, len(m))
+//	for k := range m {
+//	    keys = append(keys, k)
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	keys := slices.Collect(maps.Keys(m))
+//
+// Benefits:
+//   - More concise and readable
+//   - Works with iterator composition
+//   - Can be sorted directly: slices.Sorted(maps.Keys(m))
+//
+// See: https://pkg.go.dev/maps#Keys
+// See: https://pkg.go.dev/slices#Collect
+func MapKeysCollection(m dsl.Matcher) {
+	// Pattern: for k := range m { keys = append(keys, k) }
+	// This is a common pattern for collecting map keys
+	// Type guard ensures we only match maps, not channels or iterators
+	m.Match(
+		`for $k := range $m { $keys = append($keys, $k) }`,
+	).
+		Where(m["m"].Type.Is("map[$k]$v")).
+		Report("use slices.Collect(maps.Keys($m)) to collect map keys (Go 1.23+)")
+
+	// Pattern with underscore for value: for k, _ := range m
+	m.Match(
+		`for $k, _ := range $m { $keys = append($keys, $k) }`,
+	).
+		Where(m["m"].Type.Is("map[$k]$v")).
+		Report("use slices.Collect(maps.Keys($m)) to collect map keys (Go 1.23+)")
+}
+
+// MapValuesCollection detects manual map value collection patterns and suggests maps.Values.
+//
+// Old pattern:
+//
+//	values := make([]V, 0, len(m))
+//	for _, v := range m {
+//	    values = append(values, v)
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	values := slices.Collect(maps.Values(m))
+//
+// See: https://pkg.go.dev/maps#Values
+// See: https://pkg.go.dev/slices#Collect
+func MapValuesCollection(m dsl.Matcher) {
+	// Pattern: for _, v := range m { values = append(values, v) }
+	// Type guard ensures we only match maps, not slices or other iterables
+	m.Match(
+		`for _, $v := range $m { $values = append($values, $v) }`,
+	).
+		Where(m["m"].Type.Is("map[$k]$v")).
+		Report("use slices.Collect(maps.Values($m)) to collect map values (Go 1.23+)")
+}
+
+// SliceRepeat detects manual slice repetition patterns and suggests slices.Repeat.
+//
+// Old pattern:
+//
+//	result := make([]T, 0, len(s)*n)
+//	for i := 0; i < n; i++ {
+//	    result = append(result, s...)
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	result := slices.Repeat(s, n)
+//
+// See: https://pkg.go.dev/slices#Repeat
+func SliceRepeat(m dsl.Matcher) {
+	// Pattern: for loop appending same slice multiple times
+	m.Match(
+		`for $i := 0; $i < $n; $i++ { $result = append($result, $s...) }`,
+	).
+		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+); false positive if $s depends on the loop variable")
+
+	// Pattern: range-over-integer form (with variable)
+	m.Match(
+		`for $i := range $n { $result = append($result, $s...) }`,
+	).
+		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+); false positive if $s depends on the loop variable")
+
+	// Pattern: range-over-integer form (without variable)
+	m.Match(
+		`for range $n { $result = append($result, $s...) }`,
+	).
+		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+)")
+}

--- a/rules/strings.go
+++ b/rules/strings.go
@@ -1,0 +1,151 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// StringsLinesIteration detects manual line splitting patterns and suggests strings.Lines.
+//
+// Old pattern:
+//
+//	for _, line := range strings.Split(s, "\n") {
+//	    process(line)
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	for line := range strings.Lines(s) {
+//	    process(line)
+//	}
+//
+// Benefits:
+//   - No intermediate slice allocation
+//   - Handles both \n and \r\n line endings
+//   - More memory efficient for large strings
+//
+// See: https://pkg.go.dev/strings#Lines
+// See: https://pkg.go.dev/bytes#Lines
+func StringsLinesIteration(m dsl.Matcher) {
+	// Pattern: for _, line := range strings.Split(s, "\n")
+	m.Match(
+		`for $_, $line := range strings.Split($s, "\n") { $*body }`,
+	).
+		Report(`use for $line := range strings.Lines($s) instead of ranging over strings.Split($s, "\n") (Go 1.23+); note: Lines() handles both \n and \r\n`)
+
+	// Pattern: for _, line := range strings.Split(s, "\r\n")
+	m.Match(
+		`for $_, $line := range strings.Split($s, "\r\n") { $*body }`,
+	).
+		Report(`use for $line := range strings.Lines($s) instead of ranging over strings.Split($s, "\r\n") (Go 1.23+)`)
+
+	// Also detect bytes.Split for line iteration
+	m.Match(
+		`for $_, $line := range bytes.Split($s, []byte("\n")) { $*body }`,
+	).
+		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split($s, []byte("\n")) (Go 1.23+)`)
+
+	m.Match(
+		`for $_, $line := range bytes.Split($s, []byte{'\n'}) { $*body }`,
+	).
+		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split (Go 1.23+)`)
+}
+
+// StringsSplitIteration detects strings.Split used only for iteration
+// and suggests strings.SplitSeq for better memory efficiency.
+//
+// Old pattern:
+//
+//	for _, part := range strings.Split(s, ",") {
+//	    process(part)
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	for part := range strings.SplitSeq(s, ",") {
+//	    process(part)
+//	}
+//
+// Benefits:
+//   - No intermediate slice allocation
+//   - Better for large strings with many parts
+//   - Works with iterator composition
+//
+// Note: Only use SplitSeq when you're just iterating. If you need the slice
+// result (e.g., to access by index or get length), keep using Split.
+//
+// See: https://pkg.go.dev/strings#SplitSeq
+// See: https://pkg.go.dev/bytes#SplitSeq
+func StringsSplitIteration(m dsl.Matcher) {
+	// Pattern: for _, part := range strings.Split(s, sep)
+	// Excluding newline separators which should use Lines() instead
+	m.Match(
+		`for $_, $part := range strings.Split($s, $sep) { $*body }`,
+	).
+		Where(!m["sep"].Text.Matches(`^"\\n"$`) && !m["sep"].Text.Matches(`^"\\r\\n"$`)).
+		Report("use for $part := range strings.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.23+)")
+
+	// bytes.Split pattern
+	m.Match(
+		`for $_, $part := range bytes.Split($s, $sep) { $*body }`,
+	).
+		Where(!m["sep"].Text.Matches(`\[\]byte\("\\n"\)`) && !m["sep"].Text.Matches(`\[\]byte\{.*\\n.*\}`)).
+		Report("use for $part := range bytes.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.23+)")
+}
+
+// StringsFieldsIteration detects strings.Fields used only for iteration
+// and suggests strings.FieldsSeq.
+//
+// Old pattern:
+//
+//	for _, field := range strings.Fields(s) {
+//	    process(field)
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	for field := range strings.FieldsSeq(s) {
+//	    process(field)
+//	}
+//
+// See: https://pkg.go.dev/strings#FieldsSeq
+// See: https://pkg.go.dev/bytes#FieldsSeq
+func StringsFieldsIteration(m dsl.Matcher) {
+	m.Match(
+		`for $_, $field := range strings.Fields($s) { $*body }`,
+	).
+		Report("use for $field := range strings.FieldsSeq($s) to avoid intermediate slice allocation (Go 1.23+)")
+
+	m.Match(
+		`for $_, $field := range bytes.Fields($s) { $*body }`,
+	).
+		Report("use for $field := range bytes.FieldsSeq($s) to avoid intermediate slice allocation (Go 1.23+)")
+}
+
+// StringsFieldsFuncIteration detects strings.FieldsFunc used only for iteration
+// and suggests strings.FieldsFuncSeq.
+//
+// Old pattern:
+//
+//	for _, field := range strings.FieldsFunc(s, f) {
+//	    process(field)
+//	}
+//
+// New pattern (Go 1.23+):
+//
+//	for field := range strings.FieldsFuncSeq(s, f) {
+//	    process(field)
+//	}
+//
+// See: https://pkg.go.dev/strings#FieldsFuncSeq
+// See: https://pkg.go.dev/bytes#FieldsFuncSeq
+func StringsFieldsFuncIteration(m dsl.Matcher) {
+	m.Match(
+		`for $_, $field := range strings.FieldsFunc($s, $f) { $*body }`,
+	).
+		Report("use for $field := range strings.FieldsFuncSeq($s, $f) to avoid intermediate slice allocation (Go 1.23+)")
+
+	m.Match(
+		`for $_, $field := range bytes.FieldsFunc($s, $f) { $*body }`,
+	).
+		Report("use for $field := range bytes.FieldsFuncSeq($s, $f) to avoid intermediate slice allocation (Go 1.23+)")
+}

--- a/rules/sync.go
+++ b/rules/sync.go
@@ -1,0 +1,55 @@
+//go:build ruleguard
+
+// Package gorules defines custom linter rules for Go modernization.
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// WaitGroupGo detects the old sync.WaitGroup pattern and suggests using Go 1.25's wg.Go().
+//
+// The old pattern:
+//
+//	wg.Add(1)
+//	go func() {
+//	    defer wg.Done()
+//	    doSomething()
+//	}()
+//
+// Can be simplified to:
+//
+//	wg.Go(func() {
+//	    doSomething()
+//	})
+//
+// Benefits:
+//   - Cleaner, less error-prone (no Add/Done mismatch)
+//   - Single function call
+//   - Automatic panic handling
+//
+// See: https://pkg.go.dev/sync#WaitGroup.Go
+func WaitGroupGo(m dsl.Matcher) {
+	// Pattern 1: wg.Add(1) followed by go func() with defer wg.Done()
+	// This matches when the defer is the first statement
+	m.Match(
+		`$wg.Add(1); go func() { defer $wg.Done(); $*body }()`,
+	).
+		Where(m["wg"].Type.Is("*sync.WaitGroup") || m["wg"].Type.Is("sync.WaitGroup")).
+		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)").
+		Suggest("$wg.Go(func() { $body })")
+
+	// Pattern 2: Same but with pointer receiver explicitly
+	m.Match(
+		`$wg.Add(1); go func() { defer $wg.Done(); $*body }()`,
+	).
+		Where(m["wg"].Type.Underlying().Is("sync.WaitGroup")).
+		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)").
+		Suggest("$wg.Go(func() { $body })")
+
+	// Pattern 3: When wg is passed by reference to the closure
+	m.Match(
+		`$wg.Add(1); go func($param $typ) { defer $param.Done(); $*body }($wg)`,
+		`$wg.Add(1); go func($param $typ) { defer $param.Done(); $*body }(&$wg)`,
+	).
+		Where(m["wg"].Type.Is("*sync.WaitGroup") || m["wg"].Type.Is("sync.WaitGroup")).
+		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)")
+}

--- a/rules/testing.go
+++ b/rules/testing.go
@@ -1,0 +1,152 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// BenchmarkLoop detects the old benchmark iteration pattern and suggests using b.Loop().
+//
+// The old pattern:
+//
+//	func BenchmarkFoo(b *testing.B) {
+//	    for i := 0; i < b.N; i++ {
+//	        // work
+//	    }
+//	}
+//
+// New pattern (Go 1.24+):
+//
+//	func BenchmarkFoo(b *testing.B) {
+//	    for b.Loop() {
+//	        // work
+//	    }
+//	}
+//
+// Benefits:
+//   - Setup/cleanup executes only once per -count
+//   - Compiler cannot optimize away the loop body
+//   - Cleaner, more idiomatic code
+//
+// See: https://pkg.go.dev/testing#B.Loop
+func BenchmarkLoop(m dsl.Matcher) {
+	// Pattern 1: for i := 0; i < b.N; i++
+	// No auto-fix: loop variable $i may be used in body
+	m.Match(
+		`for $i := 0; $i < $b.N; $i++ { $*body }`,
+	).
+		Where(m["b"].Type.Is("*testing.B")).
+		Report("use for $b.Loop() { ... } instead of for $i := 0; $i < $b.N; $i++ (Go 1.24+); if using $i in body, declare it separately")
+
+	// Pattern 2: for i := range b.N (Go 1.22+ style)
+	// No auto-fix: loop variable $i may be used in body
+	m.Match(
+		`for $i := range $b.N { $*body }`,
+	).
+		Where(m["b"].Type.Is("*testing.B")).
+		Report("use for $b.Loop() { ... } instead of for $i := range $b.N (Go 1.24+); if using $i in body, declare it separately")
+
+	// Pattern 3: for range b.N (no variable) - safe for auto-fix
+	m.Match(
+		`for range $b.N { $*body }`,
+	).
+		Where(m["b"].Type.Is("*testing.B")).
+		Report("use for $b.Loop() { ... } instead of for range $b.N (Go 1.24+)").
+		Suggest("for $b.Loop() { $body }")
+}
+
+// TestingContext detects context.Background() or context.TODO() in test functions
+// and suggests using t.Context() instead.
+//
+// The old pattern:
+//
+//	func TestFoo(t *testing.T) {
+//	    ctx := context.Background()
+//	    result, err := doSomething(ctx)
+//	}
+//
+// New pattern (Go 1.24+):
+//
+//	func TestFoo(t *testing.T) {
+//	    ctx := t.Context()
+//	    result, err := doSomething(ctx)
+//	}
+//
+// Benefits:
+//   - Context is automatically canceled when test completes
+//   - Test cleanup is properly signaled to goroutines
+//   - Resources are released promptly on test failure
+//
+// See: https://pkg.go.dev/testing#T.Context
+// See: https://pkg.go.dev/testing#B.Context
+func TestingContext(m dsl.Matcher) {
+	// Pattern 1: Assigning context.Background() to a variable
+	m.Match(
+		`$ctx := context.Background()`,
+		`$ctx = context.Background()`,
+	).
+		Where(m.File().Name.Matches(`_test\.go$`)).
+		Report("in tests, use t.Context() instead of context.Background() for automatic cancellation on test completion (Go 1.24+)")
+
+	// Pattern 2: Assigning context.TODO() to a variable
+	m.Match(
+		`$ctx := context.TODO()`,
+		`$ctx = context.TODO()`,
+	).
+		Where(m.File().Name.Matches(`_test\.go$`)).
+		Report("in tests, use t.Context() instead of context.TODO() for automatic cancellation on test completion (Go 1.24+)")
+
+	// Pattern 3: Passing context.Background() directly to a function
+	m.Match(
+		`$fn(context.Background(), $*args)`,
+	).
+		Where(m.File().Name.Matches(`_test\.go$`)).
+		Report("in tests, use t.Context() instead of context.Background() (Go 1.24+)")
+
+	// Pattern 4: Passing context.TODO() directly to a function
+	m.Match(
+		`$fn(context.TODO(), $*args)`,
+	).
+		Where(m.File().Name.Matches(`_test\.go$`)).
+		Report("in tests, use t.Context() instead of context.TODO() (Go 1.24+)")
+}
+
+// TestingArtifactDir detects os.MkdirTemp in test files and suggests using
+// the testing.T.ArtifactDir method added in Go 1.26.
+//
+// Old pattern:
+//
+//	func TestFoo(t *testing.T) {
+//	    dir, err := os.MkdirTemp("", "test-output-*")
+//	    if err != nil { t.Fatal(err) }
+//	    defer os.RemoveAll(dir)
+//	    // write test artifacts to dir
+//	}
+//
+// New pattern (Go 1.26+):
+//
+//	func TestFoo(t *testing.T) {
+//	    dir := t.ArtifactDir()
+//	    // write test artifacts to dir
+//	    // directory persists after test for inspection
+//	}
+//
+// Benefits:
+//   - No error handling needed
+//   - Automatically named after the test
+//   - Survives test cleanup (unlike t.TempDir)
+//   - Location reported with -artifacts flag
+//   - Consistent output location across test runs
+//
+// Note: ArtifactDir is for test output files (golden files, debug output,
+// snapshots), not for temporary scratch space. If you need a directory that
+// is cleaned up after the test, continue using t.TempDir().
+//
+// See: https://pkg.go.dev/testing#T.ArtifactDir
+func TestingArtifactDir(m dsl.Matcher) {
+	// os.MkdirTemp in test files - advisory suggestion
+	m.Match(
+		`os.MkdirTemp($dir, $pattern)`,
+	).
+		Where(m.File().Name.Matches(`_test\.go$`)).
+		Report("in tests, consider t.ArtifactDir() for test output files instead of os.MkdirTemp (Go 1.26+); use t.TempDir() for scratch space that should be cleaned up")
+}

--- a/rules/time.go
+++ b/rules/time.go
@@ -1,0 +1,208 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// TimeDateTimeConstants detects magic date/time format strings and suggests
+// using the named constants added in Go 1.20.
+//
+// Old pattern:
+//
+//	t.Format("2006-01-02 15:04:05")
+//	t.Format("2006-01-02")
+//	t.Format("15:04:05")
+//
+// New pattern (Go 1.20+):
+//
+//	t.Format(time.DateTime)
+//	t.Format(time.DateOnly)
+//	t.Format(time.TimeOnly)
+//
+// Benefits:
+//   - More readable and self-documenting
+//   - No need to memorize Go's reference time format
+//   - Less error-prone
+//
+// See: https://pkg.go.dev/time#pkg-constants (DateTime, DateOnly, TimeOnly)
+func TimeDateTimeConstants(m dsl.Matcher) {
+	// DateTime: "2006-01-02 15:04:05"
+	m.Match(
+		`$t.Format("2006-01-02 15:04:05")`,
+	).
+		Report(`use $t.Format(time.DateTime) instead of magic format string (Go 1.20+)`).
+		Suggest(`$t.Format(time.DateTime)`)
+
+	m.Match(
+		`time.Parse("2006-01-02 15:04:05", $s)`,
+	).
+		Report(`use time.Parse(time.DateTime, $s) instead of magic format string (Go 1.20+)`).
+		Suggest(`time.Parse(time.DateTime, $s)`)
+
+	// DateOnly: "2006-01-02"
+	m.Match(
+		`$t.Format("2006-01-02")`,
+	).
+		Report(`use $t.Format(time.DateOnly) instead of magic format string (Go 1.20+)`).
+		Suggest(`$t.Format(time.DateOnly)`)
+
+	m.Match(
+		`time.Parse("2006-01-02", $s)`,
+	).
+		Report(`use time.Parse(time.DateOnly, $s) instead of magic format string (Go 1.20+)`).
+		Suggest(`time.Parse(time.DateOnly, $s)`)
+
+	// TimeOnly: "15:04:05"
+	m.Match(
+		`$t.Format("15:04:05")`,
+	).
+		Report(`use $t.Format(time.TimeOnly) instead of magic format string (Go 1.20+)`).
+		Suggest(`$t.Format(time.TimeOnly)`)
+
+	m.Match(
+		`time.Parse("15:04:05", $s)`,
+	).
+		Report(`use time.Parse(time.TimeOnly, $s) instead of magic format string (Go 1.20+)`).
+		Suggest(`time.Parse(time.TimeOnly, $s)`)
+}
+
+// TimerChannelLen detects len() or cap() checks on timer/ticker channels.
+//
+// In Go 1.23+, timer and ticker channels are unbuffered (capacity 0),
+// so checking len() or cap() always returns 0 and is likely a bug.
+//
+// Problematic pattern:
+//
+//	timer := time.NewTimer(1 * time.Second)
+//	if len(timer.C) > 0 {  // Always false in Go 1.23+
+//	    <-timer.C
+//	}
+//
+// Correct pattern (Go 1.23+):
+//
+//	timer := time.NewTimer(1 * time.Second)
+//	select {
+//	case <-timer.C:
+//	    // timer fired
+//	default:
+//	    // timer not yet fired
+//	}
+//
+// Background: Before Go 1.23, timer channels had capacity 1. Code that
+// checked len(timer.C) to avoid blocking reads is now broken.
+//
+// See: https://go.dev/doc/go1.23#timer-changes
+// See: https://pkg.go.dev/time#Timer
+func TimerChannelLen(m dsl.Matcher) {
+	// len() on timer.C
+	m.Match(
+		`len($timer.C)`,
+	).
+		Where(m["timer"].Type.Is("*time.Timer")).
+		Report("len() on timer channel is always 0 in Go 1.23+ (channels are now unbuffered); use non-blocking select instead")
+
+	// len() on ticker.C
+	m.Match(
+		`len($ticker.C)`,
+	).
+		Where(m["ticker"].Type.Is("*time.Ticker")).
+		Report("len() on ticker channel is always 0 in Go 1.23+ (channels are now unbuffered); use non-blocking select instead")
+
+	// cap() on timer.C
+	m.Match(
+		`cap($timer.C)`,
+	).
+		Where(m["timer"].Type.Is("*time.Timer")).
+		Report("cap() on timer channel is always 0 in Go 1.23+ (channels are now unbuffered)")
+
+	// cap() on ticker.C
+	m.Match(
+		`cap($ticker.C)`,
+	).
+		Where(m["ticker"].Type.Is("*time.Ticker")).
+		Report("cap() on ticker channel is always 0 in Go 1.23+ (channels are now unbuffered)")
+}
+
+// DeferredTimeSince detects deferred calls to time.Since which evaluate
+// the duration at defer time, not at function exit.
+//
+// Broken pattern:
+//
+//	func foo() {
+//	    start := time.Now()
+//	    defer log.Println(time.Since(start))  // Evaluated NOW, not at exit!
+//	    // ... work ...
+//	}
+//
+// The time.Since(start) is called immediately when defer is executed,
+// so it will always report ~0 duration.
+//
+// Correct pattern:
+//
+//	func foo() {
+//	    start := time.Now()
+//	    defer func() { log.Println(time.Since(start)) }()
+//	    // ... work ...
+//	}
+//
+// See: https://pkg.go.dev/time#Since
+// Note: Go 1.22 vet tool also warns about this pattern.
+func DeferredTimeSince(m dsl.Matcher) {
+	// Pattern: defer with time.Since as argument
+	m.Match(
+		`defer $fn(time.Since($start))`,
+	).
+		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
+
+	// Pattern: defer with time.Since as argument (multiple args)
+	m.Match(
+		`defer $fn(time.Since($start), $*args)`,
+	).
+		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
+
+	m.Match(
+		`defer $fn($arg, time.Since($start))`,
+	).
+		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
+
+	m.Match(
+		`defer $fn($arg1, $arg2, time.Since($start))`,
+	).
+		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
+
+	// time.Since as second argument with trailing args
+	m.Match(
+		`defer $fn($arg, time.Since($start), $*args)`,
+	).
+		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
+
+	// time.Since as fourth argument (3 preceding args)
+	m.Match(
+		`defer $fn($arg1, $arg2, $arg3, time.Since($start))`,
+	).
+		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
+}
+
+// DeferredTimeNow detects deferred calls to time.Now which evaluate
+// the time at defer time, not at function exit.
+//
+// Broken pattern:
+//
+//	defer log.Println("finished at", time.Now())  // Evaluated NOW!
+//
+// Correct pattern:
+//
+//	defer func() { log.Println("finished at", time.Now()) }()
+//
+// See: https://pkg.go.dev/time#Now
+func DeferredTimeNow(m dsl.Matcher) {
+	m.Match(
+		`defer $fn(time.Now())`,
+	).
+		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
+
+	m.Match(
+		`defer $fn($*args, time.Now())`,
+	).
+		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
+}


### PR DESCRIPTION
## Summary

This implements agy-mcp, an MCP server that wraps the Antigravity CLI (`agy`) so any MCP client (Claude Code, Cursor, Cline, and others) can run `agy` prompts and peer reviews as native, typed tools instead of hand-built shell commands. The headline use is cross-model peer review, but the surface is general: run any `agy` prompt and retrieve the result.

## Architecture

A transport-agnostic `manager` core (imports nothing from the MCP SDK) plus a thin MCP layer (modelcontextprotocol/go-sdk v1.6.1):

- `agy` runs as detached async jobs via a supervisor subprocess (`agy-mcp run-job`), with stdin from `/dev/null` (eliminating agy's stdin-blocking footgun), output captured to per-job files, and an exit-code sentinel written by the supervisor so jobs survive a manager restart.
- The supervisor enforces a hard timeout (SIGTERM then SIGKILL after a grace window) so a hung `agy` can never block forever.
- Reboot-robust liveness (boot id plus `/proc` comm), supervisor-mediated cancel, per-conversation/cwd serialization with a global concurrency cap, and startup GC that never deletes a still-running job (including one that survived a restart).
- stdio is the default transport; Streamable HTTP is opt-in (`-http 127.0.0.1:8765`, unauthenticated, localhost only).
- Session continuation rides agy's own SQLite store via `--conversation <uuid>`; `continue_latest` resolves to a concrete id before the run.

## Tools

`agy_run`, `agy_status`, `agy_cancel`, `list_models`, `list_sessions`.

## Tests and quality

- Built test-first; full unit coverage with a fake-agy and fake-supervisor (no real agy invoked in CI), plus end-to-end run-job and cancel-via-signal subprocess tests.
- `go build`, `go vet`, and `go test ./... -race` all pass; golangci-lint (v2.11.4, with ruleguard rules) reports 0 issues.
- CI runs build, vet, race tests, and lint.

## Known follow-ups

- A fresh `agy_run` returns an empty `conversation_id` for now; the snapshot-diff UUID capture is staged pending a one-off probe against the real `agy`. `continue_latest` covers the continuation workflow today.
- HTTP mode hardening (Origin/CSRF checks, optional bearer token) is deferred; the SDK gives DNS-rebinding protection by default and the mode is opt-in and localhost only.
- Rebuilding the concurrency gate from on-disk jobs after a manager restart.

## Test plan

- [ ] CI green (build, vet, race tests, lint)
- [ ] One manual end-to-end run against the real `agy` before tagging a release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Model Context Protocol (MCP) server supporting stdio and HTTP transports for integration with Claude Code and other MCP clients.
  * Implemented job management functionality including async execution, status tracking, and cancellation of agy tasks.
  * Added model and session discovery capabilities.

* **Documentation**
  * Updated README with installation instructions, setup guides, available tools, and configuration options.

* **Chores**
  * Added GitHub Actions CI workflow for automated testing and linting.
  * Configured golangci-lint for code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->