### PR TITLE
fix(status): stderr tail, IO-error handling, spawn-fail and models errors

### DIFF
--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -2,6 +2,8 @@ package manager
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -10,7 +12,13 @@ import (
 func (m *Manager) ListModels(ctx context.Context) ([]string, error) {
 	out, err := exec.CommandContext(ctx, m.cfg.AgyPath, "models").Output()
 	if err != nil {
-		return nil, err
+		// Output() captures stderr into (*exec.ExitError).Stderr; include it so a
+		// real cause (an auth prompt, a usage error) is visible instead of a bare
+		// "exit status 1".
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok && len(ee.Stderr) > 0 {
+			return nil, fmt.Errorf("agy models: %w: %s", err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, fmt.Errorf("agy models: %w", err)
 	}
 	return parseModels(string(out)), nil
 }

--- a/internal/manager/models_test.go
+++ b/internal/manager/models_test.go
@@ -1,6 +1,24 @@
 package manager
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// TestListModelsIncludesStderrOnError: when `agy models` fails, the error must
+// carry agy's stderr (e.g. an auth prompt) rather than a bare "exit status 1".
+func TestListModelsIncludesStderrOnError(t *testing.T) {
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stderr: "agy: not logged in", Exit: 1})
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	_, err := m.ListModels(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "not logged in") {
+		t.Fatalf("err = %v, want it to include agy's stderr", err)
+	}
+}
 
 func TestParseModels(t *testing.T) {
 	raw := "Gemini 3.5 Flash (Medium)\nGemini 3.1 Pro (High)\n\nClaude Opus 4.6 (Thinking)\n"

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -1,7 +1,10 @@
 package manager
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,6 +19,10 @@ import (
 // runaway agy emitting huge output cannot OOM the server. Reviews are text and
 // far smaller than this; anything larger is truncated.
 const maxReadBytes = 32 << 20 // 32 MiB
+
+// errTailBytes is how much of the trailing stderr a failed job reports. The tail
+// (not the head) is what matters: the final lines carry the actual error.
+const errTailBytes = 2000
 
 // Job states reported by Status. These are shared with StartJob and the gate
 // watchdog so the producer and consumer of a job's state cannot drift apart.
@@ -63,12 +70,16 @@ func (m *Manager) Status(id string) (Status, error) {
 		return m.statusFromExitCode(dir, meta, st, code), nil
 	}
 	// Process is gone without a sentinel. If output was captured, recover it.
-	out := readFile(filepath.Join(dir, "out"))
-	if out != "" {
+	out, rerr := readFile(filepath.Join(dir, "out"))
+	switch {
+	case rerr != nil:
+		st.State = StateFailed
+		st.Error = fmt.Sprintf("job process exited and its output could not be read: %v", rerr)
+	case out != "":
 		st.State = StateDone
 		st.Result = out
 		st.ConversationID = m.lazyCaptureConversationID(meta)
-	} else {
+	default:
 		st.State = StateFailed
 		st.Error = "job process exited without writing a result (interrupted)"
 	}
@@ -79,14 +90,31 @@ func (m *Manager) Status(id string) (Status, error) {
 func (m *Manager) statusFromExitCode(dir string, meta jobstore.Meta, st Status, code int) Status {
 	switch code {
 	case 0:
-		st.State = StateDone
-		st.Result = readFile(filepath.Join(dir, "out"))
+		// Capture the conversation id first: a clean exit means the backend
+		// conversation advanced, so even if the local out file cannot be read the
+		// caller still needs the id to continue the conversation.
 		st.ConversationID = m.lazyCaptureConversationID(meta)
+		out, err := readFile(filepath.Join(dir, "out"))
+		if err != nil {
+			// The job exited cleanly but we cannot read what it produced. Report
+			// that as a failure rather than a successful empty result.
+			st.State = StateFailed
+			st.Error = fmt.Sprintf("job completed but its output could not be read: %v", err)
+			return st
+		}
+		st.State = StateDone
+		st.Result = out
 	case jobstore.ExitSIGTERM, jobstore.ExitSIGINT:
 		st.State = StateCancelled
 	case jobstore.ExitTimeout:
 		st.State = StateFailed
 		st.Error = "job exceeded its timeout and was terminated"
+	case jobstore.ExitSpawnFail:
+		// 127 is written both when the supervisor could not exec agy and when agy
+		// itself exits 127, so name both causes rather than asserting one, and keep
+		// any stderr (a true spawn failure has none; a genuine agy 127 does).
+		st.State = StateFailed
+		st.Error = spawnFailMessage(dir)
 	default:
 		st.State = StateFailed
 		st.Error = errorSummary(dir, code)
@@ -94,27 +122,93 @@ func (m *Manager) statusFromExitCode(dir string, meta jobstore.Meta, st Status, 
 	return st
 }
 
-func readFile(p string) string {
+// readFile returns the file's contents (trailing newline trimmed), capped at
+// maxReadBytes. A missing file yields "" with no error: a job may legitimately
+// have produced no output. Any other error is returned so callers can tell an
+// unreadable file (report a failure) from an empty one (a clean empty result).
+func readFile(p string) (string, error) {
 	f, err := os.Open(p)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer func() { _ = f.Close() }()
 	b, err := io.ReadAll(io.LimitReader(f, maxReadBytes))
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return strings.TrimRight(string(b), "\n")
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// tailFile returns the last n bytes of the file at path. Unlike a LimitReader
+// from offset 0 (which keeps the FIRST n bytes), it seeks to the end, so the
+// tail is the real end of the stream even when the file is far larger than n.
+// A missing file yields "" with no error.
+func tailFile(path string, n int64) (string, error) {
+	f, err := os.Open(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	start := int64(0)
+	if size := info.Size(); size > n {
+		start = size - n
+	}
+	buf := make([]byte, info.Size()-start)
+	// A terminal job's file is normally static, but guard the TOCTOU window: if
+	// the file shrank between Stat and ReadAt, ReadAt fills fewer than len(buf)
+	// bytes and returns io.EOF. Slice to what was actually read so the tail is not
+	// padded with NUL bytes from the unfilled allocation.
+	read, err := f.ReadAt(buf, start)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	return string(buf[:read]), nil
+}
+
+// cleanTail returns the trailing stderr of a terminal job (the last errTailBytes,
+// trailing newline trimmed and starting on a valid UTF-8 boundary), or "" when
+// there is none.
+func cleanTail(dir string) (string, error) {
+	tail, err := tailFile(filepath.Join(dir, "err"), errTailBytes)
+	if err != nil {
+		return "", err
+	}
+	tail = strings.TrimRight(tail, "\n")
+	// tailFile may have started mid-rune; advance to a valid UTF-8 boundary so a
+	// multi-byte rune is not split.
+	for tail != "" && !utf8.RuneStart(tail[0]) {
+		tail = tail[1:]
+	}
+	return tail, nil
 }
 
 func errorSummary(dir string, code int) string {
-	tail := readFile(filepath.Join(dir, "err"))
-	if len(tail) > 2000 {
-		tail = tail[len(tail)-2000:]
-		// Advance to a valid UTF-8 boundary so a multi-byte rune is not split.
-		for tail != "" && !utf8.RuneStart(tail[0]) {
-			tail = tail[1:]
-		}
+	tail, err := cleanTail(dir)
+	if err != nil {
+		// The stderr file exists but cannot be read; say so rather than emitting a
+		// bare "exit N:" that looks like there was no error output.
+		return fmt.Sprintf("exit %d: <stderr unavailable: %v>", code, err)
 	}
 	return strings.TrimSpace("exit " + strconv.Itoa(code) + ": " + tail)
+}
+
+// spawnFailMessage explains a 127 exit. The supervisor writes 127 both when it
+// could not exec agy (the intended meaning) and when agy itself exits 127, so it
+// names both causes and appends any stderr instead of masking it.
+func spawnFailMessage(dir string) string {
+	msg := "agy exited 127: the supervisor could not exec the agy binary (check the configured agy path), or agy itself exited 127"
+	if tail, err := cleanTail(dir); err == nil && tail != "" {
+		msg += "; stderr: " + tail
+	}
+	return msg
 }

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -55,6 +55,90 @@ func TestStatusTimedOut(t *testing.T) {
 	}
 }
 
+func TestTailFileReturnsRealEnd(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "err")
+	// Content longer than the requested tail; the tail must come from the END,
+	// not the start (the bug: an io.LimitReader from offset 0 keeps the first N).
+	content := strings.Repeat("A", 5000) + "THE-REAL-END"
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := tailFile(p, 20)
+	if err != nil {
+		t.Fatalf("tailFile: %v", err)
+	}
+	if got != content[len(content)-20:] {
+		t.Fatalf("tail = %q, want the last 20 bytes", got)
+	}
+	if !strings.HasSuffix(got, "THE-REAL-END") {
+		t.Fatalf("tail %q is not from the real end of the file", got)
+	}
+}
+
+func TestTailFileShorterThanRequested(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "err")
+	if err := os.WriteFile(p, []byte("short"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := tailFile(p, 4096)
+	if err != nil {
+		t.Fatalf("tailFile: %v", err)
+	}
+	if got != "short" {
+		t.Fatalf("tail = %q, want the whole short file", got)
+	}
+}
+
+// TestStatusDoneButOutputUnreadable: a job that exited 0 whose out file cannot
+// be read must report failed, not done with an empty result. Making out a
+// directory lets os.Open succeed while the read fails, exposing the old
+// readFile that collapsed every IO error into "".
+func TestStatusDoneButOutputUnreadable(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	if err := os.Mkdir(filepath.Join(dir, "out"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.store.WriteExitCode("j", 0)
+
+	st, _ := m.Status("j")
+	if st.State != StateFailed || st.Error == "" {
+		t.Fatalf("status = %+v, want failed when the output file cannot be read", st)
+	}
+}
+
+// TestStatusSpawnFail: ExitSpawnFail (127) with no stderr (a true spawn failure)
+// gets a dedicated message instead of a bare "exit 127:".
+func TestStatusSpawnFail(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	_ = os.WriteFile(filepath.Join(dir, "err"), []byte(""), 0o644)
+	_ = m.store.WriteExitCode("j", jobstore.ExitSpawnFail)
+
+	st, _ := m.Status("j")
+	if st.State != StateFailed {
+		t.Fatalf("state = %q, want failed", st.State)
+	}
+	if !strings.Contains(st.Error, "could not exec the agy binary") {
+		t.Fatalf("error = %q, want a dedicated spawn-failure message", st.Error)
+	}
+}
+
+// TestStatusExit127SurfacesStderr: 127 is also a valid agy exit code, so when
+// agy itself exits 127 (with stderr) the message must surface that stderr rather
+// than masking it behind the spawn-failure text.
+func TestStatusExit127SurfacesStderr(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("agy: internal tool not found\n"), 0o644)
+	_ = m.store.WriteExitCode("j", jobstore.ExitSpawnFail)
+
+	st, _ := m.Status("j")
+	if st.State != StateFailed || !strings.Contains(st.Error, "internal tool not found") {
+		t.Fatalf("error = %q, want it to surface agy's stderr for a real 127 exit", st.Error)
+	}
+}
+
 func TestStatusInterruptedAfterReboot(t *testing.T) {
 	m := newTestManager(t)
 	// BootID differs from current -> the recorded PID is from a previous boot.

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -130,7 +130,8 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "agy_cancel", Description: "Cancel a running agy job.",
+		Name:        "agy_cancel",
+		Description: `Cancel a running agy job. Returns the resulting state: "cancelled", or the job's terminal state if it had already finished, or "unknown" if the state could not be read after cancelling.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in cancelInput) (*mcp.CallToolResult, cancelOutput, error) {
 		if err := mgr.Cancel(in.JobID); err != nil {
 			return nil, cancelOutput{}, err


### PR DESCRIPTION
## Summary

Status and tool-output correctness fixes, the low-risk subset of #29 (the structural items, persisted completion time and the gate-rejection cause, are deferred to a follow-up).

- **stderr tail from the wrong end:** `errorSummary` read stderr via an `io.LimitReader` from offset 0, so for an err file larger than `maxReadBytes` (32 MiB) the reported "tail" was actually the **first** 32 MiB, not the end where the real error is. New `tailFile` seeks to the end and returns the true last bytes. It also slices to the bytes actually read, so a file that shrinks under the (tiny) Stat/ReadAt window cannot pad the tail with NUL bytes.
- **IO errors masked as success:** `readFile` collapsed every IO error into `""`, so an unreadable `out` file made a completed (exit 0) job report a successful empty result. It now returns the error; that job is reported failed. A missing file is still a normal empty result. The conversation id is captured first, so a clean run whose local output cannot be read still reports the conversation to continue.
- **`ExitSpawnFail` (127):** rendered as a bare `exit 127:` with an empty stderr tail. It now gets a dedicated message. Since 127 is also a valid agy exit code, the message names both causes and still surfaces any stderr rather than masking it.
- **`list_models`:** discarded agy's stderr, surfacing failures as a bare `exit status 1`. It now includes `(*exec.ExitError).Stderr`.
- **`agy_cancel`:** its tool description now documents the returned states, including `"unknown"`.

## Related Issues
Relates to #29 (the structural items remain for a follow-up PR)

## Test Plan
- [x] `go test ./...`, `golangci-lint run`, `gofmt`, `go vet` all clean
- [x] New regression tests cover the real-end tail, the unreadable-output failure, the spawn-fail message, a real agy-127 surfacing stderr, and the `list_models` stderr passthrough; each verified to fail without its fix
- [x] Reviewed by parallel Claude review agent + Gemini 3.1 Pro cross-validation; all findings addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command execution errors now display stderr output for clearer diagnostics
  * Improved error handling when job output files cannot be read
  * Job status messages now provide enhanced error context
  * File reading failures are properly reported instead of silently failing

* **Documentation**
  * Updated tool descriptions for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->