### PR TITLE
Consolidate fake-supervisor test doubles into testutil (#16)

### DIFF
--- a/internal/manager/capture_linux_test.go
+++ b/internal/manager/capture_linux_test.go
@@ -9,32 +9,8 @@ import (
 
 	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
 )
-
-// fakeSupervisorWritingCache mimics `agy-mcp run-job <dir>`: it writes out and
-// exit_code like the plain fake supervisor, but also overwrites the agy
-// conversation cache with cacheJSON, simulating agy creating a new conversation
-// for the run's cwd. The cache write lands before exit_code, so it is on disk by
-// the time the supervisor exits and the manager's completion goroutine reads it.
-func fakeSupervisorWritingCache(t *testing.T, cachePath, cacheJSON string) string {
-	t.Helper()
-	dir := t.TempDir()
-	p := filepath.Join(dir, "fake-sup-cache")
-	payload := filepath.Join(dir, "cache-payload.json")
-	if err := os.WriteFile(payload, []byte(cacheJSON), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	script := fmt.Sprintf(`#!/usr/bin/env bash
-dir="$2"
-printf 'done' > "$dir/out"
-cat %q > %q
-printf '0' > "$dir/exit_code"
-`, payload, cachePath)
-	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return p
-}
 
 // A completed fresh run must report the conversation id agy created for it,
 // captured by diffing the conversation cache against the pre-run snapshot.
@@ -49,7 +25,9 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 
 	c := config.Config{
 		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  fakeSupervisorWritingCache(t, cachePath, fmt.Sprintf(`{%q:%q}`, cwd, newUUID)),
+		SupervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+			Out: "done", CachePath: cachePath, CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, newUUID),
+		}),
 		StateDir:       state,
 		DefaultTimeout: time.Minute,
 		MaxConcurrency: 4,
@@ -87,7 +65,7 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 // an empty conversation id and, crucially, still release its gate key after the
 // capture budget so a later same-cwd run is not blocked forever.
 // waitForExitCode blocks until the job has written its exit_code, the supervisor's last
-// write into the job dir. Its callers use the cache-less fakeSupervisor, which creates no
+// write into the job dir. Its callers use a cache-less testutil.WriteFakeSupervisor, which creates no
 // conversation, so no manager-side meta rewrite follows the exit; for them this is the
 // final write. A test that returns while a supervisor is still writing into a t.TempDir
 // StateDir races the TempDir RemoveAll cleanup.
@@ -113,7 +91,7 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 
 	c := config.Config{
 		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  fakeSupervisor(t), // writes out + exit 0, never touches the cache
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}), // writes out + exit 0, never touches the cache
 		StateDir:       state,
 		DefaultTimeout: time.Minute,
 		MaxConcurrency: 4,

--- a/internal/manager/cleanup_linux_test.go
+++ b/internal/manager/cleanup_linux_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
 // failUpdateStore wraps a real store but fails UpdateMeta whenever failUpdateMeta is
@@ -34,7 +35,7 @@ func TestStartJobCleansUpDirOnUpdateMetaFailure(t *testing.T) {
 	state := t.TempDir()
 	c := config.Config{
 		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  fakeSupervisor(t), // real: cmd.Start succeeds and a supervisor runs
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}), // real: cmd.Start succeeds and a supervisor runs
 		StateDir:       state,
 		DefaultTimeout: time.Minute,
 		MaxConcurrency: 1,

--- a/internal/manager/job_linux_test.go
+++ b/internal/manager/job_linux_test.go
@@ -1,35 +1,20 @@
 package manager
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/testutil"
 )
-
-// fakeSupervisor writes a script that mimics `agy-mcp run-job <dir>`:
-// it writes out="done" and exit_code=0 for the given job dir.
-func fakeSupervisor(t *testing.T) string {
-	t.Helper()
-	p := filepath.Join(t.TempDir(), "fake-sup")
-	script := "#!/usr/bin/env bash\n" +
-		"dir=\"$2\"\n" +
-		"printf 'done' > \"$dir/out\"\n" +
-		"printf '0' > \"$dir/exit_code\"\n"
-	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return p
-}
 
 func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 	state := t.TempDir()
 	c := config.Config{
 		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  fakeSupervisor(t),
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
 		StateDir:       state,
 		DefaultTimeout: time.Minute,
 		MaxConcurrency: 4,

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -37,7 +37,7 @@ func connect(t *testing.T, mgr *manager.Manager, opts *mcp.ClientOptions) *mcp.C
 func newTestManager(t *testing.T, fake testutil.FakeAgy) (mgr *manager.Manager, stateDir string) {
 	t.Helper()
 	agy := testutil.WriteFakeAgy(t, fake)
-	sup := writeFakeSupervisor(t, agy)
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy})
 	stateDir = t.TempDir()
 	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
 		DefaultTimeout: time.Minute, MaxConcurrency: 4}

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -1,8 +1,6 @@
 package mcptools
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,24 +8,6 @@ import (
 	"github.com/tphakala/agy-mcp/internal/manager"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
-
-func writeFakeSupervisor(t *testing.T, agy string) string {
-	t.Helper()
-	p := filepath.Join(t.TempDir(), "fake-sup")
-	// Mimics `agy-mcp run-job <dir>`: runs the fake agy, captures stdout to out,
-	// writes exit_code. Sets its comm to the script basename to stay faithful to
-	// the real supervisor for the liveness comm fallback (the primary liveness
-	// signal is the recorded starttime triple, which needs no help).
-	script := "#!/usr/bin/env bash\n" +
-		"printf '%s' \"${0##*/}\" > /proc/$$/comm\n" +
-		"dir=\"$2\"\n" +
-		"\"" + agy + "\" -p x > \"$dir/out\" 2> \"$dir/err\"\n" +
-		"printf '%s' \"$?\" > \"$dir/exit_code\"\n"
-	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return p
-}
 
 func TestAgyRunAndStatusOverMCP(t *testing.T) {
 	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})

--- a/internal/testutil/fakesupervisor.go
+++ b/internal/testutil/fakesupervisor.go
@@ -1,0 +1,78 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FakeSupervisor configures a stand-in supervisor script for tests.
+//
+// The generated script mimics `agy-mcp run-job <jobdir>`: it takes the job
+// directory as $2, writes the job's out (and err/exit_code) files there, and
+// sets its comm to the script basename so the liveness comm fallback sees the
+// same value the real supervisor would report.
+type FakeSupervisor struct {
+	// AgyPath, when set, makes the script run that (fake) agy binary with
+	// `-p x`, streaming stdout to <dir>/out and stderr to <dir>/err and
+	// recording agy's real exit code. Mutually exclusive with Out/Exit.
+	AgyPath string
+	// Out is the fixed content written to <dir>/out when AgyPath is empty.
+	Out string
+	// Exit is the fixed exit code recorded when AgyPath is empty.
+	Exit int
+	// CachePath, when set, makes the script write CacheJSON to that path
+	// before exit_code, mimicking agy persisting its conversation cache.
+	CachePath string
+	// CacheJSON is the cache payload to write; requires CachePath.
+	CacheJSON string
+}
+
+// WriteFakeSupervisor writes an executable shell script that mimics the
+// supervisor (`agy-mcp run-job <jobdir>`) and returns its path. The script is
+// created under t.TempDir(). Fixed out and cache payloads are written to
+// sibling files and reproduced via cat so arbitrary byte content survives
+// shell quoting. exit_code is always written last because the manager treats
+// its presence as job completion.
+func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
+	t.Helper()
+	if cfg.AgyPath != "" && (cfg.Out != "" || cfg.Exit != 0) {
+		t.Fatal("FakeSupervisor: AgyPath is mutually exclusive with Out/Exit")
+	}
+	if cfg.CacheJSON != "" && cfg.CachePath == "" {
+		t.Fatal("FakeSupervisor: CacheJSON requires CachePath")
+	}
+	dir := t.TempDir()
+	// The basename doubles as the comm value; it must stay under the kernel's
+	// 15-char comm limit for the liveness comm fallback to match.
+	path := filepath.Join(dir, "fake-sup")
+
+	var sb strings.Builder
+	sb.WriteString("#!/usr/bin/env bash\n")
+	sb.WriteString("printf '%s' \"${0##*/}\" > /proc/$$/comm\n")
+	sb.WriteString("dir=\"$2\"\n")
+	if cfg.AgyPath != "" {
+		fmt.Fprintf(&sb, "%q -p x > \"$dir/out\" 2> \"$dir/err\"\ncode=$?\n", cfg.AgyPath)
+	} else {
+		outPayload := filepath.Join(dir, "out-payload")
+		if err := os.WriteFile(outPayload, []byte(cfg.Out), 0o644); err != nil {
+			t.Fatalf("write fake supervisor out payload: %v", err)
+		}
+		fmt.Fprintf(&sb, "cat %q > \"$dir/out\"\ncode=%d\n", outPayload, cfg.Exit)
+	}
+	if cfg.CachePath != "" {
+		cachePayload := filepath.Join(dir, "cache-payload.json")
+		if err := os.WriteFile(cachePayload, []byte(cfg.CacheJSON), 0o644); err != nil {
+			t.Fatalf("write fake supervisor cache payload: %v", err)
+		}
+		fmt.Fprintf(&sb, "cat %q > %q\n", cachePayload, cfg.CachePath)
+	}
+	sb.WriteString("printf '%s' \"$code\" > \"$dir/exit_code\"\n")
+
+	if err := os.WriteFile(path, []byte(sb.String()), 0o755); err != nil {
+		t.Fatalf("write fake supervisor: %v", err)
+	}
+	return path
+}

--- a/internal/testutil/fakesupervisor_linux_test.go
+++ b/internal/testutil/fakesupervisor_linux_test.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// runSupervisor executes the fake supervisor the way the manager does
+// (`<exe> run-job <jobdir>`) and returns the job dir.
+func runSupervisor(t *testing.T, sup string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := exec.Command(sup, "run-job", dir).Run(); err != nil {
+		t.Fatalf("run fake supervisor: %v", err)
+	}
+	return dir
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestFakeSupervisorFixedOutAndExit(t *testing.T) {
+	sup := WriteFakeSupervisor(t, FakeSupervisor{Out: "done", Exit: 3})
+	dir := runSupervisor(t, sup)
+	if got := readFile(t, filepath.Join(dir, "out")); got != "done" {
+		t.Errorf("out = %q, want %q", got, "done")
+	}
+	if got := readFile(t, filepath.Join(dir, "exit_code")); got != "3" {
+		t.Errorf("exit_code = %q, want %q", got, "3")
+	}
+}
+
+func TestFakeSupervisorRunsAgy(t *testing.T) {
+	agy := WriteFakeAgy(t, FakeAgy{Stdout: "hello", Stderr: "warn", Exit: 2})
+	sup := WriteFakeSupervisor(t, FakeSupervisor{AgyPath: agy})
+	dir := runSupervisor(t, sup)
+	if got := readFile(t, filepath.Join(dir, "out")); got != "hello" {
+		t.Errorf("out = %q, want %q", got, "hello")
+	}
+	if got := readFile(t, filepath.Join(dir, "err")); got != "warn" {
+		t.Errorf("err = %q, want %q", got, "warn")
+	}
+	if got := readFile(t, filepath.Join(dir, "exit_code")); got != "2" {
+		t.Errorf("exit_code = %q, want %q", got, "2")
+	}
+}
+
+func TestFakeSupervisorWritesCache(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	const payload = `{"/some/cwd":"uuid-1234"}`
+	sup := WriteFakeSupervisor(t, FakeSupervisor{Out: "done", CachePath: cachePath, CacheJSON: payload})
+	dir := runSupervisor(t, sup)
+	if got := readFile(t, cachePath); got != payload {
+		t.Errorf("cache = %q, want %q", got, payload)
+	}
+	if got := readFile(t, filepath.Join(dir, "exit_code")); got != "0" {
+		t.Errorf("exit_code = %q, want %q", got, "0")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the three hand-rolled bash fake-supervisor script writers with a single configurable `testutil.WriteFakeSupervisor(t, cfg)`, mirroring the existing `FakeAgy`/`WriteFakeAgy` config-struct pattern:

- `internal/mcptools/tools_test.go` `writeFakeSupervisor` (ran the fake agy, wrote comm) - deleted
- `internal/manager/job_linux_test.go` `fakeSupervisor` (fixed out/exit_code) - deleted
- `internal/manager/capture_linux_test.go` `fakeSupervisorWritingCache` (also wrote the conversation cache) - deleted

The consolidated helper supports all three behaviors via `FakeSupervisor{AgyPath, Out, Exit, CachePath, CacheJSON}` with mutual-exclusion validation, and pins two invariants the old copies relied on:

- `exit_code` is always written last, since the manager treats its presence as job completion (the capture test depends on the cache landing first).
- The script always writes its basename to `/proc/$$/comm`, so the liveness comm fallback fidelity fix now applies to the manager tests too instead of living only in the mcptools copy.

Fixed out and cache payloads go through sibling payload files plus `cat` (the `WriteFakeAgy` pattern), so arbitrary byte content survives shell quoting. The helper itself is plain Go with no build tags; its self-test executes bash and writes `/proc`, so it carries the `_linux_test.go` suffix like the manager tests.

## Related Issues

Closes #16

## Test Plan

- [x] `go test ./... -race` passes
- [x] `go build ./...`, `go vet ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go vet ./...` all clean
- [x] `golangci-lint run` reports 0 issues
- [x] New self-tests cover fixed out/exit mode, fake-agy mode (out/err/exit code), and the cache write
- [x] `grep` confirms no leftover references to the deleted doubles