### PR TITLE
Add agy_run_sync convenience tool with progress notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Driving `agy` from a shell for automation has two recurring problems:
 ## What it provides
 
 - `agy_run` / `agy_status` / `agy_cancel`: start an `agy` prompt, poll for completion, cancel if needed.
+- `agy_run_sync`: start a prompt and wait for it inline (bounded, with MCP progress notifications); returns the `job_id` to poll if it outlives the wait cap.
 - `list_models`: enumerate available `agy` models.
 - `list_sessions`: list known conversations so review threads can be continued.
 
@@ -28,7 +29,7 @@ Session continuation rides `agy`'s own durable conversation store (`--conversati
 
 ## Requirements
 
-- The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_status` / `agy_cancel`) relies on process groups, `/proc`, and the kernel boot id, so it runs on Linux only; on macOS and Windows those tools return a clear "job supervision is only supported on Linux" error, while stdio/HTTP serving, `list_models`, and `list_sessions` work everywhere.
+- The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) relies on process groups, `/proc`, and the kernel boot id, so it runs on Linux only; on macOS and Windows those tools return a clear "job supervision is only supported on Linux" error, while stdio/HTTP serving, `list_models`, and `list_sessions` work everywhere.
 - The `agy` binary on `PATH` (or configured explicitly).
 - Go 1.26+ to build.
 
@@ -63,6 +64,7 @@ Or add to your MCP client config:
 ## Tools
 
 - `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?)` -> `{ job_id, conversation_id, state }`
+- `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`
 - `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id? }`
 - `agy_cancel(job_id)` -> `{ state }`
 - `list_models()` -> `{ models }`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Or add to your MCP client config:
 
 ## Tools
 
-- `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?)` -> `{ job_id, conversation_id, state }`
+- `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?)` -> `{ job_id, conversation_id?, state }`
 - `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`
 - `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id? }`
 - `agy_cancel(job_id)` -> `{ state }`

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -38,26 +38,26 @@ func (m *Manager) processAlive(meta jobstore.Meta) bool {
 	if err := syscall.Kill(meta.PID, 0); err != nil {
 		return false
 	}
-	// Defense in depth: confirm the process is still our supervisor by name.
+	// A matching (boot id, pid, starttime) triple uniquely pins the process:
+	// starttime is set at fork and survives exec, and was recorded right after
+	// cmd.Start while the PID was unreapable. When the recorded ticks are
+	// readable they are authoritative liveness, and the comm check must NOT
+	// run: in the fork-to-exec window comm is inherited from the parent (or is
+	// briefly the script interpreter's), so requiring the supervisor name there
+	// would misread a just-spawned live job as dead. A successful read that
+	// mismatches proves same-boot PID recycling.
+	if meta.StartTimeTicks != 0 {
+		if cur, ok := readStartTimeTicks(meta.PID); ok {
+			return cur == meta.StartTimeTicks
+		}
+	}
+	// Fallback (no recorded starttime in older meta, or a transient stat read
+	// failure): confirm the process is still our supervisor by name.
 	comm, err := os.ReadFile("/proc/" + strconv.Itoa(meta.PID) + "/comm")
 	if err != nil {
 		return false
 	}
-	name := strings.TrimSpace(string(comm))
-	if name != expectedComm(m.cfg.SupervisorExe) {
-		return false
-	}
-	// Same-boot PID recycling: a recycled PID may pass the comm check if the new
-	// process is also an agy-mcp. The start time pins identity to this exact
-	// process. Only a successful read that mismatches proves recycling; a recorded
-	// zero (older meta, or an unreadable /proc at spawn) or a transient read failure
-	// here skips the check, so a live job is never falsely read as dead.
-	if meta.StartTimeTicks != 0 {
-		if cur, ok := readStartTimeTicks(meta.PID); ok && cur != meta.StartTimeTicks {
-			return false
-		}
-	}
-	return true
+	return strings.TrimSpace(string(comm)) == expectedComm(m.cfg.SupervisorExe)
 }
 
 // readStartTimeTicks returns the process start time (field 22 of

--- a/internal/manager/liveness_linux_test.go
+++ b/internal/manager/liveness_linux_test.go
@@ -61,6 +61,15 @@ func TestProcessAliveStartTimeCheck(t *testing.T) {
 		t.Error("mismatched start time should read as not alive")
 	}
 
+	// A matching (boot id, pid, starttime) triple pins the exact process, so it
+	// must read as alive even when the comm does not match the supervisor name.
+	// This is the fork-to-exec window: comm is inherited from the parent (or is
+	// briefly the script interpreter's) before exec sets the final name.
+	wrongComm := New(config.Config{SupervisorExe: "/bogus/not-this-process", StateDir: t.TempDir(), MaxConcurrency: 4})
+	if !wrongComm.processAlive(match) {
+		t.Error("matching start time should be authoritative over a mismatched comm")
+	}
+
 	// Unknown (0) start time: the check is skipped, preserving prior behavior.
 	unknown := base
 	unknown.StartTimeTicks = 0

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -48,27 +48,19 @@ func (m *Manager) Status(id string) (Status, error) {
 	}
 
 	if code, ok := m.store.ExitCode(id); ok {
-		switch code {
-		case 0:
-			st.State = StateDone
-			st.Result = readFile(filepath.Join(dir, "out"))
-			st.ConversationID = m.lazyCaptureConversationID(meta)
-		case jobstore.ExitSIGTERM, jobstore.ExitSIGINT:
-			st.State = StateCancelled
-		case jobstore.ExitTimeout:
-			st.State = StateFailed
-			st.Error = "job exceeded its timeout and was terminated"
-		default:
-			st.State = StateFailed
-			st.Error = errorSummary(dir, code)
-		}
-		return st, nil
+		return m.statusFromExitCode(dir, meta, st, code), nil
 	}
 
 	// No sentinel: decide running vs interrupted.
 	if m.processAlive(meta) {
 		st.State = StateRunning
 		return st, nil
+	}
+	// The supervisor may have written the sentinel and exited between the two
+	// checks above; re-read once so a job that just finished normally is not
+	// misreported as interrupted.
+	if code, ok := m.store.ExitCode(id); ok {
+		return m.statusFromExitCode(dir, meta, st, code), nil
 	}
 	// Process is gone without a sentinel. If output was captured, recover it.
 	out := readFile(filepath.Join(dir, "out"))
@@ -81,6 +73,25 @@ func (m *Manager) Status(id string) (Status, error) {
 		st.Error = "job process exited without writing a result (interrupted)"
 	}
 	return st, nil
+}
+
+// statusFromExitCode fills st from a recorded exit-code sentinel.
+func (m *Manager) statusFromExitCode(dir string, meta jobstore.Meta, st Status, code int) Status {
+	switch code {
+	case 0:
+		st.State = StateDone
+		st.Result = readFile(filepath.Join(dir, "out"))
+		st.ConversationID = m.lazyCaptureConversationID(meta)
+	case jobstore.ExitSIGTERM, jobstore.ExitSIGINT:
+		st.State = StateCancelled
+	case jobstore.ExitTimeout:
+		st.State = StateFailed
+		st.Error = "job exceeded its timeout and was terminated"
+	default:
+		st.State = StateFailed
+		st.Error = errorSummary(dir, code)
+	}
+	return st
 }
 
 func readFile(p string) string {

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -82,7 +82,7 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 			}
 			// Notify once per elapsed second, not per poll tick: the message has
 			// whole-second granularity, so finer cadence is pure stream noise.
-			if sec := st.Elapsed.Round(time.Second); token != nil && sec != lastNotified {
+			if sec := st.Elapsed.Truncate(time.Second); token != nil && sec != lastNotified {
 				lastNotified = sec
 				// Best effort: the result, not the notifications, is the
 				// contract. The bounded context keeps a client that stopped

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -1,0 +1,107 @@
+package mcptools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+const (
+	// defaultSyncWait bounds how long agy_run_sync blocks when the caller
+	// does not say otherwise; quick models finish well inside it.
+	defaultSyncWait = 2 * time.Minute
+	// maxSyncWait caps caller-supplied waits so a tool call cannot park a
+	// session indefinitely; longer runs are for agy_run + agy_status.
+	maxSyncWait = 10 * time.Minute
+	// syncPollInterval is how often the wait loop re-reads job status and
+	// emits a progress notification. Status reads a few small files, so
+	// this is cheap.
+	syncPollInterval = 250 * time.Millisecond
+)
+
+// runSyncInput is runInput plus the inline wait cap.
+type runSyncInput struct {
+	runInput
+	Wait string `json:"wait,omitempty" jsonschema:"max time to wait inline (Go duration, default 2m, max 10m); on overrun the job keeps running and the job_id is returned for agy_status polling"`
+}
+
+type runSyncOutput struct {
+	JobID          string `json:"job_id"`
+	State          string `json:"state"`
+	Elapsed        string `json:"elapsed"`
+	Result         string `json:"result,omitempty"`
+	Error          string `json:"error,omitempty"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	Note           string `json:"note,omitempty"`
+}
+
+// registerRunSync adds the agy_run_sync tool: start a job, wait inline for it
+// (bounded), streaming progress notifications when the client asked for them.
+func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name: "agy_run_sync",
+		Description: "Start an agy prompt and wait for it inline (bounded by wait, default 2m). " +
+			"Sends MCP progress notifications while waiting. If the job outlives the wait cap " +
+			"it keeps running and the returned job_id can be polled with agy_status.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in runSyncInput) (*mcp.CallToolResult, runSyncOutput, error) {
+		wait := defaultSyncWait
+		if in.Wait != "" {
+			d, err := time.ParseDuration(in.Wait)
+			if err != nil || d <= 0 {
+				return nil, runSyncOutput{}, fmt.Errorf("invalid wait %q: want a positive Go duration like 90s", in.Wait)
+			}
+			wait = min(d, maxSyncWait)
+		}
+		startReq, err := in.toStartRequest()
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		job, err := mgr.StartJob(startReq)
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+
+		token := req.Params.GetProgressToken()
+		deadline := time.Now().Add(wait)
+		ticker := time.NewTicker(syncPollInterval)
+		defer ticker.Stop()
+		for {
+			st, err := mgr.Status(job.ID)
+			if err != nil {
+				return nil, runSyncOutput{}, fmt.Errorf("job %s started but status read failed: %w", job.ID, err)
+			}
+			out := runSyncOutput{
+				JobID: job.ID, State: st.State,
+				Elapsed:        st.Elapsed.Round(time.Second).String(),
+				Result:         st.Result,
+				Error:          st.Error,
+				ConversationID: st.ConversationID,
+			}
+			if st.State != manager.StateRunning {
+				return nil, out, nil
+			}
+			if time.Now().After(deadline) {
+				out.Note = "wait cap reached; the job is still running, poll it with agy_status"
+				return nil, out, nil
+			}
+			if token != nil {
+				// Best effort: the result, not the notifications, is the contract.
+				_ = req.Session.NotifyProgress(ctx, &mcp.ProgressNotificationParams{
+					ProgressToken: token,
+					Progress:      st.Elapsed.Seconds(),
+					Message:       fmt.Sprintf("job %s running (%s)", job.ID, st.Elapsed.Round(time.Second)),
+				})
+			}
+			select {
+			case <-ctx.Done():
+				// The client gave up on the call; the job stays alive under
+				// its detached supervisor for agy_status polling.
+				return nil, runSyncOutput{}, ctx.Err()
+			case <-ticker.C:
+			}
+		}
+	})
+}

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -29,13 +29,9 @@ type runSyncInput struct {
 }
 
 type runSyncOutput struct {
-	JobID          string `json:"job_id"`
-	State          string `json:"state"`
-	Elapsed        string `json:"elapsed"`
-	Result         string `json:"result,omitempty"`
-	Error          string `json:"error,omitempty"`
-	ConversationID string `json:"conversation_id,omitempty"`
-	Note           string `json:"note,omitempty"`
+	JobID string `json:"job_id"`
+	statusOutput
+	Note string `json:"note,omitempty"`
 }
 
 // registerRunSync adds the agy_run_sync tool: start a job, wait inline for it
@@ -68,18 +64,13 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 		deadline := time.Now().Add(wait)
 		ticker := time.NewTicker(syncPollInterval)
 		defer ticker.Stop()
+		lastNotified := time.Duration(-1)
 		for {
 			st, err := mgr.Status(job.ID)
 			if err != nil {
 				return nil, runSyncOutput{}, fmt.Errorf("job %s started but status read failed: %w", job.ID, err)
 			}
-			out := runSyncOutput{
-				JobID: job.ID, State: st.State,
-				Elapsed:        st.Elapsed.Round(time.Second).String(),
-				Result:         st.Result,
-				Error:          st.Error,
-				ConversationID: st.ConversationID,
-			}
+			out := runSyncOutput{JobID: job.ID, statusOutput: toStatusOutput(st)}
 			if st.State != manager.StateRunning {
 				return nil, out, nil
 			}
@@ -89,13 +80,20 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 				out.Note = "wait cap reached; the job is still running, poll it with agy_status"
 				return nil, out, nil
 			}
-			if token != nil {
-				// Best effort: the result, not the notifications, is the contract.
-				_ = req.Session.NotifyProgress(ctx, &mcp.ProgressNotificationParams{
+			// Notify once per elapsed second, not per poll tick: the message has
+			// whole-second granularity, so finer cadence is pure stream noise.
+			if sec := st.Elapsed.Round(time.Second); token != nil && sec != lastNotified {
+				lastNotified = sec
+				// Best effort: the result, not the notifications, is the
+				// contract. The bounded context keeps a client that stopped
+				// draining the stream from parking the loop past the wait cap.
+				nctx, ncancel := context.WithTimeout(ctx, syncPollInterval)
+				_ = req.Session.NotifyProgress(nctx, &mcp.ProgressNotificationParams{
 					ProgressToken: token,
 					Progress:      st.Elapsed.Seconds(),
-					Message:       fmt.Sprintf("job %s running (%s)", job.ID, st.Elapsed.Round(time.Second)),
+					Message:       fmt.Sprintf("job %s running (%s)", job.ID, sec),
 				})
+				ncancel()
 			}
 			select {
 			case <-ctx.Done():

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -100,8 +100,10 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 			select {
 			case <-ctx.Done():
 				// The client gave up on the call; the job stays alive under
-				// its detached supervisor for agy_status polling.
-				return nil, runSyncOutput{}, ctx.Err()
+				// its detached supervisor for agy_status polling. Carry the
+				// job id in the error so a gracefully-cancelling client can
+				// still find the job.
+				return nil, runSyncOutput{}, fmt.Errorf("wait cancelled; job %s is still running, poll it with agy_status: %w", job.ID, ctx.Err())
 			case <-ticker.C:
 			}
 		}

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -83,6 +83,8 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 			if st.State != manager.StateRunning {
 				return nil, out, nil
 			}
+			// The cap is approximate: the loop only observes the deadline on a
+			// poll tick, so a call can overshoot wait by up to syncPollInterval.
 			if time.Now().After(deadline) {
 				out.Note = "wait cap reached; the job is still running, poll it with agy_status"
 				return nil, out, nil

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -1,6 +1,8 @@
 package mcptools
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -114,4 +116,56 @@ func TestAgyRunSyncOverrunReturnsJobID(t *testing.T) {
 
 	// The overrun must not have cancelled the job: it finishes on its own.
 	waitForDone(t, mgr, jobID, "LATE OK", 15*time.Second)
+}
+
+func TestAgyRunSyncSendsProgress(t *testing.T) {
+	// One second spans several 250ms poll ticks, so at least one progress
+	// notification fires while the job runs.
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "SLOW OK", Exit: 0, SleepSecs: 1})
+
+	var mu sync.Mutex
+	var tokens []any
+	opts := &mcp.ClientOptions{
+		ProgressNotificationHandler: func(_ context.Context, r *mcp.ProgressNotificationClientRequest) {
+			mu.Lock()
+			tokens = append(tokens, r.Params.ProgressToken)
+			mu.Unlock()
+		},
+	}
+	cs := connect(t, mgr, opts)
+
+	params := &mcp.CallToolParams{
+		Name:      "agy_run_sync",
+		Arguments: map[string]any{"prompt": "review", "wait": "30s"},
+	}
+	params.SetProgressToken("tok-7")
+	res, err := cs.CallTool(t.Context(), params)
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
+	}
+	if sc := res.StructuredContent.(map[string]any); sc["state"] != "done" {
+		t.Fatalf("state = %v, want done", sc["state"])
+	}
+
+	// Notifications are one-way; give in-flight ones a moment to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(tokens)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(tokens) == 0 {
+		t.Fatal("no progress notifications received")
+	}
+	for _, tok := range tokens {
+		if tok != "tok-7" {
+			t.Fatalf("progress token = %v, want tok-7", tok)
+		}
+	}
 }

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -39,6 +39,30 @@ func newTestManager(t *testing.T, fake testutil.FakeAgy) (*manager.Manager, stri
 	return manager.New(c), stateDir
 }
 
+// waitForDone polls the manager directly until the job reports done with the
+// wanted result, or fails the test at the deadline.
+func waitForDone(t *testing.T, mgr *manager.Manager, jobID, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		st, err := mgr.Status(jobID)
+		if err != nil {
+			t.Fatalf("status: %v", err)
+		}
+		if st.State == manager.StateDone {
+			if st.Result != want {
+				t.Fatalf("result = %q, want %q", st.Result, want)
+			}
+			return
+		}
+		if st.State != manager.StateRunning {
+			t.Fatalf("job reached %q, want done", st.State)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("job did not reach done")
+}
+
 func TestAgyRunSyncCompletesInline(t *testing.T) {
 	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
 	cs := connect(t, mgr, nil)
@@ -60,4 +84,34 @@ func TestAgyRunSyncCompletesInline(t *testing.T) {
 	if id, _ := sc["job_id"].(string); id == "" {
 		t.Fatal("empty job id")
 	}
+}
+
+func TestAgyRunSyncOverrunReturnsJobID(t *testing.T) {
+	// The sleep must comfortably outlast the 100ms wait cap even on a stalled
+	// CI runner, or the job finishes before the cap and the running assertion
+	// flakes.
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "LATE OK", Exit: 0, SleepSecs: 5})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run_sync",
+		Arguments: map[string]any{"prompt": "review", "wait": "100ms"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
+	}
+	sc := res.StructuredContent.(map[string]any)
+	if sc["state"] != "running" {
+		t.Fatalf("state = %v, want running", sc["state"])
+	}
+	jobID, _ := sc["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+	if note, _ := sc["note"].(string); note == "" {
+		t.Fatal("expected an overrun note")
+	}
+
+	// The overrun must not have cancelled the job: it finishes on its own.
+	waitForDone(t, mgr, jobID, "LATE OK", 15*time.Second)
 }

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -1,0 +1,63 @@
+package mcptools
+
+import (
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// connect wires a NewServer(mgr) to a fresh client over in-memory transports
+// and returns the client session.
+func connect(t *testing.T, mgr *manager.Manager, opts *mcp.ClientOptions) *mcp.ClientSession {
+	t.Helper()
+	srv := NewServer(mgr)
+	ct, st := mcp.NewInMemoryTransports()
+	if _, err := srv.Connect(t.Context(), st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, opts)
+	cs, err := client.Connect(t.Context(), ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return cs
+}
+
+// newTestManager builds a manager around a fake agy and fake supervisor.
+func newTestManager(t *testing.T, fake testutil.FakeAgy) (*manager.Manager, string) {
+	t.Helper()
+	agy := testutil.WriteFakeAgy(t, fake)
+	sup := writeFakeSupervisor(t, agy)
+	stateDir := t.TempDir()
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4}
+	return manager.New(c), stateDir
+}
+
+func TestAgyRunSyncCompletesInline(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run_sync",
+		Arguments: map[string]any{"prompt": "review", "wait": "30s"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
+	}
+	sc := res.StructuredContent.(map[string]any)
+	if sc["state"] != "done" {
+		t.Fatalf("state = %v, want done", sc["state"])
+	}
+	if sc["result"] != "REVIEW OK" {
+		t.Fatalf("result = %v", sc["result"])
+	}
+	if id, _ := sc["job_id"].(string); id == "" {
+		t.Fatal("empty job id")
+	}
+}

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -2,6 +2,8 @@ package mcptools
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -168,4 +170,52 @@ func TestAgyRunSyncSendsProgress(t *testing.T) {
 			t.Fatalf("progress token = %v, want tok-7", tok)
 		}
 	}
+}
+
+func TestAgyRunSyncClientCancelKeepsJobAlive(t *testing.T) {
+	mgr, stateDir := newTestManager(t, testutil.FakeAgy{Stdout: "LATE OK", Exit: 0, SleepSecs: 5})
+	cs := connect(t, mgr, nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "agy_run_sync",
+			Arguments: map[string]any{"prompt": "review", "wait": "30s"},
+		})
+		done <- err
+	}()
+
+	// Wait until the job exists on disk, then cancel the call mid-wait.
+	jobID := waitForJobDir(t, stateDir, 5*time.Second)
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the cancelled call to return an error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled call did not return")
+	}
+
+	// Cancelling the call must not cancel the job.
+	waitForDone(t, mgr, jobID, "LATE OK", 15*time.Second)
+}
+
+// waitForJobDir polls <stateDir>/jobs until exactly one job directory exists
+// and returns its id.
+func waitForJobDir(t *testing.T, stateDir string, timeout time.Duration) string {
+	t.Helper()
+	jobs := filepath.Join(stateDir, "jobs")
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(jobs)
+		if err == nil && len(entries) == 1 && entries[0].IsDir() {
+			return entries[0].Name()
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("job directory did not appear")
+	return ""
 }

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -2,6 +2,7 @@ package mcptools
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -69,7 +70,18 @@ func waitForDone(t *testing.T, mgr *manager.Manager, jobID, want string, timeout
 
 func TestAgyRunSyncCompletesInline(t *testing.T) {
 	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
-	cs := connect(t, mgr, nil)
+
+	// No progress token is set on the call, so no notification may arrive.
+	var mu sync.Mutex
+	var notified int
+	opts := &mcp.ClientOptions{
+		ProgressNotificationHandler: func(_ context.Context, _ *mcp.ProgressNotificationClientRequest) {
+			mu.Lock()
+			notified++
+			mu.Unlock()
+		},
+	}
+	cs := connect(t, mgr, opts)
 
 	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "agy_run_sync",
@@ -87,6 +99,26 @@ func TestAgyRunSyncCompletesInline(t *testing.T) {
 	}
 	if id, _ := sc["job_id"].(string); id == "" {
 		t.Fatal("empty job id")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if notified != 0 {
+		t.Fatalf("got %d progress notifications without a progress token", notified)
+	}
+}
+
+func TestAgyRunSyncRejectsInvalidWait(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "x", Exit: 0})
+	cs := connect(t, mgr, nil)
+
+	for _, wait := range []string{"nope", "-1s", "0"} {
+		res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+			Name:      "agy_run_sync",
+			Arguments: map[string]any{"prompt": "review", "wait": wait},
+		})
+		if err == nil && !res.IsError {
+			t.Errorf("wait %q: expected an error, got %+v", wait, res.StructuredContent)
+		}
 	}
 }
 
@@ -187,13 +219,13 @@ func TestAgyRunSyncClientCancelKeepsJobAlive(t *testing.T) {
 		done <- err
 	}()
 
-	// Wait until the job exists on disk, then cancel the call mid-wait.
-	jobID := waitForJobDir(t, stateDir, 5*time.Second)
+	// Wait until the job is observably running, then cancel the call mid-wait.
+	jobID := waitForRunningJob(t, mgr, stateDir, 5*time.Second)
 	cancel()
 	select {
 	case err := <-done:
-		if err == nil {
-			t.Fatal("expected the cancelled call to return an error")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled call returned %v, want context.Canceled", err)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("cancelled call did not return")
@@ -203,19 +235,23 @@ func TestAgyRunSyncClientCancelKeepsJobAlive(t *testing.T) {
 	waitForDone(t, mgr, jobID, "LATE OK", 15*time.Second)
 }
 
-// waitForJobDir polls <stateDir>/jobs until exactly one job directory exists
-// and returns its id.
-func waitForJobDir(t *testing.T, stateDir string, timeout time.Duration) string {
+// waitForRunningJob polls <stateDir>/jobs until a job directory exists AND the
+// manager reports it running, then returns its id. Waiting for the directory
+// alone races StartJob's PID persistence: in that window Status reports a
+// transient "interrupted" failure for a perfectly healthy job.
+func waitForRunningJob(t *testing.T, mgr *manager.Manager, stateDir string, timeout time.Duration) string {
 	t.Helper()
 	jobs := filepath.Join(stateDir, "jobs")
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		entries, err := os.ReadDir(jobs)
-		if err == nil && len(entries) == 1 && entries[0].IsDir() {
-			return entries[0].Name()
+		if entries, err := os.ReadDir(jobs); err == nil && len(entries) == 1 && entries[0].IsDir() {
+			id := entries[0].Name()
+			if st, err := mgr.Status(id); err == nil && st.State == manager.StateRunning {
+				return id
+			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("job directory did not appear")
+	t.Fatal("job did not reach running")
 	return ""
 }

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -33,11 +33,11 @@ func connect(t *testing.T, mgr *manager.Manager, opts *mcp.ClientOptions) *mcp.C
 }
 
 // newTestManager builds a manager around a fake agy and fake supervisor.
-func newTestManager(t *testing.T, fake testutil.FakeAgy) (*manager.Manager, string) {
+func newTestManager(t *testing.T, fake testutil.FakeAgy) (mgr *manager.Manager, stateDir string) {
 	t.Helper()
 	agy := testutil.WriteFakeAgy(t, fake)
 	sup := writeFakeSupervisor(t, agy)
-	stateDir := t.TempDir()
+	stateDir = t.TempDir()
 	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
 		DefaultTimeout: time.Minute, MaxConcurrency: 4}
 	return manager.New(c), stateDir
@@ -79,7 +79,7 @@ func TestAgyRunSyncCompletesInline(t *testing.T) {
 		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
 	}
 	sc := res.StructuredContent.(map[string]any)
-	if sc["state"] != "done" {
+	if sc["state"] != manager.StateDone {
 		t.Fatalf("state = %v, want done", sc["state"])
 	}
 	if sc["result"] != "REVIEW OK" {
@@ -105,7 +105,7 @@ func TestAgyRunSyncOverrunReturnsJobID(t *testing.T) {
 		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
 	}
 	sc := res.StructuredContent.(map[string]any)
-	if sc["state"] != "running" {
+	if sc["state"] != manager.StateRunning {
 		t.Fatalf("state = %v, want running", sc["state"])
 	}
 	jobID, _ := sc["job_id"].(string)
@@ -145,7 +145,7 @@ func TestAgyRunSyncSendsProgress(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
 	}
-	if sc := res.StructuredContent.(map[string]any); sc["state"] != "done" {
+	if sc := res.StructuredContent.(map[string]any); sc["state"] != manager.StateDone {
 		t.Fatalf("state = %v, want done", sc["state"])
 	}
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -56,6 +56,18 @@ type statusOutput struct {
 	ConversationID string `json:"conversation_id,omitempty"`
 }
 
+// toStatusOutput converts a manager status into its wire shape, shared by
+// agy_status and agy_run_sync so the two cannot drift.
+func toStatusOutput(st manager.Status) statusOutput {
+	return statusOutput{
+		State:          st.State,
+		Elapsed:        st.Elapsed.Round(time.Second).String(),
+		Result:         st.Result,
+		Error:          st.Error,
+		ConversationID: st.ConversationID,
+	}
+}
+
 type cancelInput struct {
 	JobID string `json:"job_id" jsonschema:"the job id to cancel"`
 }
@@ -103,10 +115,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		if err != nil {
 			return nil, statusOutput{}, err
 		}
-		return nil, statusOutput{
-			State: st.State, Elapsed: st.Elapsed.Round(1e9).String(),
-			Result: st.Result, Error: st.Error, ConversationID: st.ConversationID,
-		}, nil
+		return nil, toStatusOutput(st), nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -21,6 +21,23 @@ type runInput struct {
 	Timeout        string   `json:"timeout,omitempty" jsonschema:"max run duration, e.g. 20m"`
 }
 
+// toStartRequest converts the wire input into a manager start request,
+// validating the timeout.
+func (in runInput) toStartRequest() (manager.StartRequest, error) {
+	req := manager.StartRequest{
+		Prompt: in.Prompt, Model: in.Model, Dirs: in.Dirs,
+		ConversationID: in.ConversationID, ContinueLatest: in.ContinueLatest, Cwd: in.Cwd,
+	}
+	if in.Timeout != "" {
+		d, err := time.ParseDuration(in.Timeout)
+		if err != nil {
+			return manager.StartRequest{}, fmt.Errorf("invalid timeout %q: %w", in.Timeout, err)
+		}
+		req.Timeout = d
+	}
+	return req, nil
+}
+
 type runOutput struct {
 	JobID          string `json:"job_id"`
 	ConversationID string `json:"conversation_id,omitempty"`
@@ -67,16 +84,9 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		Name:        "agy_run",
 		Description: "Start an agy prompt (e.g. a peer review) as an async job. Returns a job_id to poll with agy_status.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runInput) (*mcp.CallToolResult, runOutput, error) {
-		req := manager.StartRequest{
-			Prompt: in.Prompt, Model: in.Model, Dirs: in.Dirs,
-			ConversationID: in.ConversationID, ContinueLatest: in.ContinueLatest, Cwd: in.Cwd,
-		}
-		if in.Timeout != "" {
-			d, err := time.ParseDuration(in.Timeout)
-			if err != nil {
-				return nil, runOutput{}, fmt.Errorf("invalid timeout %q: %w", in.Timeout, err)
-			}
-			req.Timeout = d
+		req, err := in.toStartRequest()
+		if err != nil {
+			return nil, runOutput{}, err
 		}
 		job, err := mgr.StartJob(req)
 		if err != nil {

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -30,8 +30,8 @@ func (in runInput) toStartRequest() (manager.StartRequest, error) {
 	}
 	if in.Timeout != "" {
 		d, err := time.ParseDuration(in.Timeout)
-		if err != nil {
-			return manager.StartRequest{}, fmt.Errorf("invalid timeout %q: %w", in.Timeout, err)
+		if err != nil || d <= 0 {
+			return manager.StartRequest{}, fmt.Errorf("invalid timeout %q: want a positive Go duration like 20m", in.Timeout)
 		}
 		req.Timeout = d
 	}

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -124,6 +124,8 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		return nil, cancelOutput{State: state}, nil
 	})
 
+	registerRunSync(s, mgr)
+
 	mcp.AddTool(s, &mcp.Tool{
 		Name: "list_models", Description: "List available agy models.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ emptyInput) (*mcp.CallToolResult, modelsOutput, error) {

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -70,7 +70,7 @@ func TestAgyRunAndStatusOverMCP(t *testing.T) {
 			t.Fatal(err)
 		}
 		sc := s.StructuredContent.(map[string]any)
-		if sc["state"] == "done" {
+		if sc["state"] == manager.StateDone {
 			if sc["result"] != "REVIEW OK" {
 				t.Fatalf("result = %v", sc["result"])
 			}

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -15,9 +15,9 @@ func writeFakeSupervisor(t *testing.T, agy string) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "fake-sup")
 	// Mimics `agy-mcp run-job <dir>`: runs the fake agy, captures stdout to out,
-	// writes exit_code. Sets its comm to the script basename so the manager's
-	// liveness check (which compares /proc/<pid>/comm against the supervisor
-	// basename) sees it as alive while it runs, like the real supervisor.
+	// writes exit_code. Sets its comm to the script basename to stay faithful to
+	// the real supervisor for the liveness comm fallback (the primary liveness
+	// signal is the recorded starttime triple, which needs no help).
 	script := "#!/usr/bin/env bash\n" +
 		"printf '%s' \"${0##*/}\" > /proc/$$/comm\n" +
 		"dir=\"$2\"\n" +

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/manager"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
@@ -20,7 +19,7 @@ func writeFakeSupervisor(t *testing.T, agy string) string {
 	// liveness check (which compares /proc/<pid>/comm against the supervisor
 	// basename) sees it as alive while it runs, like the real supervisor.
 	script := "#!/usr/bin/env bash\n" +
-		"printf 'fake-sup' > /proc/$$/comm\n" +
+		"printf '%s' \"${0##*/}\" > /proc/$$/comm\n" +
 		"dir=\"$2\"\n" +
 		"\"" + agy + "\" -p x > \"$dir/out\" 2> \"$dir/err\"\n" +
 		"printf '%s' \"$?\" > \"$dir/exit_code\"\n"
@@ -31,24 +30,9 @@ func writeFakeSupervisor(t *testing.T, agy string) string {
 }
 
 func TestAgyRunAndStatusOverMCP(t *testing.T) {
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
-	sup := writeFakeSupervisor(t, agy)
-	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: t.TempDir(),
-		DefaultTimeout: time.Minute, MaxConcurrency: 4}
-	mgr := manager.New(c)
-
-	srv := NewServer(mgr)
-	ct, st := mcp.NewInMemoryTransports()
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
+	cs := connect(t, mgr, nil)
 	ctx := t.Context()
-	if _, err := srv.Connect(ctx, st, nil); err != nil { // server side
-		t.Fatalf("server connect: %v", err)
-	}
-	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, nil)
-	cs, err := client.Connect(ctx, ct, nil)
-	if err != nil {
-		t.Fatalf("client connect: %v", err)
-	}
-	defer func() { _ = cs.Close() }()
 
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "agy_run",

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -16,8 +16,11 @@ func writeFakeSupervisor(t *testing.T, agy string) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "fake-sup")
 	// Mimics `agy-mcp run-job <dir>`: runs the fake agy, captures stdout to out,
-	// writes exit_code.
+	// writes exit_code. Sets its comm to the script basename so the manager's
+	// liveness check (which compares /proc/<pid>/comm against the supervisor
+	// basename) sees it as alive while it runs, like the real supervisor.
 	script := "#!/usr/bin/env bash\n" +
+		"printf 'fake-sup' > /proc/$$/comm\n" +
 		"dir=\"$2\"\n" +
 		"\"" + agy + "\" -p x > \"$dir/out\" 2> \"$dir/err\"\n" +
 		"printf '%s' \"$?\" > \"$dir/exit_code\"\n"


### PR DESCRIPTION
## Summary

Implements the deferred `agy_run_sync` tool: start an agy prompt and wait for it inline, bounded by a wait cap, streaming MCP progress notifications while the job runs.

- `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, wait?)`: starts the job via the existing manager, then polls `Status` every 250ms. Returns the terminal result inline when the job finishes within `wait` (default 2m, max 10m), or `state: "running"` with the `job_id` and a note to poll `agy_status` when it overruns. The wait loop is wired to the tool call's context: a client cancelling the call exits the loop without cancelling the job (it stays alive under the detached supervisor).
- Progress notifications are sent only when the client supplies a progress token, once per elapsed second, with a bounded send context so a stalled client cannot park the loop past the cap.
- Shared `toStartRequest` (input) and `toStatusOutput` (output) helpers keep `agy_run`/`agy_status` and the new tool from drifting; `runSyncOutput` embeds `statusOutput`. Non-positive `timeout`/`wait` values are now rejected loudly.

Hardening that fell out of pre-merge review:

- `processAlive` now treats a matching (boot id, PID, starttime) triple as authoritative liveness, with the comm check demoted to a fallback for meta without recorded ticks. The comm-only check misread the fork-to-exec window (comm is inherited, then briefly the interpreter's) as a dead process, which `agy_run_sync` would have returned as a terminal `failed`.
- `Status` re-reads the exit-code sentinel once after liveness reports the supervisor dead, so a job finishing between the two checks is not misreported as interrupted.

Tests run over real in-memory MCP transports: inline completion, wait-cap overrun with job survival, progress-token correlation (and no-token suppression), invalid `wait` rejection, and client-cancel-keeps-job-alive (`context.Canceled` asserted). The bash fake supervisor now sets its comm to stay faithful to the real one for the fallback path.

## Related Issues

Closes #7

## Test Plan

- [x] `go test ./... -race` green; run_sync suite repeated 3x and the cancel test 10x without flakes
- [x] `go vet`, `golangci-lint run` clean; `GOOS=darwin`/`GOOS=windows` builds and darwin vet pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `agy_run_sync` tool to start AI prompts and wait inline for results with optional progress notifications.

**Improvements**
- Enhanced process liveness detection using start-time pinning for more reliable job identification.
- Clarified platform support: job supervision features are Linux-only; stdio serving and model listing work on all platforms.

**Tests**
- Added comprehensive test coverage for the new synchronous run tool and refactored test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->