### PR TITLE
Harden job lifecycle: orphan cleanup, periodic GC, starttime liveness

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -14,7 +14,9 @@ import (
 	"time"
 )
 
-// Meta describes a job. It is written once at creation and is immutable.
+// Meta describes a job. The identity fields are set at creation; PID,
+// StartTimeTicks, and ConversationID are filled in afterward by atomic rewrites
+// (UpdateMeta / SetConversationID).
 type Meta struct {
 	ID             string        `json:"id"`
 	AgyPath        string        `json:"agy_path"`
@@ -25,6 +27,7 @@ type Meta struct {
 	Prompt         string        `json:"prompt"`
 	StartedAt      time.Time     `json:"started_at"`
 	PID            int           `json:"pid"`
+	StartTimeTicks uint64        `json:"start_time_ticks,omitempty"` // supervisor /proc start time; 0 = unknown
 	BootID         string        `json:"boot_id"`
 	CwdUUIDBefore  string        `json:"cwd_uuid_before,omitempty"`
 	Timeout        time.Duration `json:"timeout,omitempty"`
@@ -83,6 +86,9 @@ func (s *Store) Create(m Meta) (string, error) {
 		return "", err
 	}
 	if err := os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644); err != nil {
+		// Remove the just-created dir so a failed Create leaves no orphan: a dir
+		// without a readable meta.json is skipped forever by GarbageCollect.
+		_ = os.RemoveAll(dir)
 		return "", err
 	}
 	return dir, nil
@@ -123,6 +129,13 @@ func (s *Store) UpdateMeta(m Meta) error {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	// Flush the data to disk before the rename so a crash cannot leave a renamed
+	// but zero-length meta.json, which would orphan the job (Load fails, GC skips).
+	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpName)
 		return err

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -63,6 +63,57 @@ func TestCreateAndLoadMeta(t *testing.T) {
 	}
 }
 
+func TestCreateCleansUpDirOnWriteFailure(t *testing.T) {
+	s := New(t.TempDir())
+	dir := s.jobDir("j")
+	// Make meta.json a directory so Create's WriteFile fails after MkdirAll has
+	// already created the job dir. Without cleanup the empty dir would be orphaned:
+	// GarbageCollect skips it forever because Load (no meta.json) errors.
+	if err := os.MkdirAll(filepath.Join(dir, "meta.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Create(Meta{ID: "j"}); err == nil {
+		t.Fatal("Create should fail when meta.json cannot be written")
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("job dir should be removed after a failed Create; stat err = %v", err)
+	}
+}
+
+func TestStartTimeTicksRoundTripAndBackCompat(t *testing.T) {
+	s := New(t.TempDir())
+	if _, err := s.Create(Meta{ID: "j", PID: 4242, StartTimeTicks: 987654}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := s.Load("j")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.StartTimeTicks != 987654 {
+		t.Fatalf("round-trip StartTimeTicks = %d, want 987654", got.StartTimeTicks)
+	}
+
+	// A meta.json written by an older binary has no start_time_ticks field; it must
+	// load as 0 ("unknown"), which disables the start-time liveness check rather
+	// than misbehaving.
+	old := New(t.TempDir())
+	dir := old.jobDir("legacy")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"id":"legacy","agy_path":"/usr/bin/agy","args":["-p","hi"],"cwd":"/work","prompt":"hi","started_at":"2026-01-01T00:00:00Z","pid":7,"boot_id":"b"}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lm, err := old.Load("legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lm.StartTimeTicks != 0 {
+		t.Fatalf("legacy meta StartTimeTicks = %d, want 0", lm.StartTimeTicks)
+	}
+}
+
 func TestUpdateMetaRoundTrip(t *testing.T) {
 	s := New(t.TempDir())
 	if _, err := s.Create(Meta{ID: "j"}); err != nil {

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -28,11 +28,11 @@ func TestGarbageCollectRemovesExpired(t *testing.T) {
 
 func TestGCInterval(t *testing.T) {
 	cases := []struct{ ttl, want time.Duration }{
-		{0, 0},                          // disabled
-		{-time.Second, 0},               // disabled
-		{2 * time.Hour, time.Hour},      // ttl/2
+		{0, 0},                             // disabled
+		{-time.Second, 0},                  // disabled
+		{2 * time.Hour, time.Hour},         // ttl/2
 		{4 * time.Minute, 2 * time.Minute}, // ttl/2, above the floor
-		{time.Second, time.Minute},      // ttl/2 below the floor -> floored to 1m
+		{time.Second, time.Minute},         // ttl/2 below the floor -> floored to 1m
 	}
 	for _, c := range cases {
 		if got := gcInterval(c.ttl); got != c.want {
@@ -47,6 +47,7 @@ func TestRunPeriodicGCCollectsAndStops(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel() // stop the goroutine even if an assertion below fails early
 	done := make(chan struct{})
 	go func() { m.runPeriodicGC(ctx, 10*time.Millisecond); close(done) }()
 

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,6 +23,52 @@ func TestGarbageCollectRemovesExpired(t *testing.T) {
 	}
 	if len(removed) != 1 || removed[0] != "old" {
 		t.Fatalf("removed = %v, want [old]", removed)
+	}
+}
+
+func TestGCInterval(t *testing.T) {
+	cases := []struct{ ttl, want time.Duration }{
+		{0, 0},                          // disabled
+		{-time.Second, 0},               // disabled
+		{2 * time.Hour, time.Hour},      // ttl/2
+		{4 * time.Minute, 2 * time.Minute}, // ttl/2, above the floor
+		{time.Second, time.Minute},      // ttl/2 below the floor -> floored to 1m
+	}
+	for _, c := range cases {
+		if got := gcInterval(c.ttl); got != c.want {
+			t.Errorf("gcInterval(%v) = %v, want %v", c.ttl, got, c.want)
+		}
+	}
+}
+
+func TestRunPeriodicGCCollectsAndStops(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { m.runPeriodicGC(ctx, 10*time.Millisecond); close(done) }()
+
+	// The ticker collects the expired job.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ids, _ := m.store.List()
+		if len(ids) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("periodic GC did not collect the expired job")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Cancelling the context stops the loop and returns.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunPeriodicGC did not return after context cancellation")
 	}
 }
 

--- a/internal/manager/job_test.go
+++ b/internal/manager/job_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,6 +69,40 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 	}
 	if _, ok := m.store.ExitCode(job.ID); !ok {
 		t.Fatal("supervisor did not write exit_code")
+	}
+}
+
+func TestStartJobCleansUpDirOnSpawnFailure(t *testing.T) {
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  filepath.Join(t.TempDir(), "nonexistent-supervisor"),
+		StateDir:       t.TempDir(),
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	cwd := t.TempDir()
+
+	_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
+	if err == nil || !strings.Contains(err.Error(), "spawn supervisor") {
+		t.Fatalf("StartJob error = %v, want a spawn-supervisor failure", err)
+	}
+
+	// The job directory created before the failed spawn must be removed, not left
+	// orphaned for GarbageCollect to reap later.
+	ids, lerr := m.store.List()
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("orphaned job dir left on disk after spawn failure: %v", ids)
+	}
+
+	// The gate slot/key must also be released: a second same-cwd run fails at spawn
+	// again, rather than being refused by the gate ("conflicting job").
+	_, err2 := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
+	if err2 == nil || !strings.Contains(err2.Error(), "spawn supervisor") {
+		t.Fatalf("second run error = %v, want spawn-supervisor (gate slot leaked?)", err2)
 	}
 }
 

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -43,7 +44,58 @@ func (m *Manager) processAlive(meta jobstore.Meta) bool {
 		return false
 	}
 	name := strings.TrimSpace(string(comm))
-	return name == expectedComm(m.cfg.SupervisorExe)
+	if name != expectedComm(m.cfg.SupervisorExe) {
+		return false
+	}
+	// Same-boot PID recycling: a recycled PID may pass the comm check if the new
+	// process is also an agy-mcp. The start time pins identity to this exact
+	// process. Only a successful read that mismatches proves recycling; a recorded
+	// zero (older meta, or an unreadable /proc at spawn) or a transient read failure
+	// here skips the check, so a live job is never falsely read as dead.
+	if meta.StartTimeTicks != 0 {
+		if cur, ok := readStartTimeTicks(meta.PID); ok && cur != meta.StartTimeTicks {
+			return false
+		}
+	}
+	return true
+}
+
+// readStartTimeTicks returns the process start time (field 22 of
+// /proc/<pid>/stat, in clock ticks since boot) for pid. The second result is
+// false on any read or parse failure, so a transient error is never mistaken for
+// a recycled pid: callers only act on a successful read.
+func readStartTimeTicks(pid int) (uint64, bool) {
+	b, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return 0, false
+	}
+	return parseStartTimeTicks(b)
+}
+
+// parseStartTimeTicks extracts field 22 (starttime) from a /proc/<pid>/stat line.
+// Field 2 (comm) is wrapped in parentheses and may itself contain spaces and
+// parentheses, so the fields after it are located from the LAST ')'. After that
+// ')' the first token is field 3 (state), making field 22 the token at index 19.
+func parseStartTimeTicks(stat []byte) (uint64, bool) {
+	i := bytes.LastIndexByte(stat, ')')
+	if i < 0 || i+1 >= len(stat) {
+		return 0, false
+	}
+	// Only field 22 is needed, so iterate (FieldsSeq) and stop at it rather than
+	// allocating a full slice of every field on each liveness poll.
+	const startTimeIdx = 19 // field 22 - field 3 (the first post-')' field)
+	idx := 0
+	for f := range bytes.FieldsSeq(stat[i+1:]) {
+		if idx == startTimeIdx {
+			ticks, err := strconv.ParseUint(string(f), 10, 64)
+			if err != nil {
+				return 0, false
+			}
+			return ticks, true
+		}
+		idx++
+	}
+	return 0, false
 }
 
 // expectedComm returns the process name as the kernel records it in

--- a/internal/manager/liveness_test.go
+++ b/internal/manager/liveness_test.go
@@ -1,6 +1,12 @@
 package manager
 
-import "testing"
+import (
+	"os"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
 
 func TestExpectedComm(t *testing.T) {
 	if got := expectedComm("/usr/local/bin/agy-mcp"); got != "agy-mcp" {
@@ -9,5 +15,68 @@ func TestExpectedComm(t *testing.T) {
 	// Kernel /proc/comm is capped at 15 chars; a longer basename is truncated.
 	if got := expectedComm("/x/agy-mcp-v1.2.3-linux-amd64"); got != "agy-mcp-v1.2.3-" {
 		t.Errorf("expectedComm truncation = %q (len %d)", got, len(got))
+	}
+}
+
+func TestParseStartTimeTicks(t *testing.T) {
+	// comm is wrapped in a single outer paren pair but may itself contain spaces
+	// and parens; parsing must key off the LAST ')'. starttime is field 22, which
+	// is index 19 of the whitespace-split remainder after that ')'.
+	const stat = "1234 (odd) proc (x) S 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 8888888 0 0 0 0"
+	got, ok := parseStartTimeTicks([]byte(stat))
+	if !ok || got != 8888888 {
+		t.Fatalf("parseStartTimeTicks = %d,%v, want 8888888,true", got, ok)
+	}
+
+	// Malformed input returns (0, false), never a misread.
+	for _, bad := range []string{"", "no parens here", "123 (x) S 1 2 3"} {
+		if v, ok := parseStartTimeTicks([]byte(bad)); ok || v != 0 {
+			t.Errorf("parseStartTimeTicks(%q) = %d,%v, want 0,false", bad, v, ok)
+		}
+	}
+}
+
+func TestProcessAliveStartTimeCheck(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := New(config.Config{SupervisorExe: exePath, StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	actual, ok := readStartTimeTicks(pid)
+	if !ok {
+		t.Fatalf("could not read start time for live pid %d", pid)
+	}
+	base := jobstore.Meta{PID: pid, BootID: readBootID()}
+
+	// Recorded start time matches the live process: alive.
+	match := base
+	match.StartTimeTicks = actual
+	if !m.processAlive(match) {
+		t.Error("matching start time should read as alive")
+	}
+
+	// Recorded start time differs (a same-boot recycled pid now owned by another
+	// agy-mcp would pass the comm check but fail here): not our process.
+	mismatch := base
+	mismatch.StartTimeTicks = actual + 1
+	if m.processAlive(mismatch) {
+		t.Error("mismatched start time should read as not alive")
+	}
+
+	// Unknown (0) start time: the check is skipped, preserving prior behavior.
+	unknown := base
+	unknown.StartTimeTicks = 0
+	if !m.processAlive(unknown) {
+		t.Error("zero start time should skip the check and read as alive")
+	}
+}
+
+func TestReadStartTimeTicks(t *testing.T) {
+	// Our own pid has a readable, non-zero start time.
+	got, ok := readStartTimeTicks(os.Getpid())
+	if !ok || got == 0 {
+		t.Fatalf("readStartTimeTicks(self) = %d,%v, want non-zero,true", got, ok)
+	}
+	// A pid that cannot exist yields (0, false), not a panic or a misread.
+	if v, ok := readStartTimeTicks(1 << 30); ok || v != 0 {
+		t.Errorf("readStartTimeTicks(bogus) = %d,%v, want 0,false", v, ok)
 	}
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -3,6 +3,7 @@
 package manager
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -26,7 +27,13 @@ type Manager struct {
 	// Timing for the fresh-run conversation-id capture and the restored-job
 	// liveness watcher. Fields (not package globals) so tests stay isolated and can
 	// run in parallel. agy's conversation cache is flushed by a separate daemon that
-	// can lag the foreground agy exit, so the capture retries briefly.
+	// can lag the foreground agy exit, so the capture retries briefly. Verified
+	// against agy 1.0.6: agy rewrites last_conversations.json in place (O_TRUNC, no
+	// file lock), so a concurrent read can be torn; loadCache tolerates that (an
+	// unparsable read yields no capture) and this retry loop re-reads, so no mutex
+	// is needed. agy also ignores a caller-supplied fresh --conversation UUID and
+	// mints its own, which is why the id must be captured by diffing the cache
+	// rather than generated and passed in.
 	captureBudget        time.Duration
 	capturePoll          time.Duration
 	restoredPollInterval time.Duration
@@ -187,18 +194,33 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	if err := cmd.Start(); err != nil {
+		// No supervisor was spawned, so the just-created job dir is a never-started
+		// orphan; remove it now rather than leaving it for a later GarbageCollect.
+		_ = m.store.Remove(id)
 		m.gate.release(key)
 		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
 	}
-	// Record the supervisor PID (for liveness and cancel) with an atomic rewrite,
-	// so the just-spawned supervisor never reads a half-written meta.json.
+	// Record the supervisor PID (for liveness and cancel) and its start time (so a
+	// later process that recycles the same PID within this boot is not mistaken for
+	// the supervisor) with an atomic rewrite, so the just-spawned supervisor never
+	// reads a half-written meta.json.
 	meta.PID = cmd.Process.Pid
+	if ticks, ok := readStartTimeTicks(cmd.Process.Pid); ok {
+		meta.StartTimeTicks = ticks
+	}
 	if err := m.store.UpdateMeta(meta); err != nil {
 		// Without a persisted PID the supervisor would be untrackable
-		// (uncancellable, and reported as not-alive). Fail closed: terminate it.
+		// (uncancellable, and reported as not-alive). Fail closed: terminate it,
+		// then once it has fully exited (so nothing is still writing the job dir)
+		// remove the dir and release the gate. Releasing only after the agy process
+		// group is gone keeps a conflicting same-key run from starting while the
+		// dying agy still holds its session lock.
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-		go func() { _ = cmd.Wait() }()
-		m.gate.release(key)
+		go func() {
+			_ = cmd.Wait()
+			_ = m.store.Remove(id)
+			m.gate.release(key)
+		}()
 		return Job{}, fmt.Errorf("record supervisor pid: %w", err)
 	}
 	// Wait for the supervisor in the background. cmd.Wait returns exactly when
@@ -250,6 +272,53 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 		}
 	}
 	return removed, nil
+}
+
+// gcInterval returns how often a long-lived server should sweep finished jobs:
+// half the job TTL, so a finished job is collected within ~1.5x its TTL, floored
+// at one minute so a tiny configured TTL cannot spin the ticker. A non-positive
+// TTL returns 0, which disables periodic collection (matching GarbageCollect's
+// own JobTTL<=0 short-circuit).
+func gcInterval(ttl time.Duration) time.Duration {
+	if ttl <= 0 {
+		return 0
+	}
+	if d := ttl / 2; d > time.Minute {
+		return d
+	}
+	return time.Minute
+}
+
+// RunPeriodicGCFromConfig runs periodic GC using the sweep interval derived from
+// the configured JobTTL (see gcInterval). It blocks until ctx is cancelled, so
+// callers run it in a goroutine; it is a no-op when JobTTL disables collection.
+func (m *Manager) RunPeriodicGCFromConfig(ctx context.Context) {
+	m.runPeriodicGC(ctx, gcInterval(m.cfg.JobTTL))
+}
+
+// runPeriodicGC sweeps finished jobs every interval until ctx is cancelled, so a
+// long-running HTTP daemon does not accumulate finished job dirs between restarts.
+// It reuses GarbageCollect, which never removes a still-alive job, so the ticker
+// inherits that safety. It blocks; callers run it in a goroutine. A non-positive
+// interval is a no-op.
+func (m *Manager) runPeriodicGC(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if removed, err := m.GarbageCollect(); err != nil {
+				log.Printf("agy-mcp: periodic GC: %v", err)
+			} else if len(removed) > 0 {
+				log.Printf("agy-mcp: periodic GC removed %d expired job(s)", len(removed))
+			}
+		}
+	}
 }
 
 // reqFromMeta reconstructs the parts of a StartRequest that determine a job's

--- a/main.go
+++ b/main.go
@@ -70,6 +70,11 @@ func serve() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// Sweep finished jobs periodically, not just at startup, so a long-lived daemon
+	// (especially HTTP serve mode) does not accumulate finished job dirs until the
+	// next restart. Stops when ctx is cancelled on shutdown; no-op if JobTTL<=0.
+	go mgr.RunPeriodicGCFromConfig(ctx)
+
 	if *httpAddr != "" {
 		if err := checkLoopbackAddr(*httpAddr); err != nil {
 			return err


### PR DESCRIPTION
## Summary

PR1 of a batch addressing the open issues. It hardens the job manager and supervisor lifecycle. All changes are additive and backward compatible with on-disk job state from the prior binary.

- **#10 (bug): remove the job directory on StartJob failure.** On a spawn failure the dir is removed synchronously (no supervisor exists). On a post-spawn `UpdateMeta` failure the supervisor is terminated and the dir is removed plus the gate released only after `cmd.Wait()` returns, so no writer races the delete and a conflicting same-key run cannot start while the dying agy still holds its session lock.
- **#9: run GarbageCollect periodically.** A ticker (`JobTTL/2`, floored at 1m) sweeps finished jobs while serving and stops on shutdown, instead of only at startup, so a long-lived HTTP daemon no longer accumulates finished job dirs between restarts.
- **#8: harden liveness against same-boot PID recycling.** `processAlive` now correlates `/proc/<pid>/stat` start time against the value recorded at spawn. The check is fail-safe: a zero recorded value (older meta or unreadable `/proc`) or a transient read failure skips it, so a live supervisor is never read as dead.

### Bonus robustness fixes (found by the pre-push gate review, same files)

- `jobstore.Create` removes the job dir if `meta.json` cannot be written, so a failed create leaves no orphan dir (GarbageCollect skips dirs whose `meta.json` will not load).
- `jobstore.UpdateMeta` fsyncs the temp file before the atomic rename, so a crash cannot leave a renamed but zero-length `meta.json`.

### #4 verification (live probe of agy 1.0.6)

Verified and recorded as a code comment: `--print-timeout` takes Go duration strings (no change needed); agy rewrites its conversation cache non-atomically and unlocked, so the existing retry loop that tolerates torn reads is correct and no mutex is needed; agy mints its own conversation UUID and ignores a caller-supplied one, so the snapshot-diff capture must stay.

## Related Issues

Fixes #8
Fixes #9
Fixes #10
Relates to #4 (verified)
Follow-up test gap: #12

## Test Plan

- [x] `go build ./...`, `go vet ./...`
- [x] `golangci-lint run` (0 issues)
- [x] `go test ./... -race` (all packages pass)
- [x] New tests watched fail before implementing: meta round-trip + legacy-load-as-0, `/proc` stat parser (adversarial comm), `processAlive` match/mismatch/zero, StartJob orphan cleanup, `gcInterval` + periodic GC collect/stop, Create cleanup on write failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic periodic cleanup of finished jobs during long-running server operations, configurable via job TTL settings.

* **Bug Fixes**
  * Improved reliability of job directory cleanup when metadata operations or supervisor startup fail.
  * Enhanced process liveness detection to prevent PID recycling from causing incorrect job identification.
  * Ensured metadata is properly synchronized to disk before replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->