### PR TITLE
fix(rules): stop three Suggest autofixes from breaking code under --fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work.sum
 .vscode/
 .serena/
 .sentrux/
+.codegraph/

--- a/rules/builtins.go
+++ b/rules/builtins.go
@@ -32,43 +32,44 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 // See: https://pkg.go.dev/builtin#min
 // See: https://pkg.go.dev/builtin#max
 func MinMaxBuiltin(m dsl.Matcher) {
+	// Report-only, no autofix. The Suggest would drop the outer integer
+	// conversion (int/int64/int32) that makes the expression type-check.
+	// min/max return the operand type, so for operands narrower or wider than
+	// the conversion target the rewrite does not compile, and removing the only
+	// math.Min/Max call orphans the "math" import (--fix does not prune imports).
+	// The rewrite also needs a type constraint on the operands to be safe.
+
 	// math.Min with float64 conversion for integers
 	m.Match(
 		`int(math.Min(float64($a), float64($b)))`,
 	).
-		Report("use min($a, $b) instead of int(math.Min(float64(...))) (Go 1.21+)").
-		Suggest("min($a, $b)")
+		Report("use min($a, $b) instead of int(math.Min(float64(...))) (Go 1.21+)")
 
 	m.Match(
 		`int64(math.Min(float64($a), float64($b)))`,
 	).
-		Report("use min($a, $b) instead of int64(math.Min(float64(...))) (Go 1.21+)").
-		Suggest("min($a, $b)")
+		Report("use min($a, $b) instead of int64(math.Min(float64(...))) (Go 1.21+)")
 
 	m.Match(
 		`int32(math.Min(float64($a), float64($b)))`,
 	).
-		Report("use min($a, $b) instead of int32(math.Min(float64(...))) (Go 1.21+)").
-		Suggest("min($a, $b)")
+		Report("use min($a, $b) instead of int32(math.Min(float64(...))) (Go 1.21+)")
 
 	// math.Max with float64 conversion for integers
 	m.Match(
 		`int(math.Max(float64($a), float64($b)))`,
 	).
-		Report("use max($a, $b) instead of int(math.Max(float64(...))) (Go 1.21+)").
-		Suggest("max($a, $b)")
+		Report("use max($a, $b) instead of int(math.Max(float64(...))) (Go 1.21+)")
 
 	m.Match(
 		`int64(math.Max(float64($a), float64($b)))`,
 	).
-		Report("use max($a, $b) instead of int64(math.Max(float64(...))) (Go 1.21+)").
-		Suggest("max($a, $b)")
+		Report("use max($a, $b) instead of int64(math.Max(float64(...))) (Go 1.21+)")
 
 	m.Match(
 		`int32(math.Max(float64($a), float64($b)))`,
 	).
-		Report("use max($a, $b) instead of int32(math.Max(float64(...))) (Go 1.21+)").
-		Suggest("max($a, $b)")
+		Report("use max($a, $b) instead of int32(math.Max(float64(...))) (Go 1.21+)")
 }
 
 // ClearBuiltin detects loop-based map/slice clearing patterns and suggests
@@ -140,16 +141,27 @@ func ClearBuiltin(m dsl.Matcher) {
 // See: https://go.dev/doc/go1.22#language
 func RangeOverInteger(m dsl.Matcher) {
 	// Pattern: for i := 0; i < n; i++
-	// Exclude benchmark loops (b.N) which should use b.Loop() instead
+	// Report-only, no autofix. Rewriting to `for i := range n` evaluates n once
+	// at loop entry, so any loop whose body mutates n (a worklist that appends to
+	// the slice it ranges, for example) silently changes behavior while still
+	// compiling. The range form also drops i when the body never reads it, which
+	// would leave an "unused variable" autofix.
+	//
+	// Exclusions:
+	//   - benchmark loops (b.N) should use b.Loop() instead
+	//   - reflect Num* counters
+	//   - single-statement spread-append bodies, which are SliceRepeat's pattern;
+	//     without this, RangeOverInteger (loaded first, first match wins) shadows
+	//     the more specific "use slices.Repeat" advice.
 	m.Match(
 		`for $i := 0; $i < $n; $i++ { $*body }`,
 	).
 		Where(
 			!m["n"].Text.Matches(`.*\.N$`) &&
-				!m["n"].Text.Matches(`\.(NumField|NumMethod|NumIn|NumOut)\(\)$`),
+				!m["n"].Text.Matches(`\.(NumField|NumMethod|NumIn|NumOut)\(\)$`) &&
+				!m["body"].Text.Matches(`^\s*\S+\s*=\s*append\(.*\.\.\.\)\s*$`),
 		).
-		Report("use for $i := range $n instead of for $i := 0; $i < $n; $i++ (Go 1.22+)").
-		Suggest("for $i := range $n { $body }")
+		Report("use for $i := range $n instead of for $i := 0; $i < $n; $i++ (Go 1.22+)")
 }
 
 // AppendWithoutValues detects append calls with no values which have no effect.

--- a/rules/time.go
+++ b/rules/time.go
@@ -27,9 +27,13 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 // See: https://pkg.go.dev/time#pkg-constants (DateTime, DateOnly, TimeOnly)
 func TimeDateTimeConstants(m dsl.Matcher) {
 	// DateTime: "2006-01-02 15:04:05"
+	// The type guard keeps the Format matches from firing on any value with a
+	// Format(string) method (e.g. a custom formatter), where the time.* constant
+	// is undefined and --fix would emit non-compiling "undefined: time".
 	m.Match(
 		`$t.Format("2006-01-02 15:04:05")`,
 	).
+		Where(m["t"].Type.Is("time.Time")).
 		Report(`use $t.Format(time.DateTime) instead of magic format string (Go 1.20+)`).
 		Suggest(`$t.Format(time.DateTime)`)
 
@@ -43,6 +47,7 @@ func TimeDateTimeConstants(m dsl.Matcher) {
 	m.Match(
 		`$t.Format("2006-01-02")`,
 	).
+		Where(m["t"].Type.Is("time.Time")).
 		Report(`use $t.Format(time.DateOnly) instead of magic format string (Go 1.20+)`).
 		Suggest(`$t.Format(time.DateOnly)`)
 
@@ -56,6 +61,7 @@ func TimeDateTimeConstants(m dsl.Matcher) {
 	m.Match(
 		`$t.Format("15:04:05")`,
 	).
+		Where(m["t"].Type.Is("time.Time")).
 		Report(`use $t.Format(time.TimeOnly) instead of magic format string (Go 1.20+)`).
 		Suggest(`$t.Format(time.TimeOnly)`)
 


### PR DESCRIPTION
## What

Three ruleguard `Suggest` autofixes in the shared `rules/*.go` config could break or silently change code when a project runs `golangci-lint run --fix`. All three are reproduced with golangci-lint v2.11.4 against fixtures, then confirmed fixed.

## The bugs

- **MinMaxBuiltin** dropped the outer `int`/`int64`/`int32` conversion with no type constraint. `int64(math.Min(float64(a), float64(b)))` with `int16` operands autofixed to `min(a, b)`, which does not compile (wrong return type) and orphans the now-unused `math` import (`--fix` does not prune imports).
- **RangeOverInteger** rewrote `for i := 0; i < n; i++` to `for i := range n`. That evaluates `n` once at loop entry, so a worklist loop that appends to the slice it ranges silently changed behavior while still compiling. It also dropped `i` when the body never read it, leaving an unused variable.
- **TimeDateTimeConstants** had no guard that the receiver is a `time.Time`, so the `Format` matches fired on any type with a `Format(string)` method; the autofix emitted `time.DateTime` and produced `undefined: time`.

## The fix

- Drop `Suggest` on `MinMaxBuiltin` (all six matches) and `RangeOverInteger`; keep the `Report` so the advice still surfaces without an unsafe rewrite.
- Add `Where(m["t"].Type.Is("time.Time"))` to the three `TimeDateTimeConstants` `Format` matches. The genuine `time.Time` case still autofixes correctly; the `time.Parse` variants are unchanged.
- Exclude single-statement spread-append bodies from `RangeOverInteger` so the more specific `SliceRepeat` advice wins instead of being shadowed (first match wins, and `builtins.go` loads before `slices.go`).

## Verification

- Reproduced each broken autofix with `golangci-lint run --fix`, then confirmed the buggy fixes no longer apply and the fixed code compiles.
- A real `time.Time` value still rewrites to `time.DateTime` and compiles.
- `go build -tags ruleguard ./rules/` passes (rule layer still compiles).
- Repo lints clean (`golangci-lint run ./...`, 0 issues) and `go test ./...` is green.

Fixes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rule accuracy by adding type guards to prevent incorrect autofix suggestions on time-related patterns.
  * Converted certain matchers to report-only mode to eliminate potentially incorrect code transformations.

* **Chores**
  * Updated project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->