### PR TITLE
Make conversation-id capture reliable for fresh agy runs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	MaxConcurrency int           // global cap on concurrent jobs
 	JobTTL         time.Duration // age after which finished jobs are GC'd
 	HTTPToken      string        // optional bearer token for HTTP mode; empty = unauthenticated
+
+	// ConversationCacheFile overrides where agy's conversation cache
+	// (last_conversations.json) is read from. Empty means agy's default
+	// location under the user's home. Primarily a test seam.
+	ConversationCacheFile string
 }
 
 // Resolve builds a Config from environment variables and defaults.

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -18,23 +18,23 @@ import (
 // StartTimeTicks, and ConversationID are filled in afterward by atomic rewrites
 // (UpdateMeta / SetConversationID).
 type Meta struct {
-	ID             string        `json:"id"`
-	AgyPath        string        `json:"agy_path"`
-	Args           []string      `json:"args"`
-	Cwd            string        `json:"cwd"`
-	Model          string        `json:"model,omitempty"`
-	ConversationID string        `json:"conversation_id,omitempty"`
-	Prompt         string        `json:"prompt"`
-	StartedAt      time.Time     `json:"started_at"`
-	PID            int           `json:"pid"`
-	StartTimeTicks uint64        `json:"start_time_ticks,omitempty"` // supervisor /proc start time; 0 = unknown
-	BootID         string        `json:"boot_id"`
-	CwdUUIDBefore  string        `json:"cwd_uuid_before,omitempty"`
+	ID             string    `json:"id"`
+	AgyPath        string    `json:"agy_path"`
+	Args           []string  `json:"args"`
+	Cwd            string    `json:"cwd"`
+	Model          string    `json:"model,omitempty"`
+	ConversationID string    `json:"conversation_id,omitempty"`
+	Prompt         string    `json:"prompt"`
+	StartedAt      time.Time `json:"started_at"`
+	PID            int       `json:"pid"`
+	StartTimeTicks uint64    `json:"start_time_ticks,omitempty"` // supervisor /proc start time; 0 = unknown
+	BootID         string    `json:"boot_id"`
+	CwdUUIDBefore  string    `json:"cwd_uuid_before,omitempty"`
 	// CaptureDisabled marks a fresh run whose pre-run cache snapshot could not
 	// be read: without a trustworthy snapshot a post-run cache diff cannot be
 	// attributed safely, so conversation-id capture is skipped for this job.
 	CaptureDisabled bool          `json:"capture_disabled,omitempty"`
-	Timeout        time.Duration `json:"timeout,omitempty"`
+	Timeout         time.Duration `json:"timeout,omitempty"`
 }
 
 // Exit-code sentinels the supervisor writes to the exit_code file and the

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -30,6 +30,10 @@ type Meta struct {
 	StartTimeTicks uint64        `json:"start_time_ticks,omitempty"` // supervisor /proc start time; 0 = unknown
 	BootID         string        `json:"boot_id"`
 	CwdUUIDBefore  string        `json:"cwd_uuid_before,omitempty"`
+	// CaptureDisabled marks a fresh run whose pre-run cache snapshot could not
+	// be read: without a trustworthy snapshot a post-run cache diff cannot be
+	// attributed safely, so conversation-id capture is skipped for this job.
+	CaptureDisabled bool          `json:"capture_disabled,omitempty"`
 	Timeout        time.Duration `json:"timeout,omitempty"`
 }
 

--- a/internal/manager/capture_linux_test.go
+++ b/internal/manager/capture_linux_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -284,6 +285,9 @@ func TestFreshRunWithCorruptCacheDisablesCapture(t *testing.T) {
 	if !meta.CaptureDisabled {
 		t.Fatal("expected CaptureDisabled for a run started with an unreadable cache")
 	}
+	if m.CapturePending(job.ID) {
+		t.Fatal("a capture-disabled run must not be armed in pendingCaptures")
+	}
 	waitForExitCode(t, m, job.ID)
 
 	// The cache "recovers" with an entry for this cwd; it must not be captured.
@@ -419,6 +423,89 @@ func TestStatusLazyCaptureSkipsWhenLaterRunExists(t *testing.T) {
 	}
 }
 
+// failListStore wraps a real store but fails List whenever failList is set, to
+// drive the lazy-capture path where the store cannot be scanned to rule out a
+// later same-cwd run.
+type failListStore struct {
+	jobStore
+	failList bool
+}
+
+func (f *failListStore) List() ([]string, error) {
+	if f.failList {
+		return nil, errors.New("injected List failure")
+	}
+	return f.jobStore.List()
+}
+
+// A transient store-scan failure must not permanently settle a lazy capture: the
+// id is skipped for that poll (never misattributed) but the job stays capturable,
+// so once the store is readable again the id is captured.
+func TestStatusLazyCaptureSkipsButDoesNotSettleOnListError(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	const uuid = "abcd0000-1111-2222-3333-444455556666"
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, uuid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+	fls := &failListStore{jobStore: m.store}
+	m.store = fls
+
+	// A completed fresh run from a previous manager; id never captured.
+	meta := jobstore.Meta{
+		ID:            "job-listerr",
+		Cwd:           cwd,
+		CwdUUIDBefore: "",
+		StartedAt:     time.Now().Add(-time.Minute),
+		Timeout:       time.Hour,
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(meta.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// With List failing, the capture must be skipped (no misattribution) and the
+	// job must NOT be settled (so a later poll can still capture).
+	fls.failList = true
+	st, err := m.Status(meta.ID)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.ConversationID != "" {
+		t.Fatalf("must not capture while the store scan fails, got %q", st.ConversationID)
+	}
+	if m.captureSettled(meta.ID) {
+		t.Fatal("a transient List error must not permanently settle the capture")
+	}
+
+	// Once the store is scannable again and no later same-cwd run exists, the id
+	// is captured: the earlier failure did not lose it.
+	fls.failList = false
+	st, err = m.Status(meta.ID)
+	if err != nil {
+		t.Fatalf("Status (recovered): %v", err)
+	}
+	if st.ConversationID != uuid {
+		t.Fatalf("id should be captured after the store recovers, got %q", st.ConversationID)
+	}
+}
+
 // Once a job is long past its timeout with no cache change, lazy capture must
 // settle permanently: a cache change appearing afterward belongs to some other
 // (possibly out-of-store) run and must not be captured, and settled jobs must
@@ -465,6 +552,60 @@ func TestStatusLazyCaptureSettlesAfterHorizon(t *testing.T) {
 	}
 	// A cache entry appears later (some unrelated run); it must not be captured.
 	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, "abcdef00-1111-2222-3333-444455556666")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if st, err := m.Status(meta.ID); err != nil || st.ConversationID != "" {
+		t.Fatalf("settled job captured a late id: id=%q err=%v", st.ConversationID, err)
+	}
+}
+
+// An old meta with no recorded Timeout (zero value) must still settle once it is
+// past the conservative 1h fallback horizon, so it stops re-reading the cache and
+// cannot capture a much-later unrelated cache write.
+func TestStatusLazyCaptureSettlesViaFallbackHorizonWhenTimeoutZero(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	// No Timeout recorded; StartedAt is well past the 1h fallback horizon.
+	meta := jobstore.Meta{
+		ID:            "job-notimeout",
+		Cwd:           cwd,
+		CwdUUIDBefore: "",
+		StartedAt:     time.Now().Add(-2 * time.Hour),
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(meta.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// First Status: empty cache, long past the fallback horizon, so it settles.
+	if st, err := m.Status(meta.ID); err != nil || st.ConversationID != "" {
+		t.Fatalf("first Status: id=%q err=%v", st.ConversationID, err)
+	}
+	if !m.captureSettled(meta.ID) {
+		t.Fatal("a Timeout==0 job past the 1h fallback horizon must settle")
+	}
+	// A later unrelated cache entry must not be captured.
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, "00001111-2222-3333-4444-555566667777")), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if st, err := m.Status(meta.ID); err != nil || st.ConversationID != "" {

--- a/internal/manager/capture_linux_test.go
+++ b/internal/manager/capture_linux_test.go
@@ -24,7 +24,7 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 	const newUUID = "11111111-2222-3333-4444-555555555555"
 
 	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
+		AgyPath: "/usr/bin/agy",
 		SupervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
 			Out: "done", CachePath: cachePath, CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, newUUID),
 		}),

--- a/internal/manager/capture_linux_test.go
+++ b/internal/manager/capture_linux_test.go
@@ -313,3 +313,47 @@ func waitForCapturedID(t *testing.T, m *Manager, id string, within time.Duration
 	}
 	return st
 }
+
+// CapturePending must be armed synchronously by a fresh StartJob and settle
+// once the completion goroutine has captured (or given up on) the id.
+func TestCapturePendingSettles(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := t.TempDir()
+	const newUUID = "55556666-7777-8888-9999-000011112222"
+
+	c := config.Config{
+		AgyPath: "/usr/bin/agy",
+		SupervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+			Out: "done", CachePath: cachePath, CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, newUUID),
+		}),
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = cachePath
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	if !m.CapturePending(job.ID) {
+		t.Fatal("capture must be pending right after a fresh StartJob")
+	}
+
+	st := waitForCapturedID(t, m, job.ID, 3*time.Second)
+	if st.ConversationID != newUUID {
+		t.Fatalf("captured id = %q, want %q", st.ConversationID, newUUID)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for m.CapturePending(job.ID) {
+		if time.Now().After(deadline) {
+			t.Fatal("capture never settled after the id was captured")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/manager/capture_linux_test.go
+++ b/internal/manager/capture_linux_test.go
@@ -357,3 +357,117 @@ func TestCapturePendingSettles(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// A lazily captured id must not be stolen from a later same-cwd run: when
+// another job started in this cwd after this one, a changed cache entry cannot
+// be attributed to this job.
+func TestStatusLazyCaptureSkipsWhenLaterRunExists(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	const laterUUID = "99998888-7777-6666-5555-444433332222"
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, laterUUID)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	// Job A: a completed fresh run from a previous manager, id never captured.
+	metaA := jobstore.Meta{
+		ID:            "job-a",
+		Cwd:           cwd,
+		CwdUUIDBefore: "",
+		StartedAt:     time.Now().Add(-2 * time.Minute),
+		Timeout:       time.Hour,
+	}
+	dirA, err := m.store.Create(metaA)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dirA, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(metaA.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Job B: a later run in the same cwd; the cache entry is (or may be) B's.
+	metaB := jobstore.Meta{ID: "job-b", Cwd: cwd, StartedAt: time.Now().Add(-time.Minute)}
+	if _, err := m.store.Create(metaB); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	st, err := m.Status(metaA.ID)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.ConversationID != "" {
+		t.Fatalf("must not attribute the later run's id, got %q", st.ConversationID)
+	}
+	reloaded, err := m.store.Load(metaA.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.ConversationID != "" {
+		t.Fatalf("misattributed id was persisted: %q", reloaded.ConversationID)
+	}
+}
+
+// Once a job is long past its timeout with no cache change, lazy capture must
+// settle permanently: a cache change appearing afterward belongs to some other
+// (possibly out-of-store) run and must not be captured, and settled jobs must
+// stop re-reading the cache on every poll.
+func TestStatusLazyCaptureSettlesAfterHorizon(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	// Done long ago: StartedAt is far past Timeout + captureBudget.
+	meta := jobstore.Meta{
+		ID:            "job-old",
+		Cwd:           cwd,
+		CwdUUIDBefore: "",
+		StartedAt:     time.Now().Add(-time.Hour),
+		Timeout:       time.Minute,
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(meta.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// First Status: no cache change, and the job is long over, so the capture settles.
+	if st, err := m.Status(meta.ID); err != nil || st.ConversationID != "" {
+		t.Fatalf("first Status: id=%q err=%v", st.ConversationID, err)
+	}
+	// A cache entry appears later (some unrelated run); it must not be captured.
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, "abcdef00-1111-2222-3333-444455556666")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if st, err := m.Status(meta.ID); err != nil || st.ConversationID != "" {
+		t.Fatalf("settled job captured a late id: id=%q err=%v", st.ConversationID, err)
+	}
+}

--- a/internal/manager/capture_linux_test.go
+++ b/internal/manager/capture_linux_test.go
@@ -250,6 +250,55 @@ func TestStatusLazyCaptureNoOpWhenCacheUnchanged(t *testing.T) {
 	}
 }
 
+// A fresh run started while the conversation cache is unreadable must disable
+// capture for that run: even when the cache later becomes readable with a new
+// entry, the id cannot be attributed to this run.
+func TestFreshRunWithCorruptCacheDisablesCapture(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := t.TempDir()
+
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = cachePath
+	m.captureBudget = 50 * time.Millisecond
+	m.capturePoll = 10 * time.Millisecond
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	meta, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !meta.CaptureDisabled {
+		t.Fatal("expected CaptureDisabled for a run started with an unreadable cache")
+	}
+	waitForExitCode(t, m, job.ID)
+
+	// The cache "recovers" with an entry for this cwd; it must not be captured.
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, "aaaa1111-2222-3333-4444-555566667777")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st, err := m.Status(job.ID)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.ConversationID != "" {
+		t.Fatalf("capture-disabled run must report no id, got %q", st.ConversationID)
+	}
+}
+
 func waitForCapturedID(t *testing.T, m *Manager, id string, within time.Duration) Status {
 	t.Helper()
 	deadline := time.Now().Add(within)

--- a/internal/manager/conversation.go
+++ b/internal/manager/conversation.go
@@ -2,37 +2,78 @@ package manager
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 )
 
-func loadCache(cacheFile string) map[string]string {
+// loadCache reads agy's conversation cache. A missing file is a normal empty
+// cache (fresh agy install, no conversations yet). A read or parse failure is
+// reported: agy rewrites the file in place (O_TRUNC, no lock), so a concurrent
+// read can be torn, and callers must not mistake a torn read for "no entry"
+// when the difference matters.
+func loadCache(cacheFile string) (map[string]string, error) {
 	b, err := os.ReadFile(cacheFile)
+	if errors.Is(err, fs.ErrNotExist) {
+		return map[string]string{}, nil
+	}
 	if err != nil {
-		return map[string]string{}
+		return nil, err
 	}
 	var raw map[string]string
 	if err := json.Unmarshal(b, &raw); err != nil {
-		return map[string]string{}
+		return nil, fmt.Errorf("parse conversation cache %s: %w", cacheFile, err)
 	}
-	return raw
+	return raw, nil
 }
 
-// resolveLatest returns the most recent conversation UUID for cwd, if any.
+// loadCacheRetry reads the cache, retrying once on failure: torn reads are
+// transient (agy's rewrite completes in microseconds), so an immediate re-read
+// usually observes a complete file.
+func loadCacheRetry(cacheFile string) (map[string]string, error) {
+	cache, err := loadCache(cacheFile)
+	if err == nil {
+		return cache, nil
+	}
+	return loadCache(cacheFile)
+}
+
+// resolveLatest returns the most recent conversation UUID for cwd, if any. An
+// unreadable cache resolves to not-found: continue_latest then starts a fresh
+// conversation, the documented fallback for "no prior conversation".
 func resolveLatest(cacheFile, cwd string) (string, bool) {
-	id, ok := loadCache(cacheFile)[cwd]
+	cache, err := loadCacheRetry(cacheFile)
+	if err != nil {
+		return "", false
+	}
+	id, ok := cache[cwd]
 	return id, ok && id != ""
 }
 
-// snapshotCwd records the cwd's UUID before a run.
-func snapshotCwd(cacheFile, cwd string) string {
-	return loadCache(cacheFile)[cwd]
+// snapshotCwd records the cwd's UUID before a run. ok=false means the snapshot
+// could not be taken (torn or corrupt cache even after a retry); the caller
+// must disable capture for the run rather than guess, because an empty-by-error
+// snapshot would make a pre-existing conversation look newly created.
+func snapshotCwd(cacheFile, cwd string) (string, bool) {
+	cache, err := loadCacheRetry(cacheFile)
+	if err != nil {
+		return "", false
+	}
+	return cache[cwd], true
 }
 
-// captureNewUUID returns the cwd's UUID after a run, but only if it changed from
-// the pre-run snapshot. A failed run leaves the cache untouched, so this avoids
-// misattributing the failure to a previous conversation.
+// captureNewUUID returns the cwd's UUID after a run, but only if it changed
+// from the pre-run snapshot. A failed run leaves the cache untouched, and a
+// torn read yields no capture, so a single call never misattributes an old
+// conversation to this run. Both call sites sit in retry loops, so no internal
+// retry is needed here.
 func captureNewUUID(cacheFile, cwd, before string) (string, bool) {
-	after := loadCache(cacheFile)[cwd]
+	cache, err := loadCache(cacheFile)
+	if err != nil {
+		return "", false
+	}
+	after := cache[cwd]
 	if after != "" && after != before {
 		return after, true
 	}

--- a/internal/manager/conversation.go
+++ b/internal/manager/conversation.go
@@ -66,8 +66,9 @@ func snapshotCwd(cacheFile, cwd string) (string, bool) {
 // captureNewUUID returns the cwd's UUID after a run, but only if it changed
 // from the pre-run snapshot. A failed run leaves the cache untouched, and a
 // torn read yields no capture, so a single call never misattributes an old
-// conversation to this run. Both call sites sit in retry loops, so no internal
-// retry is needed here.
+// conversation to this run. The completion-goroutine call site retries in a
+// loop; the lazy-capture path is best-effort single-shot (re-tried across Status
+// polls), so no internal retry is needed here.
 func captureNewUUID(cacheFile, cwd, before string) (string, bool) {
 	cache, err := loadCache(cacheFile)
 	if err != nil {

--- a/internal/manager/conversation_test.go
+++ b/internal/manager/conversation_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/config"
 )
 
 func writeCache(t *testing.T, dir string, kv map[string]string) string {
@@ -105,5 +107,13 @@ func TestSnapshotCwdOkOnMissingCache(t *testing.T) {
 	before, ok := snapshotCwd(filepath.Join(t.TempDir(), "absent.json"), "/w")
 	if !ok || before != "" {
 		t.Fatalf("missing cache = valid empty snapshot, got %q,%v", before, ok)
+	}
+}
+
+func TestNewUsesConfiguredCacheFile(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 1,
+		ConversationCacheFile: "/tmp/agy-test-cache.json"})
+	if m.cacheFile != "/tmp/agy-test-cache.json" {
+		t.Fatalf("cacheFile = %q, want the configured override", m.cacheFile)
 	}
 }

--- a/internal/manager/conversation_test.go
+++ b/internal/manager/conversation_test.go
@@ -52,7 +52,10 @@ func TestCaptureNewUUIDByDiff(t *testing.T) {
 func TestCaptureNoChangeOnFailedRun(t *testing.T) {
 	dir := t.TempDir()
 	cache := writeCache(t, dir, map[string]string{"/w": "old"})
-	before, _ := snapshotCwd(cache, "/w")
+	before, ok := snapshotCwd(cache, "/w")
+	if !ok {
+		t.Fatal("snapshot should be readable")
+	}
 	// agy failed -> cache unchanged.
 	got, changed := captureNewUUID(cache, "/w", before)
 	if changed || got != "" {

--- a/internal/manager/conversation_test.go
+++ b/internal/manager/conversation_test.go
@@ -35,7 +35,10 @@ func TestResolveLatestForCwd(t *testing.T) {
 func TestCaptureNewUUIDByDiff(t *testing.T) {
 	dir := t.TempDir()
 	cache := writeCache(t, dir, map[string]string{"/w": "old"})
-	before := snapshotCwd(cache, "/w") // "old"
+	before, ok := snapshotCwd(cache, "/w") // "old"
+	if !ok {
+		t.Fatal("snapshot should be readable")
+	}
 	// Simulate agy creating a new conversation for /w.
 	_ = writeCache(t, dir, map[string]string{"/w": "new"})
 	got, changed := captureNewUUID(cache, "/w", before)
@@ -47,10 +50,60 @@ func TestCaptureNewUUIDByDiff(t *testing.T) {
 func TestCaptureNoChangeOnFailedRun(t *testing.T) {
 	dir := t.TempDir()
 	cache := writeCache(t, dir, map[string]string{"/w": "old"})
-	before := snapshotCwd(cache, "/w")
+	before, _ := snapshotCwd(cache, "/w")
 	// agy failed -> cache unchanged.
 	got, changed := captureNewUUID(cache, "/w", before)
 	if changed || got != "" {
 		t.Fatalf("should not capture stale id: %q,%v", got, changed)
+	}
+}
+
+func TestLoadCacheMissingFileIsEmptyNotError(t *testing.T) {
+	cache, err := loadCache(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Fatalf("a missing cache is a normal empty cache, got error: %v", err)
+	}
+	if len(cache) != 0 {
+		t.Fatalf("want empty cache, got %v", cache)
+	}
+}
+
+func TestLoadCacheTornReadIsError(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last_conversations.json")
+	if err := os.WriteFile(p, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadCache(p); err == nil {
+		t.Fatal("a torn/unparsable cache read must surface an error")
+	}
+}
+
+func TestResolveLatestNotFoundOnTornCache(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last_conversations.json")
+	if err := os.WriteFile(p, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resolveLatest(p, "/w"); ok {
+		t.Fatal("a torn cache must resolve to not-found, not to a bogus id")
+	}
+}
+
+func TestSnapshotCwdUnknownOnTornCache(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last_conversations.json")
+	if err := os.WriteFile(p, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := snapshotCwd(p, "/w"); ok {
+		t.Fatal("a torn cache must report the snapshot as unknown")
+	}
+}
+
+func TestSnapshotCwdOkOnMissingCache(t *testing.T) {
+	before, ok := snapshotCwd(filepath.Join(t.TempDir(), "absent.json"), "/w")
+	if !ok || before != "" {
+		t.Fatalf("missing cache = valid empty snapshot, got %q,%v", before, ok)
 	}
 }

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -26,6 +26,30 @@ func TestGarbageCollectRemovesExpired(t *testing.T) {
 	}
 }
 
+func TestGarbageCollectUntracksSettledCapture(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	// The job's lazy capture settled before it aged out; its memo must not outlive
+	// the job, or settledCapture would grow without bound in a long-running server.
+	m.settleCapture("old")
+	if !m.captureSettled("old") {
+		t.Fatal("precondition: the job should be settled")
+	}
+
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "old" {
+		t.Fatalf("removed = %v, want [old]", removed)
+	}
+	if m.captureSettled("old") {
+		t.Fatal("GarbageCollect must untrack a collected job's settled-capture memo")
+	}
+}
+
 func TestGCInterval(t *testing.T) {
 	cases := []struct{ ttl, want time.Duration }{
 		{0, 0},                             // disabled

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -178,6 +178,17 @@ func (m *Manager) settleCapture(id string) {
 	m.settledCapture[id] = struct{}{}
 }
 
+// untrackCapture forgets a job's capture-tracking state once the job is gone
+// (garbage-collected from the store), so neither map grows without bound in a
+// long-running server. pendingCaptures is normally already cleared by the time
+// a job is collectable; deleting both keeps the bookkeeping leak-free.
+func (m *Manager) untrackCapture(id string) {
+	m.pendingCaptures.Delete(id)
+	m.settledMu.Lock()
+	delete(m.settledCapture, id)
+	m.settledMu.Unlock()
+}
+
 // maybeSettleCapture marks a job's lazy capture as permanently over once the
 // run is certainly long finished: the supervisor's hard timeout bounds the run
 // and agy's cache daemon flushes within moments of the exit, so past
@@ -389,6 +400,7 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 		}
 		if err := m.store.Remove(id); err == nil {
 			removed = append(removed, id)
+			m.untrackCapture(id)
 		}
 	}
 	return removed, nil

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -400,6 +400,11 @@ func (m *Manager) RestoreGate() error {
 		// already holds this key, so it is already watched.
 		key := keyFor(reqFromMeta(meta))
 		if m.gate.forceAcquire(key) {
+			if meta.ConversationID == "" && !meta.CaptureDisabled {
+				// Mirror StartJob: arm the capture so pollers can tell this
+				// restored fresh run's id is still being settled.
+				m.pendingCaptures.Store(meta.ID, struct{}{})
+			}
 			m.watchRestored(meta, key)
 		}
 	}
@@ -430,6 +435,14 @@ func (m *Manager) watchRestored(meta jobstore.Meta, key string) {
 				}
 			}
 		}
+		// Mirror the StartJob completion path: a restored fresh run that exited 0
+		// still needs its conversation id captured, and like there the capture
+		// must happen while the gate key is held, so a new same-cwd run cannot
+		// overwrite the cache entry first.
+		if code, ok := m.store.ExitCode(meta.ID); ok && code == 0 {
+			m.captureFreshConversationID(&meta)
+		}
+		m.pendingCaptures.Delete(meta.ID)
 		m.gate.release(key)
 	}()
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -3,6 +3,7 @@
 package manager
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -44,7 +45,7 @@ func New(c config.Config) *Manager {
 		cfg:                  c,
 		store:                jobstore.New(c.StateDir),
 		gate:                 newGate(c.MaxConcurrency),
-		cacheFile:            agyCachePath(),
+		cacheFile:            cmp.Or(c.ConversationCacheFile, agyCachePath()),
 		captureBudget:        2 * time.Second,
 		capturePoll:          100 * time.Millisecond,
 		restoredPollInterval: 2 * time.Second,

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -137,7 +137,14 @@ func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
 		m.maybeSettleCapture(meta)
 		return ""
 	}
-	if m.hasLaterSameCwdRun(meta) {
+	later, err := m.hasLaterSameCwdRun(meta)
+	if err != nil {
+		// The store could not be scanned to rule out a later same-cwd run. Skip
+		// this attempt without settling, so a transient scan failure does not
+		// permanently lose a still-capturable id; the next poll retries.
+		return ""
+	}
+	if later {
 		m.settleCapture(meta.ID)
 		return ""
 	}
@@ -190,11 +197,14 @@ func (m *Manager) maybeSettleCapture(meta jobstore.Meta) {
 
 // hasLaterSameCwdRun reports whether any other stored job shares meta's cwd and
 // started after it. When one exists, a changed cache entry cannot be attributed
-// to meta's run: the later run may be the one that wrote it.
-func (m *Manager) hasLaterSameCwdRun(meta jobstore.Meta) bool {
+// to meta's run: the later run may be the one that wrote it. A non-nil error
+// means the store could not be scanned; callers must treat that as "unknown"
+// (skip this attempt) rather than "a later run exists", so a transient scan
+// failure does not permanently settle a still-capturable job.
+func (m *Manager) hasLaterSameCwdRun(meta jobstore.Meta) (bool, error) {
 	ids, err := m.store.List()
 	if err != nil {
-		return true // cannot prove safety: skip the capture rather than risk misattribution
+		return false, err
 	}
 	for _, id := range ids {
 		if id == meta.ID {
@@ -205,10 +215,10 @@ func (m *Manager) hasLaterSameCwdRun(meta jobstore.Meta) bool {
 			continue
 		}
 		if other.Cwd == meta.Cwd && other.StartedAt.After(meta.StartedAt) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // StartJob persists meta and spawns the detached supervisor.

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -42,9 +42,10 @@ type Manager struct {
 	// run in parallel. agy's conversation cache is flushed by a separate daemon that
 	// can lag the foreground agy exit, so the capture retries briefly. Verified
 	// against agy 1.0.6: agy rewrites last_conversations.json in place (O_TRUNC, no
-	// file lock), so a concurrent read can be torn; loadCache tolerates that (an
-	// unparsable read yields no capture) and this retry loop re-reads, so no mutex
-	// is needed. agy also ignores a caller-supplied fresh --conversation UUID and
+	// file lock), so a concurrent read can be torn; loadCache reports torn reads
+	// as errors, capture treats them as "no capture yet" and this retry loop
+	// re-reads, and StartJob disables capture when the pre-run snapshot itself is
+	// unreadable, so no mutex is needed. agy also ignores a caller-supplied fresh --conversation UUID and
 	// mints its own, which is why the id must be captured by diffing the cache
 	// rather than generated and passed in.
 	captureBudget        time.Duration

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -30,6 +30,13 @@ type Manager struct {
 	// not finished). Keyed by job id; values are struct{}.
 	pendingCaptures sync.Map
 
+	// settledCapture memoizes job ids whose lazy capture is permanently over
+	// (no id is coming): either the run is long past its timeout with no cache
+	// change, or a later same-cwd run made attribution unsafe. Settled jobs
+	// stop re-reading the cache on every Status poll.
+	settledMu      sync.Mutex
+	settledCapture map[string]struct{}
+
 	// Timing for the fresh-run conversation-id capture and the restored-job
 	// liveness watcher. Fields (not package globals) so tests stay isolated and can
 	// run in parallel. agy's conversation cache is flushed by a separate daemon that
@@ -55,6 +62,7 @@ func New(c config.Config) *Manager {
 		captureBudget:        2 * time.Second,
 		capturePoll:          100 * time.Millisecond,
 		restoredPollInterval: 2 * time.Second,
+		settledCapture:       make(map[string]struct{}),
 	}
 }
 
@@ -107,20 +115,29 @@ func (m *Manager) captureFreshConversationID(meta *jobstore.Meta) {
 }
 
 // lazyCaptureConversationID best-effort captures a fresh run's conversation id
-// from the cache when the completion goroutine never ran (the manager was
-// restarted while the job ran). It returns an already-known id unchanged. Unlike
-// the completion-goroutine capture, no gate key is held here, so a same-cwd run
-// that started in between may have overwritten the cache entry; in that case
-// nothing is captured and the run reports no id, exactly as before this change.
+// from the cache when no in-process watcher captured it (the manager was
+// restarted after the job ended). It returns an already-known id unchanged.
+//
+// No gate key is held here, so a cache change since the snapshot is not
+// necessarily this job's: a later same-cwd run may have written it. Two guards
+// keep that from becoming a persisted misattribution: a changed entry is not
+// captured while any later same-cwd job exists in the store, and once the run
+// is long enough over that no attributable change can still appear, the
+// capture settles permanently as empty.
 func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
 	if meta.ConversationID != "" {
 		return meta.ConversationID
 	}
-	if meta.CaptureDisabled {
+	if meta.CaptureDisabled || m.captureSettled(meta.ID) {
 		return ""
 	}
 	id, ok := captureNewUUID(m.cacheFile, meta.Cwd, meta.CwdUUIDBefore)
 	if !ok {
+		m.maybeSettleCapture(meta)
+		return ""
+	}
+	if m.hasLaterSameCwdRun(meta) {
+		m.settleCapture(meta.ID)
 		return ""
 	}
 	final, err := m.store.SetConversationID(meta.ID, id)
@@ -138,6 +155,59 @@ func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
 func (m *Manager) CapturePending(id string) bool {
 	_, ok := m.pendingCaptures.Load(id)
 	return ok
+}
+
+func (m *Manager) captureSettled(id string) bool {
+	m.settledMu.Lock()
+	defer m.settledMu.Unlock()
+	_, ok := m.settledCapture[id]
+	return ok
+}
+
+func (m *Manager) settleCapture(id string) {
+	m.settledMu.Lock()
+	defer m.settledMu.Unlock()
+	m.settledCapture[id] = struct{}{}
+}
+
+// maybeSettleCapture marks a job's lazy capture as permanently over once the
+// run is certainly long finished: the supervisor's hard timeout bounds the run
+// and agy's cache daemon flushes within moments of the exit, so past
+// StartedAt+Timeout+captureBudget no attributable cache change can still
+// appear. Settling stops later polls from re-reading the cache for a job that
+// will never get an id, and keeps a much-later unrelated cache write from
+// being misattributed to this job.
+func (m *Manager) maybeSettleCapture(meta jobstore.Meta) {
+	horizon := meta.Timeout
+	if horizon <= 0 {
+		horizon = time.Hour // old metas without a recorded timeout: stay conservative
+	}
+	if time.Since(meta.StartedAt) > horizon+m.captureBudget {
+		m.settleCapture(meta.ID)
+	}
+}
+
+// hasLaterSameCwdRun reports whether any other stored job shares meta's cwd and
+// started after it. When one exists, a changed cache entry cannot be attributed
+// to meta's run: the later run may be the one that wrote it.
+func (m *Manager) hasLaterSameCwdRun(meta jobstore.Meta) bool {
+	ids, err := m.store.List()
+	if err != nil {
+		return true // cannot prove safety: skip the capture rather than risk misattribution
+	}
+	for _, id := range ids {
+		if id == meta.ID {
+			continue
+		}
+		other, err := m.store.Load(id)
+		if err != nil {
+			continue
+		}
+		if other.Cwd == meta.Cwd && other.StartedAt.After(meta.StartedAt) {
+			return true
+		}
+	}
+	return false
 }
 
 // StartJob persists meta and spawns the detached supervisor.

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/tphakala/agy-mcp/internal/config"
@@ -23,6 +24,11 @@ type Manager struct {
 	store     jobStore // *jobstore.Store in production; an interface so tests can inject failures
 	gate      *gate    // serializes conflicting jobs and caps total concurrency
 	cacheFile string   // agy conversation cache (last_conversations.json); injectable for tests
+
+	// pendingCaptures holds the job ids of fresh runs whose conversation-id
+	// capture is armed but not yet settled (the post-exit capture attempt has
+	// not finished). Keyed by job id; values are struct{}.
+	pendingCaptures sync.Map
 
 	// Timing for the fresh-run conversation-id capture and the restored-job
 	// liveness watcher. Fields (not package globals) so tests stay isolated and can
@@ -125,6 +131,15 @@ func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
 	return final
 }
 
+// CapturePending reports whether a fresh run's conversation-id capture has not
+// yet settled in this process: capture was armed at start (or restore) and the
+// post-exit capture attempt has not finished. Pollers use it to distinguish
+// "done, id still being captured" from "done, no id is coming".
+func (m *Manager) CapturePending(id string) bool {
+	_, ok := m.pendingCaptures.Load(id)
+	return ok
+}
+
 // StartJob persists meta and spawns the detached supervisor.
 func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// Job supervision needs process groups and /proc, which only exist on Linux. On
@@ -189,6 +204,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	if req.ConversationID == "" {
 		if before, ok := snapshotCwd(m.cacheFile, cwd); ok {
 			meta.CwdUUIDBefore = before
+			m.pendingCaptures.Store(id, struct{}{})
 		} else {
 			// No trustworthy pre-run snapshot: a post-run diff could attribute
 			// a pre-existing conversation to this run. Report no id instead.
@@ -198,6 +214,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 	dir, err := m.store.Create(meta)
 	if err != nil {
+		m.pendingCaptures.Delete(id)
 		m.gate.release(key)
 		return Job{}, err
 	}
@@ -214,6 +231,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		// No supervisor was spawned, so the just-created job dir is a never-started
 		// orphan; remove it now rather than leaving it for a later GarbageCollect.
 		_ = m.store.Remove(id)
+		m.pendingCaptures.Delete(id)
 		m.gate.release(key)
 		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
 	}
@@ -236,6 +254,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		go func() {
 			_ = cmd.Wait()
 			_ = m.store.Remove(id)
+			m.pendingCaptures.Delete(id)
 			m.gate.release(key)
 		}()
 		return Job{}, fmt.Errorf("record supervisor pid: %w", err)
@@ -253,6 +272,9 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		if code, ok := m.store.ExitCode(id); ok && code == 0 {
 			m.captureFreshConversationID(&meta)
 		}
+		// Settle the capture (success or give-up) before releasing the key, so
+		// CapturePending=false means the reported status is final.
+		m.pendingCaptures.Delete(id)
 		m.gate.release(key)
 	}()
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -78,7 +78,7 @@ type Job struct {
 // between the snapshot and this capture. A torn or missing cache read yields no
 // capture (the run simply reports no id), never a misattribution.
 func (m *Manager) captureFreshConversationID(meta *jobstore.Meta) {
-	if meta.ConversationID != "" {
+	if meta.ConversationID != "" || meta.CaptureDisabled {
 		return
 	}
 	deadline := time.Now().Add(m.captureBudget)
@@ -108,6 +108,9 @@ func (m *Manager) captureFreshConversationID(meta *jobstore.Meta) {
 func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
 	if meta.ConversationID != "" {
 		return meta.ConversationID
+	}
+	if meta.CaptureDisabled {
+		return ""
 	}
 	id, ok := captureNewUUID(m.cacheFile, meta.Cwd, meta.CwdUUIDBefore)
 	if !ok {
@@ -183,7 +186,14 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// conversation. Snapshot the cwd's current conversation id so a later diff
 	// can capture the one agy creates.
 	if req.ConversationID == "" {
-		meta.CwdUUIDBefore = snapshotCwd(m.cacheFile, cwd)
+		if before, ok := snapshotCwd(m.cacheFile, cwd); ok {
+			meta.CwdUUIDBefore = before
+		} else {
+			// No trustworthy pre-run snapshot: a post-run diff could attribute
+			// a pre-existing conversation to this run. Report no id instead.
+			meta.CaptureDisabled = true
+			log.Printf("agy-mcp: job %s: conversation cache unreadable; id capture disabled for this run", id)
+		}
 	}
 	dir, err := m.store.Create(meta)
 	if err != nil {

--- a/internal/manager/restore_linux_test.go
+++ b/internal/manager/restore_linux_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -210,5 +211,57 @@ func TestRestoreGateSkipsTerminalJobs(t *testing.T) {
 
 	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err != nil {
 		t.Fatalf("a terminal job must not hold a gate key, but the run was blocked: %v", err)
+	}
+}
+
+// A restored fresh run must have its conversation id captured by the watcher
+// when its supervisor finishes, exactly like the StartJob completion path, and
+// the id must land on disk without any Status call (the watcher, not a poller,
+// owns the capture while the gate key is held).
+func TestRestoreGateCapturesConversationIDOnExit(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := newManagerForRestore(t, exePath, 4)
+	m.restoredPollInterval = 20 * time.Millisecond
+
+	cwd := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.cacheFile = cachePath
+
+	createLiveJob(t, m, "restored-fresh", cwd, pid)
+
+	if err := m.RestoreGate(); err != nil {
+		t.Fatalf("RestoreGate: %v", err)
+	}
+	if !m.CapturePending("restored-fresh") {
+		t.Fatal("a restored fresh run must have its capture armed")
+	}
+
+	// The job "finishes": agy's cache gains the new conversation, then the
+	// supervisor records exit 0 (the watcher treats the sentinel as terminal
+	// even while the fake supervisor process lingers).
+	const uuid = "deadbeef-1111-2222-3333-444455556666"
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, uuid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("restored-fresh", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		meta, err := m.store.Load("restored-fresh")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if meta.ConversationID == uuid {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("watcher never captured the id; meta.ConversationID = %q", meta.ConversationID)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -72,6 +72,22 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 			}
 			out := runSyncOutput{JobID: job.ID, statusOutput: toStatusOutput(st)}
 			if st.State != manager.StateRunning {
+				// A fresh run's conversation id can lag the exit sentinel: agy's
+				// cache daemon flushes after the process exits, and the manager's
+				// completion goroutine captures the id with a bounded retry. While
+				// that capture is still pending, keep polling instead of returning
+				// done with no id: a sync caller has no reason to poll again after
+				// a terminal result, so an id missing here is lost to the caller.
+				if st.State == manager.StateDone && st.ConversationID == "" &&
+					job.ConversationID == "" && time.Now().Before(deadline) &&
+					mgr.CapturePending(job.ID) {
+					select {
+					case <-ctx.Done():
+						return nil, out, nil
+					case <-ticker.C:
+					}
+					continue
+				}
 				return nil, out, nil
 			}
 			// The cap is approximate: the loop only observes the deadline on a

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -292,6 +292,11 @@ func TestAgyRunSyncReturnsLateCapturedConversationID(t *testing.T) {
 		t.Fatal(err)
 	}
 	const uuid = "12121212-3434-5656-7878-909090909090"
+	// CacheDelay (700ms) must stay below the manager's default captureBudget (2s)
+	// so the completion goroutine is still retrying the capture when the cache
+	// lands; otherwise the id would be lost and this test would pass for the wrong
+	// reason. The mcptools package cannot set the unexported captureBudget, so this
+	// dependency is documented rather than pinned.
 	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
 		AgyPath:    agy,
 		CachePath:  cachePath,

--- a/internal/mcptools/run_sync_test.go
+++ b/internal/mcptools/run_sync_test.go
@@ -3,6 +3,7 @@ package mcptools
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -33,14 +34,34 @@ func connect(t *testing.T, mgr *manager.Manager, opts *mcp.ClientOptions) *mcp.C
 	return cs
 }
 
-// newTestManager builds a manager around a fake agy and fake supervisor.
+// testConversationID is the id the fake supervisor's cache write attributes to
+// fresh runs started by newTestManager.
+const testConversationID = "abcdabcd-1234-5678-9abc-def012345678"
+
+// newTestManager builds a manager around a fake agy and fake supervisor. The
+// fake supervisor writes a conversation cache entry for the test's cwd after
+// the exit sentinel, so fresh runs capture an id the way real runs do, against
+// a test-owned cache file rather than the real agy cache.
 func newTestManager(t *testing.T, fake testutil.FakeAgy) (mgr *manager.Manager, stateDir string) {
 	t.Helper()
 	agy := testutil.WriteFakeAgy(t, fake)
-	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:   agy,
+		CachePath: cachePath,
+		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, testConversationID),
+	})
 	stateDir = t.TempDir()
 	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
-		DefaultTimeout: time.Minute, MaxConcurrency: 4}
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
 	return manager.New(c), stateDir
 }
 
@@ -254,4 +275,48 @@ func waitForRunningJob(t *testing.T, mgr *manager.Manager, stateDir string, time
 	}
 	t.Fatal("job did not reach running")
 	return ""
+}
+
+// A fresh run whose conversation cache lands only after the exit sentinel (the
+// real-world ordering: agy's cache daemon flushes after the process exits) must
+// still return its conversation id from agy_run_sync. Returning done with no id
+// loses the id for good, because a sync caller has no reason to poll again.
+func TestAgyRunSyncReturnsLateCapturedConversationID(t *testing.T) {
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const uuid = "12121212-3434-5656-7878-909090909090"
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:    agy,
+		CachePath:  cachePath,
+		CacheJSON:  fmt.Sprintf(`{%q:%q}`, cwd, uuid),
+		CacheDelay: 700 * time.Millisecond,
+	})
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: t.TempDir(),
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	mgr := manager.New(c)
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run_sync",
+		Arguments: map[string]any{"prompt": "review", "wait": "30s"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
+	}
+	sc := res.StructuredContent.(map[string]any)
+	if sc["state"] != manager.StateDone {
+		t.Fatalf("state = %v, want done", sc["state"])
+	}
+	if sc["conversation_id"] != uuid {
+		t.Fatalf("conversation_id = %v, want %q (the id must not be lost to cache-flush lag)",
+			sc["conversation_id"], uuid)
+	}
 }

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -3,6 +3,7 @@ package mcptools
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +15,8 @@ import (
 
 func testManager(t *testing.T) *manager.Manager {
 	t.Helper()
-	return manager.New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, DefaultTimeout: time.Minute})
+	return manager.New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, DefaultTimeout: time.Minute,
+		ConversationCacheFile: filepath.Join(t.TempDir(), "last_conversations.json")})
 }
 
 // TestHTTPRejectsCrossOriginPost verifies the Streamable HTTP handler rejects a

--- a/internal/testutil/fakesupervisor.go
+++ b/internal/testutil/fakesupervisor.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // FakeSupervisor configures a stand-in supervisor script for tests.
@@ -24,18 +25,26 @@ type FakeSupervisor struct {
 	// Exit is the fixed exit code recorded when AgyPath is empty.
 	Exit int
 	// CachePath, when set, makes the script write CacheJSON to that path
-	// before exit_code, mimicking agy persisting its conversation cache.
+	// after exit_code, mimicking the real ordering: the supervisor writes the
+	// exit sentinel at process exit, and agy's cache daemon flushes the
+	// conversation cache around or after that moment.
 	CachePath string
 	// CacheJSON is the cache payload to write; requires CachePath.
 	CacheJSON string
+	// CacheDelay, when positive, writes the cache from a backgrounded subshell
+	// that sleeps this long first, so the cache lands only after the script
+	// (and its exit_code) is gone. This reproduces the cache-daemon lag that
+	// the manager's capture retry exists for. Requires CachePath.
+	CacheDelay time.Duration
 }
 
 // WriteFakeSupervisor writes an executable shell script that mimics the
 // supervisor (`agy-mcp run-job <jobdir>`) and returns its path. The script is
 // created under t.TempDir(). Fixed out and cache payloads are written to
 // sibling files and reproduced via cat so arbitrary byte content survives
-// shell quoting. exit_code is always written last because the manager treats
-// its presence as job completion.
+// shell quoting. exit_code is written before the cache payload, matching the
+// real ordering the manager must tolerate: job completion (the sentinel) can
+// be observable before the conversation cache has been flushed.
 func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 	t.Helper()
 	if cfg.AgyPath != "" && (cfg.Out != "" || cfg.Exit != 0) {
@@ -43,6 +52,9 @@ func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 	}
 	if cfg.CacheJSON != "" && cfg.CachePath == "" {
 		t.Fatal("FakeSupervisor: CacheJSON requires CachePath")
+	}
+	if cfg.CacheDelay > 0 && cfg.CachePath == "" {
+		t.Fatal("FakeSupervisor: CacheDelay requires CachePath")
 	}
 	dir := t.TempDir()
 	// The basename doubles as the comm value; it must stay under the kernel's
@@ -62,14 +74,21 @@ func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 		}
 		fmt.Fprintf(&sb, "cat %q > \"$dir/out\"\ncode=%d\n", outPayload, cfg.Exit)
 	}
+	sb.WriteString("printf '%s' \"$code\" > \"$dir/exit_code\"\n")
 	if cfg.CachePath != "" {
 		cachePayload := filepath.Join(dir, "cache-payload.json")
 		if err := os.WriteFile(cachePayload, []byte(cfg.CacheJSON), 0o644); err != nil {
 			t.Fatalf("write fake supervisor cache payload: %v", err)
 		}
-		fmt.Fprintf(&sb, "cat %q > %q\n", cachePayload, cfg.CachePath)
+		if cfg.CacheDelay > 0 {
+			// Backgrounded so the script (the fake supervisor process) exits
+			// first and the cache lands later, like agy's real cache daemon.
+			fmt.Fprintf(&sb, "( sleep %.3f; cat %q > %q ) &\n",
+				cfg.CacheDelay.Seconds(), cachePayload, cfg.CachePath)
+		} else {
+			fmt.Fprintf(&sb, "cat %q > %q\n", cachePayload, cfg.CachePath)
+		}
 	}
-	sb.WriteString("printf '%s' \"$code\" > \"$dir/exit_code\"\n")
 
 	if err := os.WriteFile(path, []byte(sb.String()), 0o755); err != nil {
 		t.Fatalf("write fake supervisor: %v", err)


### PR DESCRIPTION
## Summary

Fixes several ways agy-mcp could lose or misattribute the conversation id it captures for a fresh agy run. agy mints its own UUID for a fresh run, so agy-mcp recovers it by diffing agy's `last_conversations.json` cache (keyed by cwd) against a pre-run snapshot. That cache is flushed by a separate agy daemon that can lag the process exit, which is what exposed the bugs below.

- **agy_run_sync no longer returns `done` with an empty `conversation_id`** while the capture is still in flight. The manager now tracks fresh runs whose capture is armed but not yet settled (`CapturePending`), and `agy_run_sync` keeps polling a done job through that window instead of returning early. Previously a sync caller lost the id for good whenever the cache flush lagged the exit sentinel (a sync caller has no reason to poll again after a terminal result).
- **Torn cache reads are detected instead of swallowed.** agy rewrites the cache file in place (`O_TRUNC`, no lock), so a concurrent read can be torn. `loadCache` now surfaces read/parse errors (a missing file stays a normal empty cache) and retries once. When the pre-run snapshot itself is unreadable, capture is disabled for that run (`Meta.CaptureDisabled`) rather than misattributing a pre-existing conversation to it.
- **Restored jobs capture their id too.** A supervisor that outlives a manager restart is re-tracked by the watcher, which now captures the conversation id while still holding the cwd gate key, mirroring the normal completion path, instead of releasing the key and leaving the id to a lazy capture a new same-cwd run could spoil.
- **The post-restart lazy capture can no longer steal a later run's id.** It skips (and permanently settles) when a later same-cwd job exists, settles once a run is long past its timeout (stopping per-poll cache re-reads), and does not permanently give up on a transient store-scan error.
- **Test fixture realism.** The fake supervisor now writes `exit_code` before the conversation cache (the real ordering) with a `CacheDelay` knob that reproduces the cache-daemon lag; the old inverted ordering masked the sync bug.

## Related Issues

Fixes #23

Sibling findings from the same review (cwd normalization, cross-process gate, Status output polish, test-suite hygiene) are intentionally out of scope here and tracked separately.

## Test Plan

- [x] `go test ./...` (full suite)
- [x] `go test -race ./...` (the change adds a `sync.Map` and a mutex-guarded map touched from the completion goroutine, the restored watcher, and Status callers)
- [x] `gofmt -l .` clean, `go vet ./...` clean, `golangci-lint run` reports 0 issues
- [x] Headline regression `TestAgyRunSyncReturnsLateCapturedConversationID` fails before the manager/run_sync change and passes after