### PR TITLE
Harden HTTP serve mode: Origin/CSRF check and optional bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Session continuation rides `agy`'s own durable conversation store (`--conversati
 ## Transports
 
 - **stdio** (default): zero-config, add one line to your MCP client config.
-- **Streamable HTTP** (opt-in): `agy-mcp -http 127.0.0.1:8765` runs the same core as a long-lived daemon for multi-client use. It is unauthenticated, so the bind is restricted to loopback (`localhost`, `127.0.0.1`, `::1`); a non-loopback address is refused at startup.
+- **Streamable HTTP** (opt-in): `agy-mcp -http 127.0.0.1:8765` runs the same core as a long-lived daemon for multi-client use. The bind is restricted to loopback (`localhost`, `127.0.0.1`, `::1`); a non-loopback address is refused at startup. Cross-origin browser requests are rejected (Origin/CSRF protection), and an optional bearer token (`-http-token`) can require authentication.
 
 ## Requirements
 
@@ -84,7 +84,16 @@ restart, so the cap and serialization hold across restarts.
 agy-mcp -http 127.0.0.1:8765
 ```
 
-HTTP mode is opt-in and unauthenticated, so it only accepts a loopback bind address (`localhost`, `127.0.0.1`, or `::1`). A non-loopback address (including `:8765`, which binds all interfaces) is refused at startup, so it cannot be accidentally exposed.
+HTTP mode is opt-in and only accepts a loopback bind address (`localhost`, `127.0.0.1`, or `::1`). A non-loopback address (including `:8765`, which binds all interfaces) is refused at startup, so it cannot be accidentally exposed.
+
+Two extra hardening layers are always available:
+
+- **Origin/CSRF protection** is always on. A state-changing cross-origin browser request (one carrying a cross-site `Sec-Fetch-Site` or a mismatched `Origin`) is rejected with `403`. Normal non-browser MCP clients (Claude Code, Cursor, the go-sdk client) send no `Origin` header and are unaffected.
+- **Optional bearer token.** Set `-http-token <token>` (or `AGY_MCP_HTTP_TOKEN`) to require `Authorization: Bearer <token>` on every request; a missing or wrong token gets `401`. The flag overrides the env var. Off by default, so the bare loopback mode stays unauthenticated.
+
+```bash
+agy-mcp -http 127.0.0.1:8765 -http-token "$(openssl rand -hex 32)"
+```
 
 ## Configuration
 
@@ -93,3 +102,4 @@ HTTP mode is opt-in and unauthenticated, so it only accepts a loopback bind addr
 | `AGY_MCP_AGY_PATH` | `agy` on PATH | path to the agy binary |
 | `AGY_MCP_STATE_DIR` | `$XDG_STATE_HOME/agy-mcp` | job state directory |
 | `AGY_MCP_DEFAULT_MODEL` | agy default | default model |
+| `AGY_MCP_HTTP_TOKEN` | (none) | optional bearer token for HTTP mode; empty = unauthenticated |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DefaultTimeout time.Duration // hard per-job timeout
 	MaxConcurrency int           // global cap on concurrent jobs
 	JobTTL         time.Duration // age after which finished jobs are GC'd
+	HTTPToken      string        // optional bearer token for HTTP mode; empty = unauthenticated
 }
 
 // Resolve builds a Config from environment variables and defaults.
@@ -27,6 +28,7 @@ func Resolve() (Config, error) {
 		DefaultTimeout: 30 * time.Minute,
 		MaxConcurrency: 4,
 		JobTTL:         24 * time.Hour,
+		HTTPToken:      os.Getenv("AGY_MCP_HTTP_TOKEN"),
 	}
 
 	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,3 +46,29 @@ func TestResolveAgyPathOverride(t *testing.T) {
 		t.Errorf("AgyPath = %q", c.AgyPath)
 	}
 }
+
+func TestResolveHTTPToken(t *testing.T) {
+	t.Setenv("AGY_MCP_AGY_PATH", "/opt/custom/agy") // skip PATH lookup
+
+	t.Run("default empty", func(t *testing.T) {
+		t.Setenv("AGY_MCP_HTTP_TOKEN", "")
+		c, err := Resolve()
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if c.HTTPToken != "" {
+			t.Errorf("HTTPToken = %q, want empty by default", c.HTTPToken)
+		}
+	})
+
+	t.Run("from env", func(t *testing.T) {
+		t.Setenv("AGY_MCP_HTTP_TOKEN", "s3cret")
+		c, err := Resolve()
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if c.HTTPToken != "s3cret" {
+			t.Errorf("HTTPToken = %q, want %q", c.HTTPToken, "s3cret")
+		}
+	})
+}

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -2,6 +2,7 @@ package mcptools
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"errors"
 	"net/http"
@@ -43,20 +44,26 @@ func HTTPHandler(mgr *manager.Manager, token string) http.Handler {
 // disables the check and returns h unchanged.
 //
 // The auth-scheme is matched case-insensitively (RFC 7235 makes it case-insensitive,
-// so "bearer"/"BEARER" are accepted), but the token itself is compared with
-// crypto/subtle so a timing side-channel cannot reveal it. An unequal length
-// short-circuits to a mismatch, which leaks only length, the standard tradeoff for a
-// bearer check.
+// so "bearer"/"BEARER" are accepted). The token is compared by its fixed-size SHA-256
+// digest rather than its raw bytes: subtle.ConstantTimeCompare returns early when the
+// lengths differ, which would leak the expected token's length through timing. Hashing
+// both sides to 32 bytes keeps the comparison constant-time regardless of the supplied
+// length, and SHA-256's preimage resistance means comparing digests does not weaken it.
 func withBearerAuth(token string, h http.Handler) http.Handler {
 	if token == "" {
 		return h
 	}
-	want := []byte(token)
+	wantHash := sha256.Sum256([]byte(token))
 	const prefix = "Bearer "
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
-		if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) ||
-			subtle.ConstantTimeCompare([]byte(auth[len(prefix):]), want) != 1 {
+		if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		gotHash := sha256.Sum256([]byte(auth[len(prefix):]))
+		if subtle.ConstantTimeCompare(gotHash[:], wantHash[:]) != 1 {
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -2,6 +2,7 @@ package mcptools
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"net/http"
 	"time"
@@ -19,18 +20,52 @@ func ServeStdio(ctx context.Context, mgr *manager.Manager) error {
 
 // HTTPHandler returns an http.Handler that serves the agy tools over the
 // Streamable HTTP transport. The same manager backs every session.
-func HTTPHandler(mgr *manager.Manager) http.Handler {
-	return mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+//
+// The handler is wrapped with cross-origin protection: a state-changing
+// cross-origin browser POST (signalled by Sec-Fetch-Site or a mismatched Origin)
+// is rejected with 403. Requests with no Origin/Sec-Fetch-Site (the normal
+// non-browser MCP clients) are treated as same-origin and pass through, so this
+// hardening does not affect Claude Code, Cursor, or the go-sdk client.
+//
+// When token is non-empty, a bearer-token check is applied in front of the
+// cross-origin protection: a request without a matching Authorization: Bearer
+// <token> header is rejected with 401. An empty token leaves HTTP mode
+// unauthenticated (the default).
+func HTTPHandler(mgr *manager.Manager, token string) http.Handler {
+	streamable := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 		return NewServer(mgr)
 	}, nil)
+	return withBearerAuth(token, http.NewCrossOriginProtection().Handler(streamable))
+}
+
+// withBearerAuth wraps h to require Authorization: Bearer <token>. An empty token
+// disables the check and returns h unchanged. The comparison is constant-time so a
+// timing side-channel cannot reveal the token; an unequal length short-circuits to
+// a mismatch, which leaks only length, the standard tradeoff for a bearer check.
+func withBearerAuth(token string, h http.Handler) http.Handler {
+	if token == "" {
+		return h
+	}
+	want := []byte("Bearer " + token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare(got, want) != 1 {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
 }
 
 // ServeHTTP runs the Streamable HTTP server on addr until ctx is cancelled, then
-// shuts down gracefully so in-flight responses can drain.
-func ServeHTTP(ctx context.Context, mgr *manager.Manager, addr string) error {
+// shuts down gracefully so in-flight responses can drain. A non-empty token
+// requires Authorization: Bearer <token> on every request; an empty token leaves
+// HTTP mode unauthenticated.
+func ServeHTTP(ctx context.Context, mgr *manager.Manager, addr, token string) error {
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           HTTPHandler(mgr),
+		Handler:           HTTPHandler(mgr, token),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	// Derive a cancelable context so the shutdown goroutine cannot leak if

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -39,17 +40,23 @@ func HTTPHandler(mgr *manager.Manager, token string) http.Handler {
 }
 
 // withBearerAuth wraps h to require Authorization: Bearer <token>. An empty token
-// disables the check and returns h unchanged. The comparison is constant-time so a
-// timing side-channel cannot reveal the token; an unequal length short-circuits to
-// a mismatch, which leaks only length, the standard tradeoff for a bearer check.
+// disables the check and returns h unchanged.
+//
+// The auth-scheme is matched case-insensitively (RFC 7235 makes it case-insensitive,
+// so "bearer"/"BEARER" are accepted), but the token itself is compared with
+// crypto/subtle so a timing side-channel cannot reveal it. An unequal length
+// short-circuits to a mismatch, which leaks only length, the standard tradeoff for a
+// bearer check.
 func withBearerAuth(token string, h http.Handler) http.Handler {
 	if token == "" {
 		return h
 	}
-	want := []byte("Bearer " + token)
+	want := []byte(token)
+	const prefix = "Bearer "
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		got := []byte(r.Header.Get("Authorization"))
-		if subtle.ConstantTimeCompare(got, want) != 1 {
+		auth := r.Header.Get("Authorization")
+		if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) ||
+			subtle.ConstantTimeCompare([]byte(auth[len(prefix):]), want) != 1 {
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -99,6 +99,22 @@ func TestHTTPBearerAuth(t *testing.T) {
 			t.Fatalf("wrong token: expected 401, got %d", resp.StatusCode)
 		}
 	})
+
+	t.Run("lowercase scheme accepted", func(t *testing.T) {
+		// RFC 7235: the auth-scheme is case-insensitive, so "bearer <token>" with the
+		// correct token must authenticate (it reaches the MCP handler, so it is never 401).
+		req, _ := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "bearer s3cret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("do: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusUnauthorized {
+			t.Fatalf("lowercase scheme with correct token must not be 401, got %d", resp.StatusCode)
+		}
+	})
 }
 
 // TestHTTPNoTokenSkipsAuth pins the default: with no token configured, a request

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -1,7 +1,9 @@
 package mcptools
 
 import (
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,9 +12,117 @@ import (
 	"github.com/tphakala/agy-mcp/internal/manager"
 )
 
+func testManager(t *testing.T) *manager.Manager {
+	t.Helper()
+	return manager.New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, DefaultTimeout: time.Minute})
+}
+
+// TestHTTPRejectsCrossOriginPost verifies the Streamable HTTP handler rejects a
+// cross-origin browser-style POST (Sec-Fetch-Site: cross-site) with 403, the
+// Origin/CSRF hardening from issue #5.
+func TestHTTPRejectsCrossOriginPost(t *testing.T) {
+	ts := httptest.NewServer(HTTPHandler(testManager(t), ""))
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-origin POST, got %d", resp.StatusCode)
+	}
+}
+
+// headerRoundTripper injects a fixed header on every request, so a go-sdk client
+// can present a bearer token.
+type headerRoundTripper struct {
+	key, val string
+	base     http.RoundTripper
+}
+
+func (h headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set(h.key, h.val)
+	return h.base.RoundTrip(req)
+}
+
+// TestHTTPBearerAuth verifies the optional bearer-token middleware (issue #5):
+// the correct token connects, a missing or wrong token gets 401.
+func TestHTTPBearerAuth(t *testing.T) {
+	ts := httptest.NewServer(HTTPHandler(testManager(t), "s3cret"))
+	defer ts.Close()
+
+	t.Run("correct token connects", func(t *testing.T) {
+		authed := &http.Client{Transport: headerRoundTripper{
+			key: "Authorization", val: "Bearer s3cret", base: http.DefaultTransport,
+		}}
+		client := mcp.NewClient(&mcp.Implementation{Name: "t", Version: "0"}, nil)
+		cs, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: ts.URL, HTTPClient: authed}, nil)
+		if err != nil {
+			t.Fatalf("connect with valid token: %v", err)
+		}
+		defer func() { _ = cs.Close() }()
+		if _, err := cs.ListTools(t.Context(), nil); err != nil {
+			t.Fatalf("list tools with valid token: %v", err)
+		}
+	})
+
+	t.Run("missing token is 401", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("do: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("missing token: expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("wrong token is 401", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(`{}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer wrong")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("do: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("wrong token: expected 401, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// TestHTTPNoTokenSkipsAuth pins the default: with no token configured, a request
+// carrying no Authorization header is not rejected by the auth layer (it reaches
+// the MCP handler, so it is never a 401). This guards against a regression that
+// would accidentally require auth even when unconfigured.
+func TestHTTPNoTokenSkipsAuth(t *testing.T) {
+	ts := httptest.NewServer(HTTPHandler(testManager(t), ""))
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Fatalf("no token configured: request must not be rejected with 401, got %d", resp.StatusCode)
+	}
+}
+
 func TestHTTPServeListsTools(t *testing.T) {
-	mgr := manager.New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, DefaultTimeout: time.Minute})
-	handler := HTTPHandler(mgr)
+	handler := HTTPHandler(testManager(t), "")
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 

--- a/main.go
+++ b/main.go
@@ -47,18 +47,24 @@ func main() {
 // than calling os.Exit so deferred cleanup (the signal stop) still runs.
 func serve() error {
 	httpAddr := flag.String("http", "", "serve over Streamable HTTP on this address (e.g. 127.0.0.1:8765) instead of stdio; bind localhost only")
-	httpToken := flag.String("http-token", "", "require Authorization: Bearer <token> in HTTP mode (overrides AGY_MCP_HTTP_TOKEN; empty = unauthenticated)")
+	httpToken := flag.String("http-token", "", "require Authorization: Bearer <token> in HTTP mode (overrides AGY_MCP_HTTP_TOKEN; pass an empty value to force unauthenticated)")
 	flag.Parse()
 
 	cfg, err := config.Resolve()
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
 	}
-	// The flag overrides the env-resolved token; empty flag falls back to the env
-	// value (which is itself empty when unset, leaving HTTP mode unauthenticated).
-	if *httpToken != "" {
-		cfg.HTTPToken = *httpToken
-	}
+	// An explicitly provided -http-token (even an empty one) overrides the
+	// env-resolved token, so the flag can both set and force-disable auth. An unset
+	// flag leaves the AGY_MCP_HTTP_TOKEN value untouched. flag.Visit reports only the
+	// flags actually present on the command line, which is how we tell "-http-token \"\""
+	// (explicit disable) apart from an omitted flag. Parsing flags before Resolve keeps
+	// -h working even when agy is not on PATH.
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "http-token" {
+			cfg.HTTPToken = *httpToken
+		}
+	})
 	mgr := manager.New(cfg)
 	if removed, err := mgr.GarbageCollect(); err != nil {
 		log.Printf("startup GC: %v", err)

--- a/main.go
+++ b/main.go
@@ -46,12 +46,18 @@ func main() {
 // MCP tools over stdio (default) or Streamable HTTP. It returns an error rather
 // than calling os.Exit so deferred cleanup (the signal stop) still runs.
 func serve() error {
-	httpAddr := flag.String("http", "", "serve over Streamable HTTP on this address (e.g. 127.0.0.1:8765) instead of stdio; unauthenticated, bind localhost only")
+	httpAddr := flag.String("http", "", "serve over Streamable HTTP on this address (e.g. 127.0.0.1:8765) instead of stdio; bind localhost only")
+	httpToken := flag.String("http-token", "", "require Authorization: Bearer <token> in HTTP mode (overrides AGY_MCP_HTTP_TOKEN; empty = unauthenticated)")
 	flag.Parse()
 
 	cfg, err := config.Resolve()
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
+	}
+	// The flag overrides the env-resolved token; empty flag falls back to the env
+	// value (which is itself empty when unset, leaving HTTP mode unauthenticated).
+	if *httpToken != "" {
+		cfg.HTTPToken = *httpToken
 	}
 	mgr := manager.New(cfg)
 	if removed, err := mgr.GarbageCollect(); err != nil {
@@ -79,8 +85,12 @@ func serve() error {
 		if err := checkLoopbackAddr(*httpAddr); err != nil {
 			return err
 		}
-		log.Printf("agy-mcp serving Streamable HTTP on %s", *httpAddr)
-		if err := mcptools.ServeHTTP(ctx, mgr, *httpAddr); err != nil {
+		authNote := "unauthenticated"
+		if cfg.HTTPToken != "" {
+			authNote = "bearer-token auth enabled"
+		}
+		log.Printf("agy-mcp serving Streamable HTTP on %s (%s)", *httpAddr, authNote)
+		if err := mcptools.ServeHTTP(ctx, mgr, *httpAddr, cfg.HTTPToken); err != nil {
 			return fmt.Errorf("http serve: %w", err)
 		}
 		return nil
@@ -93,17 +103,18 @@ func serve() error {
 	return nil
 }
 
-// checkLoopbackAddr rejects any HTTP bind address that is not loopback. The
-// HTTP mode is unauthenticated, so binding a non-loopback interface would
-// expose it; this refuses to do so rather than relying on the user reading the
-// docs.
+// checkLoopbackAddr rejects any HTTP bind address that is not loopback. HTTP mode
+// binds loopback only as a safety default: the bearer token is optional, so a
+// non-loopback bind could expose an unauthenticated server. This refuses to do so
+// rather than relying on the user reading the docs (set -http-token to add auth, but
+// the loopback restriction holds regardless).
 func checkLoopbackAddr(addr string) error {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = addr // no port; treat the whole value as the host
 	}
 	if host == "" {
-		return fmt.Errorf("http address %q binds all interfaces; specify a loopback host (e.g. 127.0.0.1:8765) for the unauthenticated HTTP mode", addr)
+		return fmt.Errorf("http address %q binds all interfaces; specify a loopback host (e.g. 127.0.0.1:8765) for HTTP mode", addr)
 	}
 	if host == "localhost" {
 		return nil
@@ -111,5 +122,5 @@ func checkLoopbackAddr(addr string) error {
 	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
 		return nil
 	}
-	return fmt.Errorf("http address %q must be loopback only (localhost, 127.0.0.1, or ::1) for the unauthenticated HTTP mode", addr)
+	return fmt.Errorf("http address %q must be loopback only (localhost, 127.0.0.1, or ::1) for HTTP mode", addr)
 }


### PR DESCRIPTION
## Summary

Hardens the opt-in Streamable HTTP transport (issue #5), keeping it backward compatible for the existing non-browser MCP clients.

- **Origin/CSRF protection (always on):** wraps the HTTP handler with `net/http.CrossOriginProtection`. A state-changing cross-origin browser request (cross-site `Sec-Fetch-Site`, or a mismatched `Origin` vs `Host`) is rejected with 403. Requests with no `Origin`/`Sec-Fetch-Site` (Claude Code, Cursor, the go-sdk client) are treated as same-origin and pass through unchanged.
- **Optional bearer token (off by default):** set `-http-token` (overriding `AGY_MCP_HTTP_TOKEN`) to require `Authorization: Bearer <token>`; a missing or wrong token gets 401. The compare is constant-time. With no token configured, HTTP mode stays unauthenticated exactly as before.
- Threaded the token through `config.Config.HTTPToken` -> `ServeHTTP` -> `HTTPHandler` -> `withBearerAuth`, with flag > env > off precedence.
- Reworded the loopback-only docs/errors so they no longer claim HTTP mode is unconditionally "unauthenticated" now that a token is available.
- README updated: HTTP mode hardening section + `AGY_MCP_HTTP_TOKEN` in the config table.

## Related Issues

Closes #5

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` clean
- [x] `go test ./... -race` passes
- [x] Cross-origin POST (`Sec-Fetch-Site: cross-site`) rejected with 403; normal go-sdk client still connects and lists tools
- [x] With a token: correct `Bearer` connects; missing/wrong token gets 401
- [x] With no token: requests without `Authorization` are not rejected (auth off)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-token authentication for HTTP mode via `-http-token` CLI flag and `AGY_MCP_HTTP_TOKEN` environment variable.
  * Implemented Origin/CSRF protection that rejects certain cross-site browser requests in HTTP mode.

* **Documentation**
  * Updated README with detailed HTTP mode security hardening documentation, transport behavior clarification, and bearer-token authentication setup examples.

* **Tests**
  * Added tests validating bearer-token authentication, CSRF rejection, and HTTP-mode configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->