### PR TITLE
fix(manager): normalize cwd before gate keying and cache lookups

### DIFF
--- a/internal/manager/job_linux_test.go
+++ b/internal/manager/job_linux_test.go
@@ -171,7 +171,9 @@ func TestStartJobSerializesEquivalentCwdSpellings(t *testing.T) {
 	// regardless of how the test exits; the fake supervisor does not forward
 	// signals, so Cancel alone would leave the sleep running.
 	t.Cleanup(func() {
-		if meta, lerr := m.store.Load(job1.ID); lerr == nil {
+		// Guard the PID: syscall.Kill(-0, ...) would signal the test runner's own
+		// process group, and a negative target needs a real group leader.
+		if meta, lerr := m.store.Load(job1.ID); lerr == nil && meta.PID > 0 {
 			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
 		}
 	})

--- a/internal/manager/job_linux_test.go
+++ b/internal/manager/job_linux_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -88,6 +89,99 @@ func TestStartJobCleansUpDirOnSpawnFailure(t *testing.T) {
 	_, err2 := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
 	if err2 == nil || !strings.Contains(err2.Error(), "spawn supervisor") {
 		t.Fatalf("second run error = %v, want spawn-supervisor (gate slot leaked?)", err2)
+	}
+}
+
+// TestStartJobNormalizesCwd verifies StartJob canonicalizes a trailing-slash
+// (or otherwise non-canonical) cwd before it reaches the gate key and the
+// persisted meta, so two "same dir" runs serialize and the agy cache lookup
+// matches. Regression test for issue #24.
+func TestStartJobNormalizesCwd(t *testing.T) {
+	dir := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		StateDir:       t.TempDir(),
+		DefaultTimeout: time.Minute,
+		DefaultModel:   "Gemini 3.1 Pro (High)",
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	// Inject a temp cache file so the run does not read the real ~/.gemini cache,
+	// and shorten the post-exit capture so no capture goroutine outlives the test.
+	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	m.captureBudget = 0
+
+	job, err := m.StartJob(StartRequest{Prompt: "x", Cwd: dir + "/"})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	meta, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if meta.Cwd != canonical {
+		t.Errorf("meta.Cwd = %q, want canonical %q (trailing slash not normalized)", meta.Cwd, canonical)
+	}
+	// The model and timeout defaults must be resolved into meta (and the args),
+	// not left stale: issue #24 asks to normalize all-or-none.
+	if meta.Model != "Gemini 3.1 Pro (High)" {
+		t.Errorf("meta.Model = %q, want the resolved default", meta.Model)
+	}
+	if meta.Timeout != time.Minute {
+		t.Errorf("meta.Timeout = %v, want the resolved default", meta.Timeout)
+	}
+	if !hasArg(meta.Args, "--model", "Gemini 3.1 Pro (High)") {
+		t.Errorf("args missing resolved default model: %v", meta.Args)
+	}
+	if !hasArg(meta.Args, "--print-timeout", time.Minute.String()) {
+		t.Errorf("args missing resolved default timeout: %v", meta.Args)
+	}
+}
+
+// TestStartJobSerializesEquivalentCwdSpellings proves the headline behavior of
+// issue #24: two fresh runs whose cwd is spelled differently (here a trailing
+// slash) collapse to one normalized gate key, so the second is refused while the
+// first still holds it. Without normalization the two keys differ and the runs
+// would not serialize, re-exposing the agy session-lock hang the gate prevents.
+func TestStartJobSerializesEquivalentCwdSpellings(t *testing.T) {
+	dir := t.TempDir()
+	// A sleeping fake agy keeps the first supervisor alive, so its gate key stays
+	// held while the second run is attempted.
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", SleepSecs: 30})
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy}),
+		StateDir:       t.TempDir(),
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+
+	job1, err := m.StartJob(StartRequest{Prompt: "first", Cwd: dir})
+	if err != nil {
+		t.Fatalf("first StartJob: %v", err)
+	}
+	// Reap the whole supervisor group (bash + the sleeping fake agy) promptly,
+	// regardless of how the test exits; the fake supervisor does not forward
+	// signals, so Cancel alone would leave the sleep running.
+	t.Cleanup(func() {
+		if meta, lerr := m.store.Load(job1.ID); lerr == nil {
+			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
+		}
+	})
+
+	// The same directory spelled with a trailing slash normalizes to the same
+	// gate key, so the gate must refuse it while job1 holds the key. The cap (4)
+	// is not the limiter here; the per-cwd key is.
+	_, err = m.StartJob(StartRequest{Prompt: "second", Cwd: dir + "/"})
+	if err == nil || !strings.Contains(err.Error(), "conflicting") {
+		t.Fatalf("second run error = %v, want a gate conflict (equivalent cwd spellings not serialized)", err)
 	}
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -256,11 +256,13 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		cwd = wd
 	}
 	// Canonicalize the cwd once so the gate key, cache lookups, cmd.Dir, and
-	// persisted meta all share one spelling (see normalizeCwd).
-	cwd, err = normalizeCwd(cwd)
+	// persisted meta all share one spelling (see normalizeCwd). Report the
+	// pre-normalization input on failure (normalizeCwd returns "" on error).
+	normalized, err := normalizeCwd(cwd)
 	if err != nil {
-		return Job{}, fmt.Errorf("normalize working directory %q: %w", req.Cwd, err)
+		return Job{}, fmt.Errorf("normalize working directory %q: %w", cwd, err)
 	}
+	cwd = normalized
 
 	// Resolve every value that feeds the gate key, agy args, and persisted meta
 	// back into req, so all three derive from one normalized request; keeping a

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -247,20 +247,32 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 	cwd := req.Cwd
 	if cwd == "" {
-		if wd, err := os.Getwd(); err == nil {
-			cwd = wd
+		wd, err := os.Getwd()
+		if err != nil {
+			// An empty cwd would produce gate key "", which skips serialization
+			// entirely and runs agy in an inherited directory. Fail instead.
+			return Job{}, fmt.Errorf("determine working directory: %w", err)
 		}
+		cwd = wd
 	}
-	model := req.Model
-	if model == "" {
-		model = m.cfg.DefaultModel
-	}
-	timeout := req.Timeout
-	if timeout <= 0 {
-		timeout = m.cfg.DefaultTimeout
+	// Canonicalize the cwd once so the gate key, cache lookups, cmd.Dir, and
+	// persisted meta all share one spelling (see normalizeCwd).
+	cwd, err = normalizeCwd(cwd)
+	if err != nil {
+		return Job{}, fmt.Errorf("normalize working directory %q: %w", req.Cwd, err)
 	}
 
+	// Resolve every value that feeds the gate key, agy args, and persisted meta
+	// back into req, so all three derive from one normalized request; keeping a
+	// resolved value in a separate local while req stays stale risks a later read
+	// of req.Model/req.Timeout silently bypassing the default fallback.
 	req.Cwd = cwd
+	if req.Model == "" {
+		req.Model = m.cfg.DefaultModel
+	}
+	if req.Timeout <= 0 {
+		req.Timeout = m.cfg.DefaultTimeout
+	}
 
 	// Resolve continue_latest to a concrete conversation id before computing the
 	// gate key and args, so serialization, the agy --conversation flag, and the
@@ -276,18 +288,18 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		return Job{}, fmt.Errorf("a conflicting agy job for this conversation or directory is already running")
 	}
 
-	args := buildAgyArgs(req, model, timeout)
+	args := buildAgyArgs(req)
 	meta := jobstore.Meta{
 		ID:             id,
 		AgyPath:        m.cfg.AgyPath,
 		Args:           args,
-		Cwd:            cwd,
-		Model:          model,
+		Cwd:            req.Cwd,
+		Model:          req.Model,
 		ConversationID: req.ConversationID,
 		Prompt:         req.Prompt,
 		StartedAt:      time.Now().UTC(),
 		BootID:         readBootID(),
-		Timeout:        timeout,
+		Timeout:        req.Timeout,
 	}
 	// Whenever the run has no resolved conversation id (a fresh run, or a
 	// continue_latest that found no prior conversation), agy will create a new
@@ -457,8 +469,20 @@ func (m *Manager) runPeriodicGC(ctx context.Context, interval time.Duration) {
 // gate key from its persisted meta. continue_latest is resolved into
 // ConversationID at start time, so ConversationID + Cwd reproduce the same key
 // the original run held.
+//
+// The cwd is re-normalized (best effort) so a job persisted by an older binary,
+// before StartJob canonicalized cwd, restores under the same key a new
+// same-directory run now computes. Without this, across the upgrade a restored
+// legacy job (raw cwd) and a new run (normalized cwd) would hold different keys,
+// fail to serialize, and risk concurrent O_TRUNC writes to the same agy cache
+// entry. For jobs started by the current binary meta.Cwd is already normalized,
+// so this is idempotent.
 func reqFromMeta(meta jobstore.Meta) StartRequest {
-	return StartRequest{ConversationID: meta.ConversationID, Cwd: meta.Cwd}
+	cwd := meta.Cwd
+	if norm, err := normalizeCwd(cwd); err == nil {
+		cwd = norm
+	}
+	return StartRequest{ConversationID: meta.ConversationID, Cwd: cwd}
 }
 
 // RestoreGate re-acquires gate slots and keys for jobs whose detached supervisor
@@ -540,10 +564,10 @@ func (m *Manager) watchRestored(meta jobstore.Meta, key string) {
 	}()
 }
 
-func buildAgyArgs(req StartRequest, model string, timeout time.Duration) []string {
-	args := []string{"--dangerously-skip-permissions", "--print-timeout", timeout.String()}
-	if model != "" {
-		args = append(args, "--model", model)
+func buildAgyArgs(req StartRequest) []string {
+	args := []string{"--dangerously-skip-permissions", "--print-timeout", req.Timeout.String()}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
 	}
 	for _, d := range req.Dirs {
 		args = append(args, "--add-dir", d)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -483,6 +483,13 @@ func reqFromMeta(meta jobstore.Meta) StartRequest {
 	cwd := meta.Cwd
 	if norm, err := normalizeCwd(cwd); err == nil {
 		cwd = norm
+	} else {
+		// Restore stays resilient (unlike StartJob, which fails closed), so a job
+		// whose cwd cannot be normalized keeps its raw cwd for the gate key. Log it:
+		// under this rare path (a legacy relative cwd plus an os.Getwd failure) the
+		// restored key may not match a new same-directory run's normalized key, the
+		// one inconsistency that can still split serialization for that job.
+		log.Printf("agy-mcp: normalize cwd %q for restored job %s: %v; using raw cwd for gate key", cwd, meta.ID, err)
 	}
 	return StartRequest{ConversationID: meta.ConversationID, Cwd: cwd}
 }

--- a/internal/manager/normalize.go
+++ b/internal/manager/normalize.go
@@ -1,0 +1,28 @@
+package manager
+
+import "path/filepath"
+
+// normalizeCwd canonicalizes a working directory so the gate key, the agy
+// conversation-cache lookups, the spawned cmd.Dir, and the persisted meta all
+// agree on one spelling. A trailing slash, a relative path, or a symlinked alias
+// would otherwise yield a distinct gate key (two "same dir" fresh runs would not
+// serialize, re-exposing the agy session-lock hang the gate exists to prevent)
+// and a missed cache entry (continue_latest silently starts a new conversation,
+// and a fresh run's id capture never matches).
+//
+// EvalSymlinks also aligns the key with the physical path agy records: the
+// supervisor sets cmd.Dir to this value, so agy's own getcwd returns the
+// symlink-resolved path and keys last_conversations.json by that.
+func normalizeCwd(cwd string) (string, error) {
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", err
+	}
+	// Best-effort symlink resolution: a path that does not exist yet (agy will
+	// fail on it regardless) or is otherwise unresolvable keeps the cleaned
+	// absolute form instead of failing the run here.
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved, nil
+	}
+	return abs, nil
+}

--- a/internal/manager/normalize.go
+++ b/internal/manager/normalize.go
@@ -14,6 +14,13 @@ import "path/filepath"
 // supervisor sets cmd.Dir to this value, so agy's own getcwd returns the
 // symlink-resolved path and keys last_conversations.json by that.
 func normalizeCwd(cwd string) (string, error) {
+	if cwd == "" {
+		// filepath.Abs("") resolves to the process working directory, which would
+		// turn an empty cwd (a legacy job persisted with no cwd, or any caller that
+		// means "no directory") into a bogus, unrelated gate key. An empty cwd has
+		// no canonical form; keep it empty so keyFor yields the no-key behavior.
+		return "", nil
+	}
 	abs, err := filepath.Abs(cwd)
 	if err != nil {
 		return "", err

--- a/internal/manager/normalize_test.go
+++ b/internal/manager/normalize_test.go
@@ -74,6 +74,27 @@ func TestReqFromMetaNormalizesLegacyCwd(t *testing.T) {
 	}
 }
 
+// TestNormalizeCwdPreservesEmpty locks the empty-cwd guard: filepath.Abs("")
+// resolves to the process working directory, which would turn a legacy job's
+// empty meta.Cwd into a bogus, unrelated gate key. An empty cwd must stay empty.
+func TestNormalizeCwdPreservesEmpty(t *testing.T) {
+	got, err := normalizeCwd("")
+	if err != nil {
+		t.Fatalf("normalizeCwd(empty): %v", err)
+	}
+	if got != "" {
+		t.Errorf("normalizeCwd(empty) = %q, want empty", got)
+	}
+}
+
+// TestReqFromMetaPreservesEmptyCwd verifies a legacy job persisted with no cwd
+// restores under the no-key behavior, not under the manager's working directory.
+func TestReqFromMetaPreservesEmptyCwd(t *testing.T) {
+	if k := keyFor(reqFromMeta(jobstore.Meta{Cwd: ""})); k != "" {
+		t.Errorf("restored gate key for empty cwd = %q, want empty", k)
+	}
+}
+
 // TestNormalizeCwdKeepsAbsoluteFormWhenUnresolvable verifies the best-effort
 // symlink step does not fail the run for a path that does not exist yet: it
 // falls back to the cleaned absolute form (agy itself will fail on a bad cwd).

--- a/internal/manager/normalize_test.go
+++ b/internal/manager/normalize_test.go
@@ -1,0 +1,89 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// TestNormalizeCwdCollapsesEquivalentSpellings is the core regression guard for
+// issue #24: a trailing slash, a relative path, and a symlinked alias of one
+// directory must all canonicalize to the same absolute, symlink-resolved path,
+// so they produce one gate key (same-dir fresh runs serialize) and hit the same
+// agy conversation-cache entry.
+func TestNormalizeCwdCollapsesEquivalentSpellings(t *testing.T) {
+	realDir := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", realDir, err)
+	}
+
+	t.Run("trailing slash", func(t *testing.T) {
+		got, err := normalizeCwd(realDir + string(filepath.Separator))
+		if err != nil {
+			t.Fatalf("normalizeCwd: %v", err)
+		}
+		if got != canonical {
+			t.Errorf("got %q, want %q", got, canonical)
+		}
+	})
+
+	t.Run("symlinked alias", func(t *testing.T) {
+		link := filepath.Join(t.TempDir(), "link")
+		if err := os.Symlink(realDir, link); err != nil {
+			t.Fatalf("Symlink: %v", err)
+		}
+		got, err := normalizeCwd(link)
+		if err != nil {
+			t.Fatalf("normalizeCwd: %v", err)
+		}
+		if got != canonical {
+			t.Errorf("symlink resolved to %q, want %q", got, canonical)
+		}
+	})
+
+	t.Run("relative path", func(t *testing.T) {
+		t.Chdir(filepath.Dir(realDir))
+		got, err := normalizeCwd(filepath.Base(realDir))
+		if err != nil {
+			t.Fatalf("normalizeCwd: %v", err)
+		}
+		if got != canonical {
+			t.Errorf("relative path resolved to %q, want %q", got, canonical)
+		}
+	})
+}
+
+// TestReqFromMetaNormalizesLegacyCwd guards the upgrade window: a job persisted
+// by an older binary may have a raw, un-normalized meta.Cwd. RestoreGate must
+// fold it onto the same normalized gate key a new same-dir run computes, or the
+// two would not serialize and could issue concurrent O_TRUNC writes to the same
+// agy cache entry. Regression test for issue #24.
+func TestReqFromMetaNormalizesLegacyCwd(t *testing.T) {
+	dir := t.TempDir()
+	canonical, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	req := reqFromMeta(jobstore.Meta{Cwd: dir + "/"})
+	want := "cwd:" + canonical
+	if got := keyFor(req); got != want {
+		t.Errorf("restored gate key = %q, want %q (legacy cwd not normalized)", got, want)
+	}
+}
+
+// TestNormalizeCwdKeepsAbsoluteFormWhenUnresolvable verifies the best-effort
+// symlink step does not fail the run for a path that does not exist yet: it
+// falls back to the cleaned absolute form (agy itself will fail on a bad cwd).
+func TestNormalizeCwdKeepsAbsoluteFormWhenUnresolvable(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "sub")
+	got, err := normalizeCwd(missing)
+	if err != nil {
+		t.Fatalf("normalizeCwd should not fail on a missing path: %v", err)
+	}
+	if got != filepath.Clean(missing) {
+		t.Errorf("got %q, want cleaned absolute %q", got, filepath.Clean(missing))
+	}
+}

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -45,7 +45,17 @@ func readSessions(cacheFile, filterDir string) ([]Session, error) {
 	}
 	cleanFilter := ""
 	if filterDir != "" {
-		cleanFilter = filepath.Clean(filterDir)
+		// Canonicalize the filter the same way StartJob canonicalizes a run's cwd
+		// (filepath.Abs + best-effort EvalSymlinks; see normalizeCwd), so the filter
+		// matches the resolved paths agy keys its cache by. A symlinked or relative
+		// filter would otherwise never match a stored entry. normalizeCwd only errors
+		// when Abs fails (a relative path with no working directory); fall back to
+		// Clean so a filter is still applied.
+		if norm, nerr := normalizeCwd(filterDir); nerr == nil {
+			cleanFilter = norm
+		} else {
+			cleanFilter = filepath.Clean(filterDir)
+		}
 	}
 	var out []Session
 	for ws, id := range raw {

--- a/internal/manager/sessions_test.go
+++ b/internal/manager/sessions_test.go
@@ -35,3 +35,36 @@ func TestListSessionsFilteredByDir(t *testing.T) {
 		t.Fatalf("got %+v", sessions)
 	}
 }
+
+// TestListSessionsFilterCanonicalizesSymlink verifies the session filter matches
+// the resolved path agy keys its cache by, even when the caller passes a
+// symlinked alias of that directory. agy keys last_conversations.json by the
+// symlink-resolved physical path (its cmd.Dir getcwd), so a Clean-only filter on
+// a symlinked alias would never match. The filter must canonicalize the same way
+// StartJob canonicalizes a run's cwd (issue #24).
+func TestListSessionsFilterCanonicalizesSymlink(t *testing.T) {
+	realDir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(realDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	cache := filepath.Join(t.TempDir(), "last_conversations.json")
+	// agy stores the entry under the resolved physical path.
+	data := `{"` + resolved + `":"uuid-1"}`
+	if err := os.WriteFile(cache, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Filtering by the symlinked alias must still find the resolved entry.
+	sessions, err := readSessions(cache, link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
+		t.Fatalf("symlinked filter did not match resolved cache key: got %+v", sessions)
+	}
+}


### PR DESCRIPTION
## Summary

A raw client-supplied `cwd` flowed straight into the gate key and the agy conversation-cache lookups, so a trailing slash, a relative path, or a symlinked alias of one directory produced a distinct gate key. Two "same dir" fresh runs were then not serialized (re-exposing the agy session-lock hang the gate exists to prevent), and the cache entry was missed (`continue_latest` silently started a new conversation; fresh-run id capture never matched).

The fix canonicalizes the cwd once at the top of `StartJob` with `filepath.Abs` plus a best-effort `filepath.EvalSymlinks`, and uses the result for the gate key, the cache snapshot/resolve, the agy args, and the persisted meta. Because the supervisor sets `cmd.Dir` to this value, agy's own `getcwd` returns the symlink-resolved physical path and keys `last_conversations.json` by that, so resolving symlinks makes our key match agy's.

### Changes
- **Normalize cwd in `StartJob`** and feed it to the gate key, cache lookups, args, and meta.
- **Fail `StartJob` when `os.Getwd` errors** instead of running agy in an inherited directory under gate key `""`.
- **Resolve `model`/`timeout` defaults back into `req`** so the gate key, args, and meta all derive from one normalized request; a later read of a stale `req.Model`/`req.Timeout` can no longer bypass the default fallback. `buildAgyArgs` now reads from `req`.
- **Canonicalize the `list_sessions` filter** through the same helper, so a symlinked or relative filter matches the resolved paths agy keys its cache by (previously it never matched).
- **Re-normalize cwd in `reqFromMeta`** so a job persisted by an older binary (raw cwd) restores under the same key a new normalized run computes, closing an upgrade-window race where the two would not serialize and could issue concurrent `O_TRUNC` writes to the same agy cache entry.

The last two items address findings from peer review (five parallel reviewers plus Gemini 3.1 Pro cross-validation) that confirmed the core fix and surfaced the `list_sessions` inconsistency and the upgrade-window race.

## Related Issues
Closes #24

## Test Plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean, `gofmt`/`go vet` clean
- [x] `go build -tags ruleguard ./rules/` builds
- [x] New regression tests cover: trailing-slash / relative / symlinked spellings, the unresolvable-path fallback, the normalized persisted meta, two equivalent-cwd runs collapsing to one gate key (verified to fail without the fix), the symlinked `list_sessions` filter (verified to fail without the fix), and the legacy-meta restore key (verified to fail without the fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Working directory paths are consistently normalized for job starts, restores, gating, and session reads so equivalent CWD spellings (symlinks, trailing slashes, relative forms) behave identically.
  * Job startup records consistent defaults (model/timeout) in job metadata and reliably rejects conflicting concurrent runs for the same canonical CWD.

* **Tests**
  * Added regression tests covering CWD normalization, job serialization conflicts, session filtering with symlinks, and related cleanup to keep tests deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->