### PR TITLE
Serialize same-cwd fresh runs, capture conversation ids, restore the gate on restart (#2, #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Or add to your MCP client config:
 - `list_models()` -> `{ models }`
 - `list_sessions(dir?)` -> `{ sessions }`
 
+A fresh `agy_run` (no `conversation_id`, no `continue_latest`) starts with an empty
+`conversation_id`; agy assigns one as the run proceeds, and `agy_status` reports it once the
+run completes, so the thread can be continued later. To keep that capture unambiguous, fresh
+runs sharing a `cwd` are serialized: while one fresh run is active, a second fresh run in the
+same directory is refused (`agy_run` returns a conflict error rather than queuing it), so run
+them in separate directories or retry once the first finishes. Runs in different directories,
+and runs continuing distinct conversations, still run concurrently up to the configured cap.
+The gate that enforces this is rebuilt at startup from jobs whose supervisor outlived a server
+restart, so the cap and serialization hold across restarts.
+
 ## HTTP mode
 
 ```bash

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -123,6 +123,26 @@ func (s *Store) UpdateMeta(m Meta) error {
 	return nil
 }
 
+// SetConversationID persists convID as the job's conversation id, but only when
+// it is currently unset: it reloads the latest meta and rewrites just that field,
+// so it cannot clobber a concurrent meta update, and a second caller that races to
+// capture the same job is a no-op. It returns the effective conversation id (the
+// existing one if already set, otherwise convID).
+func (s *Store) SetConversationID(id, convID string) (string, error) {
+	m, err := s.Load(id)
+	if err != nil {
+		return "", err
+	}
+	if m.ConversationID != "" {
+		return m.ConversationID, nil
+	}
+	m.ConversationID = convID
+	if err := s.UpdateMeta(m); err != nil {
+		return "", err
+	}
+	return convID, nil
+}
+
 // Remove deletes a job's directory and everything in it.
 func (s *Store) Remove(id string) error {
 	if !validJobID(id) {

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -44,7 +45,10 @@ const (
 var ErrInvalidID = errors.New("invalid job id")
 
 // Store is a directory-backed collection of jobs.
-type Store struct{ root string }
+type Store struct {
+	root string
+	mu   sync.Mutex // serializes SetConversationID's read-modify-write
+}
 
 // New returns a Store rooted at dir/jobs.
 func New(dir string) *Store { return &Store{root: filepath.Join(dir, "jobs")} }
@@ -100,9 +104,10 @@ func (s *Store) Load(id string) (Meta, error) {
 	return m, nil
 }
 
-// UpdateMeta atomically rewrites a job's meta.json by writing a temp file and
-// renaming it into place, so a concurrent reader (such as the freshly spawned
-// supervisor) never observes a partially written file.
+// UpdateMeta atomically rewrites a job's meta.json by writing a uniquely-named
+// temp file and renaming it into place, so a concurrent reader (such as the
+// freshly spawned supervisor) never observes a partially written file, and two
+// concurrent writers never corrupt a shared temp file.
 func (s *Store) UpdateMeta(m Meta) error {
 	if !validJobID(m.ID) {
 		return ErrInvalidID
@@ -112,12 +117,26 @@ func (s *Store) UpdateMeta(m Meta) error {
 	if err != nil {
 		return err
 	}
-	tmp := filepath.Join(dir, "meta.json.tmp")
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	tmp, err := os.CreateTemp(dir, "meta-*.json.tmp")
+	if err != nil {
 		return err
 	}
-	if err := os.Rename(tmp, filepath.Join(dir, "meta.json")); err != nil {
-		_ = os.Remove(tmp)
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, filepath.Join(dir, "meta.json")); err != nil {
+		_ = os.Remove(tmpName)
 		return err
 	}
 	return nil
@@ -129,6 +148,10 @@ func (s *Store) UpdateMeta(m Meta) error {
 // capture the same job is a no-op. It returns the effective conversation id (the
 // existing one if already set, otherwise convID).
 func (s *Store) SetConversationID(id, convID string) (string, error) {
+	// Serialize the read-modify-write so two callers racing to capture the same
+	// job cannot both observe an empty id and have the later write win (TOCTOU).
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	m, err := s.Load(id)
 	if err != nil {
 		return "", err

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -112,7 +112,10 @@ func TestSetConversationID(t *testing.T) {
 	if got != first {
 		t.Fatalf("second set returned %q, want existing %q", got, first)
 	}
-	reloaded, _ = s.Load("j")
+	reloaded, err = s.Load("j")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if reloaded.ConversationID != first {
 		t.Fatalf("existing id was overwritten: %q", reloaded.ConversationID)
 	}

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -80,6 +80,44 @@ func TestUpdateMetaRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSetConversationID(t *testing.T) {
+	const first = "conv-1"
+	s := New(t.TempDir())
+	if _, err := s.Create(Meta{ID: "j", PID: 4242, AgyPath: "/usr/bin/agy"}); err != nil {
+		t.Fatal(err)
+	}
+	// Set on an unset job: persists the id and returns it, preserving other fields.
+	got, err := s.SetConversationID("j", first)
+	if err != nil {
+		t.Fatalf("SetConversationID: %v", err)
+	}
+	if got != first {
+		t.Fatalf("returned id = %q, want %q", got, first)
+	}
+	reloaded, err := s.Load("j")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.ConversationID != first {
+		t.Fatalf("persisted id = %q, want %q", reloaded.ConversationID, first)
+	}
+	if reloaded.PID != 4242 || reloaded.AgyPath != "/usr/bin/agy" {
+		t.Fatalf("other fields clobbered: %+v", reloaded)
+	}
+	// Setting again is a no-op: returns the existing id, does not overwrite.
+	got, err = s.SetConversationID("j", "conv-2")
+	if err != nil {
+		t.Fatalf("second SetConversationID: %v", err)
+	}
+	if got != first {
+		t.Fatalf("second set returned %q, want existing %q", got, first)
+	}
+	reloaded, _ = s.Load("j")
+	if reloaded.ConversationID != first {
+		t.Fatalf("existing id was overwritten: %q", reloaded.ConversationID)
+	}
+}
+
 func TestExitCodeSentinel(t *testing.T) {
 	s := New(t.TempDir())
 	if _, err := s.Create(Meta{ID: "j"}); err != nil {

--- a/internal/manager/capture_test.go
+++ b/internal/manager/capture_test.go
@@ -87,10 +87,6 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 // an empty conversation id and, crucially, still release its gate key after the
 // capture budget so a later same-cwd run is not blocked forever.
 func TestFreshRunNoConversationReleasesKey(t *testing.T) {
-	oldBudget, oldPoll := captureBudget, capturePoll
-	captureBudget, capturePoll = 50*time.Millisecond, 10*time.Millisecond
-	t.Cleanup(func() { captureBudget, capturePoll = oldBudget, oldPoll })
-
 	state := t.TempDir()
 	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
 	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
@@ -107,6 +103,8 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 	}
 	m := New(c)
 	m.cacheFile = cachePath
+	m.captureBudget = 50 * time.Millisecond
+	m.capturePoll = 10 * time.Millisecond
 
 	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
 	if err != nil {
@@ -115,14 +113,19 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 
 	// Wait for the job to finish; the id stays empty (no conversation was created).
 	deadline := time.Now().Add(2 * time.Second)
+	seenDone := false
 	for time.Now().Before(deadline) {
 		if st, _ := m.Status(job.ID); st.State == StateDone {
 			if st.ConversationID != "" {
 				t.Fatalf("expected empty conversation id, got %q", st.ConversationID)
 			}
+			seenDone = true
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if !seenDone {
+		t.Fatal("job never reached done state")
 	}
 
 	// The gate key must have been released after the capture budget: a second

--- a/internal/manager/capture_test.go
+++ b/internal/manager/capture_test.go
@@ -1,0 +1,263 @@
+package manager
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// fakeSupervisorWritingCache mimics `agy-mcp run-job <dir>`: it writes out and
+// exit_code like the plain fake supervisor, but also overwrites the agy
+// conversation cache with cacheJSON, simulating agy creating a new conversation
+// for the run's cwd. The cache write lands before exit_code, so it is on disk by
+// the time the supervisor exits and the manager's completion goroutine reads it.
+func fakeSupervisorWritingCache(t *testing.T, cachePath, cacheJSON string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "fake-sup-cache")
+	payload := filepath.Join(dir, "cache-payload.json")
+	if err := os.WriteFile(payload, []byte(cacheJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := fmt.Sprintf(`#!/usr/bin/env bash
+dir="$2"
+printf 'done' > "$dir/out"
+cat %q > %q
+printf '0' > "$dir/exit_code"
+`, payload, cachePath)
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// A completed fresh run must report the conversation id agy created for it,
+// captured by diffing the conversation cache against the pre-run snapshot.
+func TestFreshRunCapturesConversationID(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := t.TempDir()
+	const newUUID = "11111111-2222-3333-4444-555555555555"
+
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  fakeSupervisorWritingCache(t, cachePath, fmt.Sprintf(`{%q:%q}`, cwd, newUUID)),
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = cachePath
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	if job.ConversationID != "" {
+		t.Fatalf("fresh run should start with no conversation id, got %q", job.ConversationID)
+	}
+
+	st := waitForCapturedID(t, m, job.ID, 3*time.Second)
+	if st.State != StateDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.ConversationID != newUUID {
+		t.Fatalf("captured conversation id = %q, want %q", st.ConversationID, newUUID)
+	}
+	// The completion goroutine must persist the id, not just report it via Status:
+	// a later reader (e.g. after the manager restarts) must see it on disk.
+	reloaded, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.ConversationID != newUUID {
+		t.Fatalf("persisted conversation id = %q, want %q", reloaded.ConversationID, newUUID)
+	}
+}
+
+// A successful fresh run that creates no conversation (cache unchanged) must report
+// an empty conversation id and, crucially, still release its gate key after the
+// capture budget so a later same-cwd run is not blocked forever.
+func TestFreshRunNoConversationReleasesKey(t *testing.T) {
+	oldBudget, oldPoll := captureBudget, capturePoll
+	captureBudget, capturePoll = 50*time.Millisecond, 10*time.Millisecond
+	t.Cleanup(func() { captureBudget, capturePoll = oldBudget, oldPoll })
+
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := t.TempDir()
+
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  fakeSupervisor(t), // writes out + exit 0, never touches the cache
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = cachePath
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+
+	// Wait for the job to finish; the id stays empty (no conversation was created).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if st, _ := m.Status(job.ID); st.State == StateDone {
+			if st.ConversationID != "" {
+				t.Fatalf("expected empty conversation id, got %q", st.ConversationID)
+			}
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The gate key must have been released after the capture budget: a second
+	// same-cwd fresh run eventually succeeds.
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		if _, err := m.StartJob(StartRequest{Prompt: "again", Cwd: cwd}); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("gate key was not released after a fresh run that created no conversation")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// If the manager dies after a fresh run completes but before its completion
+// goroutine captured the id, a later Status must capture it lazily from the cache.
+func TestStatusLazilyCapturesConversationID(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	const newUUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	// The cache already reflects the conversation agy created for this cwd.
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, newUUID)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	// A completed fresh run left on disk by a previous manager: no captured id, a
+	// recorded pre-run snapshot (empty: the cwd had no conversation), done sentinel.
+	meta := jobstore.Meta{
+		ID:            "job-restart-1",
+		Cwd:           cwd,
+		CwdUUIDBefore: "",
+		StartedAt:     time.Now().Add(-time.Minute),
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(meta.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := m.Status(meta.ID)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.State != StateDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.ConversationID != newUUID {
+		t.Fatalf("lazily captured id = %q, want %q", st.ConversationID, newUUID)
+	}
+	// The capture must be persisted so a subsequent Status is consistent.
+	reloaded, err := m.store.Load(meta.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.ConversationID != newUUID {
+		t.Fatalf("persisted id = %q, want %q", reloaded.ConversationID, newUUID)
+	}
+}
+
+// If the cache entry is unchanged from the pre-run snapshot (the run created no
+// new conversation), lazy capture must NOT attribute the stale id to this run.
+func TestStatusLazyCaptureNoOpWhenCacheUnchanged(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	const stale = "11112222-3333-4444-5555-666677778888"
+	// The cache holds an id that was already present before this run started.
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, stale)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	// A completed fresh run whose pre-run snapshot already equals the cache entry.
+	meta := jobstore.Meta{
+		ID:            "job-nochange",
+		Cwd:           cwd,
+		CwdUUIDBefore: stale,
+		StartedAt:     time.Now().Add(-time.Minute),
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(meta.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := m.Status(meta.ID)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.ConversationID != "" {
+		t.Fatalf("must not attribute the unchanged stale id, got %q", st.ConversationID)
+	}
+}
+
+func waitForCapturedID(t *testing.T, m *Manager, id string, within time.Duration) Status {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	var st Status
+	for time.Now().Before(deadline) {
+		var err error
+		st, err = m.Status(id)
+		if err == nil && st.State == StateDone && st.ConversationID != "" {
+			return st
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return st
+}

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -37,6 +37,26 @@ func (g *gate) tryAcquire(key string) bool {
 	return true
 }
 
+// forceAcquire reserves a slot and key for a job that is already running (a
+// restored job whose agy session exists regardless of the gate), so the gate
+// accounts for it. Unlike tryAcquire it ignores the cap: a live job must be
+// counted even when live jobs exceed max (for example the cap was lowered across a
+// restart), which then correctly blocks new runs until enough restored jobs drain.
+// It still returns false without double-counting when the key is already held, so
+// the caller starts exactly one liveness watcher per key.
+func (g *gate) forceAcquire(key string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if key != "" && g.keys[key] {
+		return false
+	}
+	g.inFlight++
+	if key != "" {
+		g.keys[key] = true
+	}
+	return true
+}
+
 func (g *gate) release(key string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -48,19 +48,23 @@ func (g *gate) release(key string) {
 	}
 }
 
-// keyFor returns the serialization key for a request, or "" for a fresh run
-// (no conversation, no continue) which needs no per-key lock.
+// keyFor returns the serialization key for a request.
 //
-// Fresh runs return "" today because the snapshot-diff UUID capture in
-// conversation.go is not wired into Status yet. If that lazy capture is ever
-// enabled, fresh runs sharing a cwd MUST be serialized too (return
-// "cwd:"+req.Cwd here), otherwise two new conversations created in the same
-// directory could misattribute their UUIDs (design spec section 5.4).
+// A run with a resolved conversation id serializes on that conversation. Any
+// other run with a cwd (a fresh run, or a continue_latest that found no prior
+// conversation) serializes on the cwd: agy creates a new conversation for it,
+// and the snapshot-diff UUID capture must hold the cwd key while it reads the
+// shared conversation cache, otherwise two new conversations created in the same
+// directory could misattribute their captured UUIDs.
+//
+// StartJob always populates req.Cwd, so the "" branch is effectively a defensive
+// default; two distinct conversations in the same cwd still get distinct conv
+// keys and run concurrently.
 func keyFor(req StartRequest) string {
 	if req.ConversationID != "" {
 		return "conv:" + req.ConversationID
 	}
-	if req.ContinueLatest && req.Cwd != "" {
+	if req.Cwd != "" {
 		return "cwd:" + req.Cwd
 	}
 	return ""

--- a/internal/manager/concurrency_test.go
+++ b/internal/manager/concurrency_test.go
@@ -34,6 +34,35 @@ func TestGateBlocksSameKey(t *testing.T) {
 	}
 }
 
+func TestGateForceAcquire(t *testing.T) {
+	g := newGate(2)
+	// A restored job is already running, so forceAcquire tracks it even past the cap.
+	g.forceAcquire("cwd:a")
+	g.forceAcquire("cwd:b")
+	if !g.forceAcquire("cwd:c") {
+		t.Fatal("forceAcquire must ignore the cap for an already-running job")
+	}
+	// A duplicate key is not double-tracked.
+	if g.forceAcquire("cwd:c") {
+		t.Fatal("forceAcquire on a held key must return false")
+	}
+	// inFlight is now past the cap, so a new normal run is refused.
+	if g.tryAcquire("cwd:d") {
+		t.Fatal("a new run must be refused while forced jobs exceed the cap")
+	}
+	// Drain below the cap; the still-held forced key cwd:c must keep blocking a
+	// same-key run even though a slot is now free (key block, not cap block).
+	g.release("cwd:a")
+	g.release("cwd:b")
+	if g.tryAcquire("cwd:c") {
+		t.Fatal("a forced key must keep blocking a same-key run with a free slot")
+	}
+	// A different key with a free slot is still acquirable.
+	if !g.tryAcquire("cwd:d") {
+		t.Fatal("a free key under the cap should be acquirable")
+	}
+}
+
 func TestGateGlobalCap(t *testing.T) {
 	g := newGate(2)
 	if !g.tryAcquire("conv:a") || !g.tryAcquire("conv:b") {

--- a/internal/manager/concurrency_test.go
+++ b/internal/manager/concurrency_test.go
@@ -4,13 +4,19 @@ import "testing"
 
 func TestKeyForRequest(t *testing.T) {
 	if k := keyFor(StartRequest{ConversationID: "abc"}); k != "conv:abc" {
-		t.Errorf("key = %q", k)
+		t.Errorf("conversation key = %q", k)
 	}
 	if k := keyFor(StartRequest{ContinueLatest: true, Cwd: "/w"}); k != "cwd:/w" {
-		t.Errorf("key = %q", k)
+		t.Errorf("continue-latest key = %q", k)
 	}
-	if k := keyFor(StartRequest{Cwd: "/w"}); k != "" {
-		t.Errorf("fresh run should have no serialization key, got %q", k)
+	// A fresh run now serializes on its cwd, so two new conversations created in the
+	// same directory cannot interleave and misattribute their captured UUIDs.
+	if k := keyFor(StartRequest{Cwd: "/w"}); k != "cwd:/w" {
+		t.Errorf("fresh run should serialize on cwd, got %q", k)
+	}
+	// With no cwd at all there is nothing to serialize on.
+	if k := keyFor(StartRequest{}); k != "" {
+		t.Errorf("keyless request = %q", k)
 	}
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -285,14 +285,14 @@ func (m *Manager) RestoreGate() error {
 		if !m.processAlive(meta) {
 			continue // supervisor gone; GarbageCollect will reap it
 		}
-		// tryAcquire reserves the key and counts the job against the cap. A failure
-		// means the cap is already full or the key is a duplicate; log it, because a
-		// live job left untracked by the gate is the bypass this method prevents.
+		// forceAcquire counts the job and holds its key unconditionally: a restored
+		// job is already running, so it must be tracked even past the cap (otherwise a
+		// new same-key run could start once a slot frees and run concurrently with it,
+		// the bypass this method prevents). A false return means another restored job
+		// already holds this key, so it is already watched.
 		key := keyFor(reqFromMeta(meta))
-		if m.gate.tryAcquire(key) {
+		if m.gate.forceAcquire(key) {
 			m.watchRestored(meta, key)
-		} else {
-			log.Printf("agy-mcp: RestoreGate could not re-acquire gate key %q for live job %s (cap full or duplicate key); it is untracked by the gate", key, id)
 		}
 	}
 	return nil

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -22,15 +22,26 @@ type Manager struct {
 	store     *jobstore.Store
 	gate      *gate  // serializes conflicting jobs and caps total concurrency
 	cacheFile string // agy conversation cache (last_conversations.json); injectable for tests
+
+	// Timing for the fresh-run conversation-id capture and the restored-job
+	// liveness watcher. Fields (not package globals) so tests stay isolated and can
+	// run in parallel. agy's conversation cache is flushed by a separate daemon that
+	// can lag the foreground agy exit, so the capture retries briefly.
+	captureBudget        time.Duration
+	capturePoll          time.Duration
+	restoredPollInterval time.Duration
 }
 
 // New constructs a Manager.
 func New(c config.Config) *Manager {
 	return &Manager{
-		cfg:       c,
-		store:     jobstore.New(c.StateDir),
-		gate:      newGate(c.MaxConcurrency),
-		cacheFile: agyCachePath(),
+		cfg:                  c,
+		store:                jobstore.New(c.StateDir),
+		gate:                 newGate(c.MaxConcurrency),
+		cacheFile:            agyCachePath(),
+		captureBudget:        2 * time.Second,
+		capturePoll:          100 * time.Millisecond,
+		restoredPollInterval: 2 * time.Second,
 	}
 }
 
@@ -52,15 +63,6 @@ type Job struct {
 	State          string // "running"
 }
 
-// Capture timing for a fresh run's conversation id. agy's conversation cache is
-// written by a separate long-lived daemon that can lag the foreground agy exit, so
-// the capture retries briefly rather than reading once. These are vars so tests can
-// shorten them.
-var (
-	captureBudget = 2 * time.Second
-	capturePoll   = 100 * time.Millisecond
-)
-
 // captureFreshConversationID records the conversation id agy created for a fresh
 // run by diffing the cwd's cache entry against the pre-run snapshot, and persists
 // it to meta so Status reports it. It is a no-op once an id is already known.
@@ -73,7 +75,7 @@ func (m *Manager) captureFreshConversationID(meta *jobstore.Meta) {
 	if meta.ConversationID != "" {
 		return
 	}
-	deadline := time.Now().Add(captureBudget)
+	deadline := time.Now().Add(m.captureBudget)
 	for {
 		if id, ok := captureNewUUID(m.cacheFile, meta.Cwd, meta.CwdUUIDBefore); ok {
 			final, err := m.store.SetConversationID(meta.ID, id)
@@ -87,7 +89,7 @@ func (m *Manager) captureFreshConversationID(meta *jobstore.Meta) {
 		if !time.Now().Before(deadline) {
 			return
 		}
-		time.Sleep(capturePoll)
+		time.Sleep(m.capturePoll)
 	}
 }
 
@@ -263,13 +265,14 @@ func reqFromMeta(meta jobstore.Meta) StartRequest {
 // global cap accounts for them. Without this, a restored job is invisible to the
 // gate and the cap could be bypassed, re-exposing the session-lock hang the gate
 // prevents. Intended to run once at startup, after GarbageCollect.
-func (m *Manager) RestoreGate() {
+//
+// It fails closed: if the on-disk jobs cannot be scanned the gate cannot be made
+// safe, so it returns an error and the caller should refuse to start rather than
+// serve with an unrestored gate.
+func (m *Manager) RestoreGate() error {
 	ids, err := m.store.List()
 	if err != nil {
-		// A failed scan leaves the gate unrestored, silently re-opening the cap
-		// bypass this method exists to prevent; surface it rather than swallow it.
-		log.Printf("agy-mcp: RestoreGate could not list jobs; gate not restored: %v", err)
-		return
+		return fmt.Errorf("scan jobs to restore concurrency gate: %w", err)
 	}
 	for _, id := range ids {
 		meta, err := m.store.Load(id)
@@ -283,26 +286,24 @@ func (m *Manager) RestoreGate() {
 			continue // supervisor gone; GarbageCollect will reap it
 		}
 		// tryAcquire reserves the key and counts the job against the cap. A failure
-		// means the cap is already full or the key is a duplicate, so skip it.
+		// means the cap is already full or the key is a duplicate; log it, because a
+		// live job left untracked by the gate is the bypass this method prevents.
 		key := keyFor(reqFromMeta(meta))
 		if m.gate.tryAcquire(key) {
 			m.watchRestored(meta, key)
+		} else {
+			log.Printf("agy-mcp: RestoreGate could not re-acquire gate key %q for live job %s (cap full or duplicate key); it is untracked by the gate", key, id)
 		}
 	}
+	return nil
 }
-
-// restoredPollInterval is how often a restored job's watcher polls its detached
-// supervisor's liveness. It is a var so tests can shorten it.
-var restoredPollInterval = 2 * time.Second
 
 // watchRestored releases a restored job's gate key once its detached supervisor
 // exits. A restored job is not a child of this manager, so there is no cmd.Wait to
 // release on; the watcher polls liveness instead. It only covers jobs that
 // outlived a restart, so the polling cost is bounded.
 func (m *Manager) watchRestored(meta jobstore.Meta, key string) {
-	// Read the interval synchronously so the package-global is never read from the
-	// spawned goroutine (tests mutate it; the goroutine must not race that write).
-	interval := restoredPollInterval
+	interval := m.restoredPollInterval
 	dead := func() bool {
 		if _, terminal := m.store.ExitCode(meta.ID); terminal {
 			return true

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"syscall"
@@ -17,17 +18,19 @@ import (
 
 // Manager coordinates jobs backed by an on-disk store.
 type Manager struct {
-	cfg   config.Config
-	store *jobstore.Store
-	gate  *gate // serializes conflicting jobs and caps total concurrency
+	cfg       config.Config
+	store     *jobstore.Store
+	gate      *gate  // serializes conflicting jobs and caps total concurrency
+	cacheFile string // agy conversation cache (last_conversations.json); injectable for tests
 }
 
 // New constructs a Manager.
 func New(c config.Config) *Manager {
 	return &Manager{
-		cfg:   c,
-		store: jobstore.New(c.StateDir),
-		gate:  newGate(c.MaxConcurrency),
+		cfg:       c,
+		store:     jobstore.New(c.StateDir),
+		gate:      newGate(c.MaxConcurrency),
+		cacheFile: agyCachePath(),
 	}
 }
 
@@ -47,6 +50,67 @@ type Job struct {
 	ID             string
 	ConversationID string
 	State          string // "running"
+}
+
+// Capture timing for a fresh run's conversation id. agy's conversation cache is
+// written by a separate long-lived daemon that can lag the foreground agy exit, so
+// the capture retries briefly rather than reading once. These are vars so tests can
+// shorten them.
+var (
+	captureBudget = 2 * time.Second
+	capturePoll   = 100 * time.Millisecond
+)
+
+// captureFreshConversationID records the conversation id agy created for a fresh
+// run by diffing the cwd's cache entry against the pre-run snapshot, and persists
+// it to meta so Status reports it. It is a no-op once an id is already known.
+//
+// The caller must invoke this while still holding the run's gate key: the cwd key
+// serializes same-cwd fresh runs, so no other run can overwrite the cache entry
+// between the snapshot and this capture. A torn or missing cache read yields no
+// capture (the run simply reports no id), never a misattribution.
+func (m *Manager) captureFreshConversationID(meta *jobstore.Meta) {
+	if meta.ConversationID != "" {
+		return
+	}
+	deadline := time.Now().Add(captureBudget)
+	for {
+		if id, ok := captureNewUUID(m.cacheFile, meta.Cwd, meta.CwdUUIDBefore); ok {
+			final, err := m.store.SetConversationID(meta.ID, id)
+			if err != nil {
+				log.Printf("agy-mcp: persist captured conversation id for job %s: %v", meta.ID, err)
+				final = id
+			}
+			meta.ConversationID = final
+			return
+		}
+		if !time.Now().Before(deadline) {
+			return
+		}
+		time.Sleep(capturePoll)
+	}
+}
+
+// lazyCaptureConversationID best-effort captures a fresh run's conversation id
+// from the cache when the completion goroutine never ran (the manager was
+// restarted while the job ran). It returns an already-known id unchanged. Unlike
+// the completion-goroutine capture, no gate key is held here, so a same-cwd run
+// that started in between may have overwritten the cache entry; in that case
+// nothing is captured and the run reports no id, exactly as before this change.
+func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
+	if meta.ConversationID != "" {
+		return meta.ConversationID
+	}
+	id, ok := captureNewUUID(m.cacheFile, meta.Cwd, meta.CwdUUIDBefore)
+	if !ok {
+		return ""
+	}
+	final, err := m.store.SetConversationID(meta.ID, id)
+	if err != nil {
+		log.Printf("agy-mcp: persist captured conversation id for job %s: %v", meta.ID, err)
+		return id // best-effort: report what we captured even if the persist failed
+	}
+	return final
 }
 
 // StartJob persists meta and spawns the detached supervisor.
@@ -76,7 +140,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// gate key and args, so serialization, the agy --conversation flag, and the
 	// returned conversation id are all deterministic and consistent.
 	if req.ContinueLatest {
-		if cid, ok := resolveLatest(agyCachePath(), cwd); ok {
+		if cid, ok := resolveLatest(m.cacheFile, cwd); ok {
 			req.ConversationID = cid
 		}
 	}
@@ -104,7 +168,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// conversation. Snapshot the cwd's current conversation id so a later diff
 	// can capture the one agy creates.
 	if req.ConversationID == "" {
-		meta.CwdUUIDBefore = snapshotCwd(agyCachePath(), cwd)
+		meta.CwdUUIDBefore = snapshotCwd(m.cacheFile, cwd)
 	}
 	dir, err := m.store.Create(meta)
 	if err != nil {
@@ -142,6 +206,12 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// the manager dies first, init adopts and reaps it.
 	go func() {
 		_ = cmd.Wait()
+		// For a successful fresh run, capture the conversation id agy created
+		// while the gate key is still held, then release. Gating on exit 0 avoids
+		// waiting out the capture budget for a run that created no conversation.
+		if code, ok := m.store.ExitCode(id); ok && code == 0 {
+			m.captureFreshConversationID(&meta)
+		}
 		m.gate.release(key)
 	}()
 
@@ -178,6 +248,81 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 		}
 	}
 	return removed, nil
+}
+
+// reqFromMeta reconstructs the parts of a StartRequest that determine a job's
+// gate key from its persisted meta. continue_latest is resolved into
+// ConversationID at start time, so ConversationID + Cwd reproduce the same key
+// the original run held.
+func reqFromMeta(meta jobstore.Meta) StartRequest {
+	return StartRequest{ConversationID: meta.ConversationID, Cwd: meta.Cwd}
+}
+
+// RestoreGate re-acquires gate slots and keys for jobs whose detached supervisor
+// survived a manager restart, so a new agy_run is serialized against them and the
+// global cap accounts for them. Without this, a restored job is invisible to the
+// gate and the cap could be bypassed, re-exposing the session-lock hang the gate
+// prevents. Intended to run once at startup, after GarbageCollect.
+func (m *Manager) RestoreGate() {
+	ids, err := m.store.List()
+	if err != nil {
+		// A failed scan leaves the gate unrestored, silently re-opening the cap
+		// bypass this method exists to prevent; surface it rather than swallow it.
+		log.Printf("agy-mcp: RestoreGate could not list jobs; gate not restored: %v", err)
+		return
+	}
+	for _, id := range ids {
+		meta, err := m.store.Load(id)
+		if err != nil {
+			continue
+		}
+		if _, terminal := m.store.ExitCode(id); terminal {
+			continue // already finished; nothing to hold
+		}
+		if !m.processAlive(meta) {
+			continue // supervisor gone; GarbageCollect will reap it
+		}
+		// tryAcquire reserves the key and counts the job against the cap. A failure
+		// means the cap is already full or the key is a duplicate, so skip it.
+		key := keyFor(reqFromMeta(meta))
+		if m.gate.tryAcquire(key) {
+			m.watchRestored(meta, key)
+		}
+	}
+}
+
+// restoredPollInterval is how often a restored job's watcher polls its detached
+// supervisor's liveness. It is a var so tests can shorten it.
+var restoredPollInterval = 2 * time.Second
+
+// watchRestored releases a restored job's gate key once its detached supervisor
+// exits. A restored job is not a child of this manager, so there is no cmd.Wait to
+// release on; the watcher polls liveness instead. It only covers jobs that
+// outlived a restart, so the polling cost is bounded.
+func (m *Manager) watchRestored(meta jobstore.Meta, key string) {
+	// Read the interval synchronously so the package-global is never read from the
+	// spawned goroutine (tests mutate it; the goroutine must not race that write).
+	interval := restoredPollInterval
+	dead := func() bool {
+		if _, terminal := m.store.ExitCode(meta.ID); terminal {
+			return true
+		}
+		return !m.processAlive(meta)
+	}
+	go func() {
+		// Check once before waiting a full interval, so a supervisor that exits
+		// right after startup does not hold its slot for a whole poll period.
+		if !dead() {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for range t.C {
+				if dead() {
+					break
+				}
+			}
+		}
+		m.gate.release(key)
+	}()
 }
 
 func buildAgyArgs(req StartRequest, model string, timeout time.Duration) []string {

--- a/internal/manager/restore_test.go
+++ b/internal/manager/restore_test.go
@@ -1,0 +1,185 @@
+package manager
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// startFakeLiveSupervisor starts a real, long-lived process to stand in for a
+// detached job supervisor that survived a manager restart. It returns the pid and
+// the resolved path to the binary; the Manager's SupervisorExe must be set to that
+// path so processAlive's /proc/<pid>/comm check matches ("sleep").
+func startFakeLiveSupervisor(t *testing.T) (pid int, exePath string) {
+	t.Helper()
+	exePath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("sleep not available: %v", err)
+	}
+	cmd := exec.Command(exePath, "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake supervisor: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd.Process.Pid, exePath
+}
+
+func newManagerForRestore(t *testing.T, exePath string, maxConcurrency int) *Manager {
+	t.Helper()
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  exePath,
+		StateDir:       t.TempDir(),
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: maxConcurrency,
+	})
+	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	return m
+}
+
+func createLiveJob(t *testing.T, m *Manager, id, cwd string, pid int) {
+	t.Helper()
+	if _, err := m.store.Create(jobstore.Meta{
+		ID:        id,
+		Cwd:       cwd,
+		PID:       pid,
+		BootID:    readBootID(),
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create live job: %v", err)
+	}
+}
+
+// A live job whose supervisor survived a manager restart must, after RestoreGate,
+// re-occupy its serialization key so a conflicting new run is blocked.
+func TestRestoreGateBlocksConflictingRun(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := newManagerForRestore(t, exePath, 4)
+	cwd := t.TempDir()
+	createLiveJob(t, m, "live-1", cwd, pid)
+
+	m.RestoreGate()
+
+	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err == nil {
+		t.Fatal("a same-cwd run should be blocked by the restored live job's key")
+	}
+}
+
+// A restored live job must also count against the global concurrency cap, so a
+// non-conflicting run is refused once the cap is full.
+func TestRestoreGateCountsAgainstCap(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := newManagerForRestore(t, exePath, 1)
+	createLiveJob(t, m, "live-1", t.TempDir(), pid)
+
+	m.RestoreGate()
+
+	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: t.TempDir()}); err == nil {
+		t.Fatal("a run in a different cwd should be refused: the restored job fills the cap")
+	}
+}
+
+// Once a restored job's detached supervisor exits, the watcher must release its
+// gate key so a subsequent same-cwd run can proceed (the key must not leak).
+func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
+	old := restoredPollInterval
+	restoredPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { restoredPollInterval = old })
+
+	exePath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("sleep not available: %v", err)
+	}
+	cmd := exec.Command(exePath, "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake supervisor: %v", err)
+	}
+	reaped := false
+	t.Cleanup(func() {
+		if !reaped {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	m := newManagerForRestore(t, exePath, 4)
+	cwd := t.TempDir()
+	createLiveJob(t, m, "live-1", cwd, cmd.Process.Pid)
+
+	m.RestoreGate()
+
+	// While the supervisor is alive the key is held: a same-cwd run is blocked.
+	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err == nil {
+		t.Fatal("expected the restored live job to block a same-cwd run")
+	}
+
+	// The supervisor exits; reap it so processAlive turns false.
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	reaped = true
+
+	// The watcher must release the key; a same-cwd run then succeeds.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("watcher did not release the restored key after the supervisor exited")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A job whose recorded supervisor is no longer alive must NOT be restored into the
+// gate. Restoring a dead job would hold its key forever and block all same-cwd runs.
+func TestRestoreGateSkipsDeadSupervisor(t *testing.T) {
+	exePath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("sleep not available: %v", err)
+	}
+	// Start then immediately kill+reap a real process so its pid is dead (and from
+	// the current boot, so only the liveness check, not the boot-id guard, rejects it).
+	cmd := exec.Command(exePath, "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	deadPID := cmd.Process.Pid
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+
+	m := newManagerForRestore(t, exePath, 4)
+	cwd := t.TempDir()
+	createLiveJob(t, m, "dead-1", cwd, deadPID)
+
+	m.RestoreGate()
+
+	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err != nil {
+		t.Fatalf("a dead-supervisor job must not hold a gate key, but the run was blocked: %v", err)
+	}
+}
+
+// A terminal job (one with an exit_code sentinel) must NOT be restored into the
+// gate, even if its recorded pid happens to still be alive.
+func TestRestoreGateSkipsTerminalJobs(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := newManagerForRestore(t, exePath, 4)
+	cwd := t.TempDir()
+	createLiveJob(t, m, "done-1", cwd, pid)
+	if err := m.store.WriteExitCode("done-1", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	m.RestoreGate()
+
+	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err != nil {
+		t.Fatalf("a terminal job must not hold a gate key, but the run was blocked: %v", err)
+	}
+}

--- a/internal/manager/restore_test.go
+++ b/internal/manager/restore_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -65,7 +66,9 @@ func TestRestoreGateBlocksConflictingRun(t *testing.T) {
 	cwd := t.TempDir()
 	createLiveJob(t, m, "live-1", cwd, pid)
 
-	m.RestoreGate()
+	if err := m.RestoreGate(); err != nil {
+		t.Fatalf("RestoreGate: %v", err)
+	}
 
 	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err == nil {
 		t.Fatal("a same-cwd run should be blocked by the restored live job's key")
@@ -79,7 +82,9 @@ func TestRestoreGateCountsAgainstCap(t *testing.T) {
 	m := newManagerForRestore(t, exePath, 1)
 	createLiveJob(t, m, "live-1", t.TempDir(), pid)
 
-	m.RestoreGate()
+	if err := m.RestoreGate(); err != nil {
+		t.Fatalf("RestoreGate: %v", err)
+	}
 
 	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: t.TempDir()}); err == nil {
 		t.Fatal("a run in a different cwd should be refused: the restored job fills the cap")
@@ -89,10 +94,6 @@ func TestRestoreGateCountsAgainstCap(t *testing.T) {
 // Once a restored job's detached supervisor exits, the watcher must release its
 // gate key so a subsequent same-cwd run can proceed (the key must not leak).
 func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
-	old := restoredPollInterval
-	restoredPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { restoredPollInterval = old })
-
 	exePath, err := exec.LookPath("sleep")
 	if err != nil {
 		t.Skipf("sleep not available: %v", err)
@@ -110,10 +111,13 @@ func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
 	})
 
 	m := newManagerForRestore(t, exePath, 4)
+	m.restoredPollInterval = 10 * time.Millisecond
 	cwd := t.TempDir()
 	createLiveJob(t, m, "live-1", cwd, cmd.Process.Pid)
 
-	m.RestoreGate()
+	if err := m.RestoreGate(); err != nil {
+		t.Fatalf("RestoreGate: %v", err)
+	}
 
 	// While the supervisor is alive the key is held: a same-cwd run is blocked.
 	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err == nil {
@@ -138,6 +142,27 @@ func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
 	}
 }
 
+// RestoreGate must fail closed: if the on-disk jobs cannot be scanned, it returns
+// an error so startup can refuse rather than serve with an unrestored gate.
+func TestRestoreGateFailsClosedOnScanError(t *testing.T) {
+	state := t.TempDir()
+	// Make the jobs path a file so the directory scan errors (distinct from the
+	// benign "directory does not exist yet" case, which is not an error).
+	if err := os.WriteFile(filepath.Join(state, "jobs"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	if err := m.RestoreGate(); err == nil {
+		t.Fatal("RestoreGate must return an error when the jobs dir cannot be scanned")
+	}
+}
+
 // A job whose recorded supervisor is no longer alive must NOT be restored into the
 // gate. Restoring a dead job would hold its key forever and block all same-cwd runs.
 func TestRestoreGateSkipsDeadSupervisor(t *testing.T) {
@@ -159,7 +184,9 @@ func TestRestoreGateSkipsDeadSupervisor(t *testing.T) {
 	cwd := t.TempDir()
 	createLiveJob(t, m, "dead-1", cwd, deadPID)
 
-	m.RestoreGate()
+	if err := m.RestoreGate(); err != nil {
+		t.Fatalf("RestoreGate: %v", err)
+	}
 
 	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err != nil {
 		t.Fatalf("a dead-supervisor job must not hold a gate key, but the run was blocked: %v", err)
@@ -177,7 +204,9 @@ func TestRestoreGateSkipsTerminalJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m.RestoreGate()
+	if err := m.RestoreGate(); err != nil {
+		t.Fatalf("RestoreGate: %v", err)
+	}
 
 	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err != nil {
 		t.Fatalf("a terminal job must not hold a gate key, but the run was blocked: %v", err)

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -24,9 +24,11 @@ func agyCachePath() string {
 	return filepath.Join(home, ".gemini", "antigravity-cli", "cache", "last_conversations.json")
 }
 
-// ListSessions returns known conversations, optionally filtered to one dir.
+// ListSessions returns known conversations, optionally filtered to one dir. It
+// reads m.cacheFile so it shares the manager's single source of truth for the agy
+// cache path (and is injectable in tests) like the capture/resolve paths.
 func (m *Manager) ListSessions(dir string) ([]Session, error) {
-	return readSessions(agyCachePath(), dir)
+	return readSessions(m.cacheFile, dir)
 }
 
 func readSessions(cacheFile, filterDir string) ([]Session, error) {

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -52,6 +52,7 @@ func (m *Manager) Status(id string) (Status, error) {
 		case 0:
 			st.State = StateDone
 			st.Result = readFile(filepath.Join(dir, "out"))
+			st.ConversationID = m.lazyCaptureConversationID(meta)
 		case jobstore.ExitSIGTERM, jobstore.ExitSIGINT:
 			st.State = StateCancelled
 		case jobstore.ExitTimeout:
@@ -74,6 +75,7 @@ func (m *Manager) Status(id string) (Status, error) {
 	if out != "" {
 		st.State = StateDone
 		st.Result = out
+		st.ConversationID = m.lazyCaptureConversationID(meta)
 	} else {
 		st.State = StateFailed
 		st.Error = "job process exited without writing a result (interrupted)"

--- a/main.go
+++ b/main.go
@@ -61,7 +61,11 @@ func serve() error {
 	}
 	// Re-occupy the concurrency gate for jobs whose detached supervisor outlived a
 	// previous manager, so a new run is serialized against them and the cap holds.
-	mgr.RestoreGate()
+	// Fail closed: serving with an unrestored gate could bypass the cap and
+	// re-expose the agy session-lock hang the gate prevents.
+	if err := mgr.RestoreGate(); err != nil {
+		return fmt.Errorf("restore concurrency gate: %w", err)
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func serve() error {
 	} else if len(removed) > 0 {
 		log.Printf("startup GC removed %d expired job(s)", len(removed))
 	}
+	// Re-occupy the concurrency gate for jobs whose detached supervisor outlived a
+	// previous manager, so a new run is serialized against them and the cap holds.
+	mgr.RestoreGate()
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()


### PR DESCRIPTION
## Summary

Implements #2 and #3 (both surfaced during review of #1), batched because they share the concurrency gate and its startup job scan.

- **#2 (same-cwd serialization + UUID capture):** a fresh `agy_run` now serializes on its `cwd`, and a completed fresh run reports the conversation id agy creates for it. The id is captured by diffing the agy conversation cache **while the cwd gate key is still held** (with a bounded retry, since the cache is flushed by a separate agy daemon that can lag the foreground exit), and persisted via a new `jobstore.SetConversationID` that rewrites only that field so it cannot clobber a concurrent meta update. `Status` keeps a best-effort lazy capture for the manager-restarted-mid-run case.
- **#3 (gate restore on restart):** `RestoreGate`, run at startup after `GarbageCollect`, re-acquires the gate key and cap slot for each live job whose detached supervisor outlived the manager; a per-job liveness watcher releases the key when that supervisor exits, so the cap and same-cwd serialization hold across a restart.

The capture approach was verified against the real agy 1.0.6: a caller-supplied `--conversation <uuid>` is **not** honored (agy warns "not found" and generates its own id), so snapshot-diff is the only viable capture and the same-cwd serialization is genuinely required; the cache is written in-place by a separate daemon, so torn reads degrade gracefully (a missed capture, never a misattribution) and an in-process mutex would not help.

Note: while one fresh run is active, a second fresh run in the same directory is **refused** with a conflict error (not queued). Runs in different directories, and runs continuing distinct conversations, still run concurrently up to the cap.

## Related Issues

Fixes #2
Fixes #3

Follow-ups filed during review (out of scope here): #8, #9, #10.

## Test Plan

- [x] `go test -race ./...` green across all packages
- [x] `golangci-lint run ./...` reports 0 issues
- [x] New tests: `keyFor` cwd serialization; fresh-run capture + on-disk persistence; lazy capture + no-op when the cache is unchanged; `RestoreGate` blocks-conflicting / counts-against-cap / releases-on-exit / skips-terminal / skips-dead-supervisor; `SetConversationID` round-trip + no-overwrite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fresh runs now automatically generate and report a conversation ID for later continuation.
  * Concurrent runs in the same working directory are now properly serialized to prevent conflicts.
  
* **Improvements**
  * Server restarts now correctly restore concurrency gates for active detached supervisors, maintaining enforced limits.

* **Tests**
  * Added comprehensive test coverage for conversation ID capture and gate restoration across server restarts.

* **Documentation**
  * Updated README with details on fresh run behavior and concurrency restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->