### PR TITLE
fix(rules): correctness, message, and version fixes

### DIFF
--- a/rules/builtins.go
+++ b/rules/builtins.go
@@ -7,16 +7,9 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 // MinMaxBuiltin detects manual min/max implementations using if statements
 // or ternary-like patterns and suggests using the built-in min/max functions.
 //
-// Old patterns:
+// Old pattern (only the math.Min/Max-with-conversion form is detected; the
+// if/else form is not matched):
 //
-//	// If-based min
-//	if a < b {
-//	    result = a
-//	} else {
-//	    result = b
-//	}
-//
-//	// math.Min/Max for integers
 //	result := int(math.Min(float64(a), float64(b)))
 //
 // New pattern (Go 1.21+):
@@ -75,22 +68,16 @@ func MinMaxBuiltin(m dsl.Matcher) {
 // ClearBuiltin detects loop-based map/slice clearing patterns and suggests
 // using the built-in clear() function.
 //
-// Old patterns:
+// Old pattern (only map clearing is detected; the slice-zeroing loop is not
+// matched):
 //
-//	// Map clearing
 //	for k := range m {
 //	    delete(m, k)
-//	}
-//
-//	// Slice zeroing
-//	for i := range s {
-//	    s[i] = 0  // or nil, "", etc.
 //	}
 //
 // New pattern (Go 1.21+):
 //
 //	clear(m)  // Deletes all map entries
-//	clear(s)  // Sets all slice elements to zero value
 //
 // Benefits:
 //   - Cleaner, more readable code

--- a/rules/builtins.go
+++ b/rules/builtins.go
@@ -4,8 +4,8 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// MinMaxBuiltin detects manual min/max implementations using if statements
-// or ternary-like patterns and suggests using the built-in min/max functions.
+// MinMaxBuiltin detects the math.Min/math.Max float64-conversion form wrapped
+// in an integer cast and suggests using the built-in min/max functions.
 //
 // Old pattern (only the math.Min/Max-with-conversion form is detected; the
 // if/else form is not matched):
@@ -146,7 +146,7 @@ func RangeOverInteger(m dsl.Matcher) {
 		Where(
 			!m["n"].Text.Matches(`.*\.N$`) &&
 				!m["n"].Text.Matches(`\.(NumField|NumMethod|NumIn|NumOut)\(\)$`) &&
-				!m["body"].Text.Matches(`^\s*\S+\s*=\s*append\(.*\.\.\.\)\s*$`),
+				!m["body"].Text.Matches(`(?s)^\s*\S+\s*=\s*append\(.*?\.\.\.\)\s*$`),
 		).
 		Report("use for $i := range $n instead of for $i := 0; $i < $n; $i++ (Go 1.22+)")
 }

--- a/rules/crypto.go
+++ b/rules/crypto.go
@@ -69,7 +69,7 @@ func WeakRSAKeySize(m dsl.Matcher) {
 	m.Match(
 		`rsa.GenerateKey($rand, $bits)`,
 	).
-		Where(m["bits"].Value.Int() < 2048).
+		Where(m["bits"].Const && m["bits"].Value.Int() < 2048).
 		Report("RSA keys under 2048 bits are weak (sizes under 1024 are rejected in Go 1.24+); use at least 2048 bits for modern security")
 }
 

--- a/rules/crypto.go
+++ b/rules/crypto.go
@@ -63,18 +63,14 @@ func DeprecatedCipherModes(m dsl.Matcher) {
 //
 // See: https://pkg.go.dev/crypto/rsa#GenerateKey
 func WeakRSAKeySize(m dsl.Matcher) {
-	// Flag 1024-bit keys (allowed but weak)
+	// One value predicate covers every weak constant size (512/768/1024/...)
+	// instead of enumerating literals; sizes under 1024 are also rejected
+	// outright in Go 1.24+. A non-constant bits argument is left alone.
 	m.Match(
-		`rsa.GenerateKey($rand, 1024)`,
+		`rsa.GenerateKey($rand, $bits)`,
 	).
-		Report("RSA 1024-bit keys are considered weak; use at least 2048 bits for modern security")
-
-	// Flag explicitly small keys (will error in Go 1.24+)
-	m.Match(
-		`rsa.GenerateKey($rand, 512)`,
-		`rsa.GenerateKey($rand, 768)`,
-	).
-		Report("RSA keys smaller than 1024 bits are rejected in Go 1.24+; use at least 2048 bits")
+		Where(m["bits"].Value.Int() < 2048).
+		Report("RSA keys under 2048 bits are weak (sizes under 1024 are rejected in Go 1.24+); use at least 2048 bits for modern security")
 }
 
 // DeprecatedElliptic detects deprecated crypto/elliptic usage and suggests

--- a/rules/errors.go
+++ b/rules/errors.go
@@ -29,8 +29,11 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 func ErrorsAsType(m dsl.Matcher) {
 	// Pattern: errors.As(err, &target)
 	// This catches all errors.As calls with address-of second argument
+	// The message uses a literal T placeholder rather than interpolating $target:
+	// $target binds the destination variable, not its type, so embedding it in the
+	// type-parameter slot would emit nonsense like "errors.AsType[pathErr](err)".
 	m.Match(
 		`errors.As($err, &$target)`,
 	).
-		Report("use errors.AsType[$target]($err) instead of errors.As for type-safe, faster error assertion (Go 1.26+)")
+		Report("use errors.AsType[T]($err), where T is $target's type, instead of errors.As for type-safe, faster error assertion (Go 1.26+)")
 }

--- a/rules/net.go
+++ b/rules/net.go
@@ -83,7 +83,7 @@ func FilepathIsLocal(m dsl.Matcher) {
 //	    },
 //	}
 //
-// New pattern (Go 1.26+):
+// New pattern (Go 1.20+):
 //
 //	proxy := &httputil.ReverseProxy{
 //	    Rewrite: func(r *httputil.ProxyRequest) {
@@ -105,13 +105,13 @@ func DeprecatedReverseProxyDirector(m dsl.Matcher) {
 	m.Match(
 		`httputil.ReverseProxy{$*_, Director: $_, $*_}`,
 	).
-		Report("httputil.ReverseProxy.Director is deprecated in Go 1.26: Director is vulnerable to hop-by-hop header abuse; use Rewrite instead for safe header handling")
+		Report("httputil.ReverseProxy.Director is deprecated in Go 1.20: Director is vulnerable to hop-by-hop header abuse; use Rewrite instead for safe header handling")
 
 	m.Match(
 		`$proxy.Director = $_`,
 	).
 		Where(m["proxy"].Type.Is("*httputil.ReverseProxy")).
-		Report("httputil.ReverseProxy.Director is deprecated in Go 1.26: Director is vulnerable to hop-by-hop header abuse; use Rewrite instead for safe header handling")
+		Report("httputil.ReverseProxy.Director is deprecated in Go 1.20: Director is vulnerable to hop-by-hop header abuse; use Rewrite instead for safe header handling")
 }
 
 // ErrorBeforeUse detects potential nil pointer dereference before error check.

--- a/rules/reflect.go
+++ b/rules/reflect.go
@@ -68,10 +68,14 @@ func ReflectPtrTo(m dsl.Matcher) {
 //
 // See: https://pkg.go.dev/reflect#TypeFor
 func ReflectTypeOf(m dsl.Matcher) {
+	// Autofix is safe here: the rewrite stays inside the reflect package, which
+	// the matched expression already imports, so --fix cannot leave a dangling
+	// reference (unlike rewrites that introduce a new import).
 	m.Match(
 		`reflect.TypeOf((*$typ)(nil)).Elem()`,
 	).
-		Report("use reflect.TypeFor[$typ]() instead of reflect.TypeOf((*$typ)(nil)).Elem() (Go 1.22+)")
+		Report("use reflect.TypeFor[$typ]() instead of reflect.TypeOf((*$typ)(nil)).Elem() (Go 1.22+)").
+		Suggest("reflect.TypeFor[$typ]()")
 }
 
 // DeprecatedReflectHeaders detects deprecated reflect.SliceHeader and

--- a/rules/runtime.go
+++ b/rules/runtime.go
@@ -4,7 +4,11 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// SetFinalizerDeprecated detects runtime.SetFinalizer and suggests runtime.AddCleanup.
+// PreferAddCleanup detects runtime.SetFinalizer and suggests runtime.AddCleanup.
+//
+// runtime.SetFinalizer is NOT deprecated (no Deprecated: tag as of Go 1.26), so
+// this is an advisory preference, not a deprecation warning. AddCleanup (Go 1.24)
+// is the recommended API for new code.
 //
 // The old pattern:
 //
@@ -22,7 +26,7 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 //   - Cleaner API with explicit cleanup argument
 //
 // See: https://pkg.go.dev/runtime#AddCleanup
-func SetFinalizerDeprecated(m dsl.Matcher) {
+func PreferAddCleanup(m dsl.Matcher) {
 	m.Match(
 		`runtime.SetFinalizer($obj, $fn)`,
 	).

--- a/rules/slices.go
+++ b/rules/slices.go
@@ -65,10 +65,8 @@ func SortInts(m dsl.Matcher) {
 
 // BytesClone detects manual byte slice cloning and suggests bytes.Clone.
 //
-// Old patterns:
-//
-//	clone := make([]byte, len(original))
-//	copy(clone, original)
+// Old patterns (only the append-based forms are detected; the make+copy form
+// is not matched):
 //
 //	clone := append([]byte(nil), original...)
 //	clone := append([]byte{}, original...)
@@ -106,10 +104,8 @@ func BytesClone(m dsl.Matcher) {
 
 // SlicesClone detects manual slice cloning patterns and suggests slices.Clone.
 //
-// Old patterns:
-//
-//	clone := make([]T, len(original))
-//	copy(clone, original)
+// Old patterns (only the append-based forms are detected; the make+copy form
+// is not matched):
 //
 //	clone := append([]T(nil), original...)
 //
@@ -170,15 +166,20 @@ func SlicesClone(m dsl.Matcher) {
 // See: https://pkg.go.dev/slices#Backward
 func BackwardIteration(m dsl.Matcher) {
 	// Pattern: for i := len(s) - 1; i >= 0; i--
+	// Slice-type guard: slices.Backward is defined over []E, so without it the
+	// advice fires on strings (where len/index work but slices.Backward does
+	// not compile).
 	m.Match(
 		`for $i := len($s) - 1; $i >= 0; $i-- { $*body }`,
 	).
+		Where(m["s"].Type.Is(`[]$elem`)).
 		Report("use slices.Backward($s) for reverse iteration (Go 1.23+)")
 
 	// Pattern: for i := len(s) - 1; i > -1; i--
 	m.Match(
 		`for $i := len($s) - 1; $i > -1; $i-- { $*body }`,
 	).
+		Where(m["s"].Type.Is(`[]$elem`)).
 		Report("use slices.Backward($s) for reverse iteration (Go 1.23+)")
 }
 
@@ -267,14 +268,18 @@ func SliceRepeat(m dsl.Matcher) {
 		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+); false positive if $s depends on the loop variable")
 
 	// Pattern: range-over-integer form (with variable)
+	// Integer guard: without it, `for i := range items` over a []T (ranging the
+	// slice, not a count) matches and yields a non-compiling slices.Repeat(s, items).
 	m.Match(
 		`for $i := range $n { $result = append($result, $s...) }`,
 	).
+		Where(m["n"].Type.OfKind("int")).
 		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+); false positive if $s depends on the loop variable")
 
 	// Pattern: range-over-integer form (without variable)
 	m.Match(
 		`for range $n { $result = append($result, $s...) }`,
 	).
+		Where(m["n"].Type.OfKind("int")).
 		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+)")
 }

--- a/rules/slices.go
+++ b/rules/slices.go
@@ -172,14 +172,14 @@ func BackwardIteration(m dsl.Matcher) {
 	m.Match(
 		`for $i := len($s) - 1; $i >= 0; $i-- { $*body }`,
 	).
-		Where(m["s"].Type.Is(`[]$elem`)).
+		Where(m["s"].Type.Underlying().Is(`[]$elem`)).
 		Report("use slices.Backward($s) for reverse iteration (Go 1.23+)")
 
 	// Pattern: for i := len(s) - 1; i > -1; i--
 	m.Match(
 		`for $i := len($s) - 1; $i > -1; $i-- { $*body }`,
 	).
-		Where(m["s"].Type.Is(`[]$elem`)).
+		Where(m["s"].Type.Underlying().Is(`[]$elem`)).
 		Report("use slices.Backward($s) for reverse iteration (Go 1.23+)")
 }
 
@@ -268,18 +268,24 @@ func SliceRepeat(m dsl.Matcher) {
 		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+); false positive if $s depends on the loop variable")
 
 	// Pattern: range-over-integer form (with variable)
-	// Integer guard: without it, `for i := range items` over a []T (ranging the
-	// slice, not a count) matches and yields a non-compiling slices.Repeat(s, items).
+	// Require exactly int. Without a guard, `for i := range items` over a []T
+	// (ranging the slice, not a count) matches and yields a non-compiling
+	// slices.Repeat(s, items). slices.Repeat's count parameter is exactly int,
+	// so a named int type or int64 would also not compile; Type.Is("int") (not
+	// OfKind, which would match those) keeps the advice to compiling cases.
+	// Note: Type.Is("int") already covers the untyped-constant form `for range 5`
+	// (go/types gives the constant its default type int in range context), so a
+	// separate "untyped int" check is neither needed nor valid as a Type.Is arg.
 	m.Match(
 		`for $i := range $n { $result = append($result, $s...) }`,
 	).
-		Where(m["n"].Type.OfKind("int")).
+		Where(m["n"].Type.Is("int")).
 		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+); false positive if $s depends on the loop variable")
 
 	// Pattern: range-over-integer form (without variable)
 	m.Match(
 		`for range $n { $result = append($result, $s...) }`,
 	).
-		Where(m["n"].Type.OfKind("int")).
+		Where(m["n"].Type.Is("int")).
 		Report("use slices.Repeat($s, $n) instead of manual repetition loop (Go 1.23+)")
 }

--- a/rules/strings.go
+++ b/rules/strings.go
@@ -97,7 +97,7 @@ func StringsSplitIteration(m dsl.Matcher) {
 	m.Match(
 		`for $_, $part := range bytes.Split($s, $sep) { $*body }`,
 	).
-		Where(!m["sep"].Text.Matches(`\[\]byte\("\\r?\\n"\)`) && !m["sep"].Text.Matches(`\[\]byte\{.*\\n.*\}`)).
+		Where(!m["sep"].Text.Matches(`\[\]byte\("\\(r\\)?n"\)`) && !m["sep"].Text.Matches(`\[\]byte\{.*\\n.*\}`)).
 		Report("use for $part := range bytes.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.24+)")
 }
 

--- a/rules/strings.go
+++ b/rules/strings.go
@@ -12,7 +12,7 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 //	    process(line)
 //	}
 //
-// New pattern (Go 1.23+):
+// New pattern (Go 1.24+):
 //
 //	for line := range strings.Lines(s) {
 //	    process(line)
@@ -25,29 +25,38 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 //
 // See: https://pkg.go.dev/strings#Lines
 // See: https://pkg.go.dev/bytes#Lines
+// Note: strings.Lines is not a drop-in value-equivalent of ranging over
+// strings.Split: Lines keeps the line terminator (the trailing \n, and \r\n)
+// on each yielded line, whereas Split strips the separator. Callers that
+// compare or trim lines must account for that, so this stays Report-only.
 func StringsLinesIteration(m dsl.Matcher) {
 	// Pattern: for _, line := range strings.Split(s, "\n")
 	m.Match(
 		`for $_, $line := range strings.Split($s, "\n") { $*body }`,
 	).
-		Report(`use for $line := range strings.Lines($s) instead of ranging over strings.Split($s, "\n") (Go 1.23+); note: Lines() handles both \n and \r\n`)
+		Report(`use for $line := range strings.Lines($s) instead of ranging over strings.Split($s, "\n") (Go 1.24+); not value-equivalent: Lines keeps the trailing newline on each line, Split strips it`)
 
 	// Pattern: for _, line := range strings.Split(s, "\r\n")
 	m.Match(
 		`for $_, $line := range strings.Split($s, "\r\n") { $*body }`,
 	).
-		Report(`use for $line := range strings.Lines($s) instead of ranging over strings.Split($s, "\r\n") (Go 1.23+)`)
+		Report(`use for $line := range strings.Lines($s) instead of ranging over strings.Split($s, "\r\n") (Go 1.24+); not value-equivalent: Lines keeps the line terminator, Split strips it`)
 
 	// Also detect bytes.Split for line iteration
 	m.Match(
 		`for $_, $line := range bytes.Split($s, []byte("\n")) { $*body }`,
 	).
-		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split($s, []byte("\n")) (Go 1.23+)`)
+		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split($s, []byte("\n")) (Go 1.24+); not value-equivalent: Lines keeps the trailing newline, Split strips it`)
+
+	m.Match(
+		`for $_, $line := range bytes.Split($s, []byte("\r\n")) { $*body }`,
+	).
+		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split($s, []byte("\r\n")) (Go 1.24+); not value-equivalent: Lines keeps the line terminator, Split strips it`)
 
 	m.Match(
 		`for $_, $line := range bytes.Split($s, []byte{'\n'}) { $*body }`,
 	).
-		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split (Go 1.23+)`)
+		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split (Go 1.24+); not value-equivalent: Lines keeps the trailing newline, Split strips it`)
 }
 
 // StringsSplitIteration detects strings.Split used only for iteration
@@ -59,7 +68,7 @@ func StringsLinesIteration(m dsl.Matcher) {
 //	    process(part)
 //	}
 //
-// New pattern (Go 1.23+):
+// New pattern (Go 1.24+):
 //
 //	for part := range strings.SplitSeq(s, ",") {
 //	    process(part)
@@ -82,14 +91,14 @@ func StringsSplitIteration(m dsl.Matcher) {
 		`for $_, $part := range strings.Split($s, $sep) { $*body }`,
 	).
 		Where(!m["sep"].Text.Matches(`^"\\n"$`) && !m["sep"].Text.Matches(`^"\\r\\n"$`)).
-		Report("use for $part := range strings.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.23+)")
+		Report("use for $part := range strings.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.24+)")
 
 	// bytes.Split pattern
 	m.Match(
 		`for $_, $part := range bytes.Split($s, $sep) { $*body }`,
 	).
-		Where(!m["sep"].Text.Matches(`\[\]byte\("\\n"\)`) && !m["sep"].Text.Matches(`\[\]byte\{.*\\n.*\}`)).
-		Report("use for $part := range bytes.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.23+)")
+		Where(!m["sep"].Text.Matches(`\[\]byte\("\\r?\\n"\)`) && !m["sep"].Text.Matches(`\[\]byte\{.*\\n.*\}`)).
+		Report("use for $part := range bytes.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.24+)")
 }
 
 // StringsFieldsIteration detects strings.Fields used only for iteration
@@ -101,7 +110,7 @@ func StringsSplitIteration(m dsl.Matcher) {
 //	    process(field)
 //	}
 //
-// New pattern (Go 1.23+):
+// New pattern (Go 1.24+):
 //
 //	for field := range strings.FieldsSeq(s) {
 //	    process(field)
@@ -113,12 +122,12 @@ func StringsFieldsIteration(m dsl.Matcher) {
 	m.Match(
 		`for $_, $field := range strings.Fields($s) { $*body }`,
 	).
-		Report("use for $field := range strings.FieldsSeq($s) to avoid intermediate slice allocation (Go 1.23+)")
+		Report("use for $field := range strings.FieldsSeq($s) to avoid intermediate slice allocation (Go 1.24+)")
 
 	m.Match(
 		`for $_, $field := range bytes.Fields($s) { $*body }`,
 	).
-		Report("use for $field := range bytes.FieldsSeq($s) to avoid intermediate slice allocation (Go 1.23+)")
+		Report("use for $field := range bytes.FieldsSeq($s) to avoid intermediate slice allocation (Go 1.24+)")
 }
 
 // StringsFieldsFuncIteration detects strings.FieldsFunc used only for iteration
@@ -130,7 +139,7 @@ func StringsFieldsIteration(m dsl.Matcher) {
 //	    process(field)
 //	}
 //
-// New pattern (Go 1.23+):
+// New pattern (Go 1.24+):
 //
 //	for field := range strings.FieldsFuncSeq(s, f) {
 //	    process(field)
@@ -142,10 +151,10 @@ func StringsFieldsFuncIteration(m dsl.Matcher) {
 	m.Match(
 		`for $_, $field := range strings.FieldsFunc($s, $f) { $*body }`,
 	).
-		Report("use for $field := range strings.FieldsFuncSeq($s, $f) to avoid intermediate slice allocation (Go 1.23+)")
+		Report("use for $field := range strings.FieldsFuncSeq($s, $f) to avoid intermediate slice allocation (Go 1.24+)")
 
 	m.Match(
 		`for $_, $field := range bytes.FieldsFunc($s, $f) { $*body }`,
 	).
-		Report("use for $field := range bytes.FieldsFuncSeq($s, $f) to avoid intermediate slice allocation (Go 1.23+)")
+		Report("use for $field := range bytes.FieldsFuncSeq($s, $f) to avoid intermediate slice allocation (Go 1.24+)")
 }

--- a/rules/sync.go
+++ b/rules/sync.go
@@ -24,7 +24,9 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 // Benefits:
 //   - Cleaner, less error-prone (no Add/Done mismatch)
 //   - Single function call
-//   - Automatic panic handling
+//
+// Note: wg.Go still calls Done on panic (it is deferred), but it does not
+// recover the panic; a panicking task crashes the program just as before.
 //
 // See: https://pkg.go.dev/sync#WaitGroup.Go
 func WaitGroupGo(m dsl.Matcher) {
@@ -37,15 +39,7 @@ func WaitGroupGo(m dsl.Matcher) {
 		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)").
 		Suggest("$wg.Go(func() { $body })")
 
-	// Pattern 2: Same but with pointer receiver explicitly
-	m.Match(
-		`$wg.Add(1); go func() { defer $wg.Done(); $*body }()`,
-	).
-		Where(m["wg"].Type.Underlying().Is("sync.WaitGroup")).
-		Report("use $wg.Go(func() { $body }) instead of manual Add/Done pattern (Go 1.25+)").
-		Suggest("$wg.Go(func() { $body })")
-
-	// Pattern 3: When wg is passed by reference to the closure
+	// Pattern 2: When wg is passed by reference to the closure
 	m.Match(
 		`$wg.Add(1); go func($param $typ) { defer $param.Done(); $*body }($wg)`,
 		`$wg.Add(1); go func($param $typ) { defer $param.Done(); $*body }(&$wg)`,

--- a/rules/testing.go
+++ b/rules/testing.go
@@ -76,6 +76,11 @@ func BenchmarkLoop(m dsl.Matcher) {
 //   - Test cleanup is properly signaled to goroutines
 //   - Resources are released promptly on test failure
 //
+// Caveat: this matches by file name (_test.go), so it also fires inside
+// TestMain(m *testing.M) and any plain helper where no *testing.T or *testing.B
+// is in scope; in those spots neither t.Context() nor b.Context() applies and
+// the suggestion should be ignored.
+//
 // See: https://pkg.go.dev/testing#T.Context
 // See: https://pkg.go.dev/testing#B.Context
 func TestingContext(m dsl.Matcher) {
@@ -85,7 +90,7 @@ func TestingContext(m dsl.Matcher) {
 		`$ctx = context.Background()`,
 	).
 		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() instead of context.Background() for automatic cancellation on test completion (Go 1.24+)")
+		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.Background() for automatic cancellation on test completion (Go 1.24+)")
 
 	// Pattern 2: Assigning context.TODO() to a variable
 	m.Match(
@@ -93,21 +98,21 @@ func TestingContext(m dsl.Matcher) {
 		`$ctx = context.TODO()`,
 	).
 		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() instead of context.TODO() for automatic cancellation on test completion (Go 1.24+)")
+		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.TODO() for automatic cancellation on test completion (Go 1.24+)")
 
 	// Pattern 3: Passing context.Background() directly to a function
 	m.Match(
 		`$fn(context.Background(), $*args)`,
 	).
 		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() instead of context.Background() (Go 1.24+)")
+		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.Background() (Go 1.24+)")
 
 	// Pattern 4: Passing context.TODO() directly to a function
 	m.Match(
 		`$fn(context.TODO(), $*args)`,
 	).
 		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() instead of context.TODO() (Go 1.24+)")
+		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.TODO() (Go 1.24+)")
 }
 
 // TestingArtifactDir detects os.MkdirTemp in test files and suggests using

--- a/rules/time.go
+++ b/rules/time.go
@@ -29,11 +29,13 @@ func TimeDateTimeConstants(m dsl.Matcher) {
 	// DateTime: "2006-01-02 15:04:05"
 	// The type guard keeps the Format matches from firing on any value with a
 	// Format(string) method (e.g. a custom formatter), where the time.* constant
-	// is undefined and --fix would emit non-compiling "undefined: time".
+	// is undefined and --fix would emit non-compiling "undefined: time". Both
+	// time.Time and *time.Time are accepted: Format has a value receiver, so it
+	// is also called through a pointer (common for nullable/optional fields).
 	m.Match(
 		`$t.Format("2006-01-02 15:04:05")`,
 	).
-		Where(m["t"].Type.Is("time.Time")).
+		Where(m["t"].Type.Is("time.Time") || m["t"].Type.Is("*time.Time")).
 		Report(`use $t.Format(time.DateTime) instead of magic format string (Go 1.20+)`).
 		Suggest(`$t.Format(time.DateTime)`)
 
@@ -47,7 +49,7 @@ func TimeDateTimeConstants(m dsl.Matcher) {
 	m.Match(
 		`$t.Format("2006-01-02")`,
 	).
-		Where(m["t"].Type.Is("time.Time")).
+		Where(m["t"].Type.Is("time.Time") || m["t"].Type.Is("*time.Time")).
 		Report(`use $t.Format(time.DateOnly) instead of magic format string (Go 1.20+)`).
 		Suggest(`$t.Format(time.DateOnly)`)
 
@@ -61,7 +63,7 @@ func TimeDateTimeConstants(m dsl.Matcher) {
 	m.Match(
 		`$t.Format("15:04:05")`,
 	).
-		Where(m["t"].Type.Is("time.Time")).
+		Where(m["t"].Type.Is("time.Time") || m["t"].Type.Is("*time.Time")).
 		Report(`use $t.Format(time.TimeOnly) instead of magic format string (Go 1.20+)`).
 		Suggest(`$t.Format(time.TimeOnly)`)
 

--- a/rules/time.go
+++ b/rules/time.go
@@ -207,8 +207,15 @@ func DeferredTimeNow(m dsl.Matcher) {
 	).
 		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
 
+	// time.Now() as the last argument (with preceding args).
 	m.Match(
 		`defer $fn($*args, time.Now())`,
+	).
+		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
+
+	// time.Now() as the first argument (with trailing args).
+	m.Match(
+		`defer $fn(time.Now(), $*args)`,
 	).
 		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
 }


### PR DESCRIPTION
Replaces #39, which GitHub auto-closed when its stacked base branch (#38) was deleted on merge. Rebased onto `main` (only the #31 work remains) and incorporates the gemini-code-assist review feedback from both #38 (already merged) and #39.

Addresses most of #31.

## #31 fixes

**Correctness:**
- **BackwardIteration**: add a slice-type guard via `Type.Underlying().Is("[]$elem")` so it fires on slices (including named slice types like `type MySlice []int`) but not strings, where `slices.Backward` does not compile.
- **SliceRepeat**: constrain `$n` with `Type.Is("int")` on the range forms. `slices.Repeat`'s count is exactly `int`, so a `[]T`, a named int type, or `int64` would all yield a non-compiling suggestion.
- **WeakRSAKeySize**: one `Where(m["bits"].Const && m["bits"].Value.Int() < 2048)` predicate replaces the `512`/`768`/`1024` literals. The `.Const` guard is required: `Value.Int()` returns `0` for a non-constant arg, which would otherwise match every `rsa.GenerateKey(rand, someVar)`.
- **WaitGroupGo**: delete the dead pattern-2 clause (`Type.Underlying().Is("sync.WaitGroup")` can never be true) and drop the wrong "Automatic panic handling" benefit.
- **DeferredTimeNow**: also match `time.Now()` as the first argument with trailing args.

**Messages and versions (verified against pkg.go.dev):**
- **ErrorsAsType**: use a literal `T` placeholder instead of interpolating the bound variable into the type slot.
- **strings.go**: `Lines`/`SplitSeq`/`FieldsSeq`/`FieldsFuncSeq` (+ `bytes`) shipped in Go **1.24**, not 1.23.
- **StringsLinesIteration**: note the rewrite is not value-equivalent (`Lines` keeps the line terminator, `Split` strips it); add the `bytes.Split(s, []byte("\r\n"))` case and a `\n`/`\r\n` exclusion in `StringsSplitIteration` so it no longer double-warns.
- **net.go**: `ReverseProxy.Rewrite`/Director deprecation are Go **1.20**, not 1.26.
- **runtime.go**: rename `SetFinalizerDeprecated` -> `PreferAddCleanup` (`runtime.SetFinalizer` is not deprecated as of Go 1.26).
- **TestingContext**: mention `b.Context()` for benchmarks and note the `TestMain` false positive.

**Docs and autofix:**
- Trim doc examples that claimed patterns with no matching clause (`MinMaxBuiltin` if/else, `ClearBuiltin` slice zeroing, `BytesClone`/`SlicesClone` make+copy).
- **ReflectTypeOf**: add an import-safe `Suggest` (the rewrite stays in the already-imported `reflect` package).

## Follow-up to #30 (already merged in #38)

The Gemini review on #38 posted after it merged; folding those fixes in here:
- **RangeOverInteger** body-exclusion regex: add `(?s)` and a non-greedy match so multi-line single-statement appends are still excluded (otherwise `SliceRepeat` gets re-shadowed).
- **TimeDateTimeConstants**: accept `*time.Time` as well as `time.Time` (`Format` has a value receiver, so it is called through pointers).

## Verification

Each change reproduced with `golangci-lint run` against fixtures, including the cases the first pass missed: a variable RSA key size (no longer false-fires), `bytes.Split(s, []byte("\n"))` (routes to `Lines` only, no duplicate), a named slice type and named/`int64` counts, a multi-line append body, and `*time.Time.Format`. `go build -tags ruleguard ./rules/` passes; repo lints clean and `go test ./...` is green.

## Still open on #31 (policy/judgment, deliberately not here)

Linter overlap dedup vs `govet`/`staticcheck` SA1019; enabling `nosprintfhostport`/`usetesting`; whether to keep or drop the noisy `FilepathIsLocal`.

Refs #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection and safer suggestions for RSA key sizes, string/bytes iterators, slices, and time-format/deferred-now patterns.
* **Bug Fixes**
  * Reduced false positives by tightening matching rules (slice guards, iterator/newline handling, loop/body filters).
* **Chores**
  * Updated advisory wording for runtime cleanup guidance and error-type suggestions; corrected Go version references and clarified builtin detection scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->