### PR TITLE
fix(supervisor): close signal window, classify signal exits, bound timeouts

### DIFF
--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -22,6 +22,11 @@ type runInput struct {
 	Timeout        string   `json:"timeout,omitempty" jsonschema:"max run duration, e.g. 20m"`
 }
 
+// maxJobTimeout caps a client-supplied per-job timeout. It bounds both the agy
+// --print-timeout and the supervisor's hard-kill deadline, so a typo like "1000h"
+// cannot leave a hung job uncollectable for weeks.
+const maxJobTimeout = 24 * time.Hour
+
 // toStartRequest converts the wire input into a manager start request,
 // validating the timeout.
 func (in runInput) toStartRequest() (manager.StartRequest, error) {
@@ -33,6 +38,9 @@ func (in runInput) toStartRequest() (manager.StartRequest, error) {
 		d, err := time.ParseDuration(in.Timeout)
 		if err != nil || d <= 0 {
 			return manager.StartRequest{}, fmt.Errorf("invalid timeout %q: want a positive Go duration like 20m", in.Timeout)
+		}
+		if d > maxJobTimeout {
+			return manager.StartRequest{}, fmt.Errorf("timeout %q exceeds the maximum of %s", in.Timeout, maxJobTimeout)
 		}
 		req.Timeout = d
 	}

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -1,6 +1,7 @@
 package mcptools
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -8,6 +9,23 @@ import (
 	"github.com/tphakala/agy-mcp/internal/manager"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
+
+// TestToStartRequestRejectsExcessiveTimeout: a client timeout is validated
+// positive but must also be capped, so a typo like "1000h" cannot become both
+// the agy --print-timeout and a weeks-long supervisor hard-kill window.
+func TestToStartRequestRejectsExcessiveTimeout(t *testing.T) {
+	_, err := runInput{Prompt: "x", Timeout: "1000h"}.toStartRequest()
+	if err == nil || !strings.Contains(err.Error(), "maximum") {
+		t.Fatalf("err = %v, want an excessive-timeout rejection", err)
+	}
+}
+
+func TestToStartRequestAcceptsTimeoutAtLimit(t *testing.T) {
+	req, err := runInput{Prompt: "x", Timeout: maxJobTimeout.String()}.toStartRequest()
+	if err != nil || req.Timeout != maxJobTimeout {
+		t.Fatalf("timeout at the limit should be accepted: req=%+v err=%v", req, err)
+	}
+}
 
 func TestAgyRunAndStatusOverMCP(t *testing.T) {
 	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})

--- a/internal/supervisor/platform_linux.go
+++ b/internal/supervisor/platform_linux.go
@@ -5,12 +5,44 @@ package supervisor
 import (
 	"os/exec"
 	"syscall"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
+
+// platformSupported reports whether job supervision (process groups, signal
+// forwarding, /proc) runs on this OS. Only Linux is supported; Run refuses early
+// elsewhere with errPlatformUnsupported.
+const platformSupported = true
+
+// errPlatformUnsupported is what Run returns on an unsupported platform. It is nil
+// on Linux; the symbol exists on every platform so Run's guard compiles.
+var errPlatformUnsupported error
 
 // setProcessGroup puts agy in its own process group so the supervisor can signal the
 // whole group (agy and its children) together.
 func setProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// signalExitCode maps a signal-terminated agy to a sentinel exit code. SIGTERM and
+// SIGINT are the cancel sentinels (a manager cancel and the hard-timeout kill both
+// forward SIGTERM); any other signal (SIGKILL from an OOM, SIGSEGV from a crash)
+// maps to 128+signal so Status reports a failure rather than a clean cancel. A
+// wait status that is not a signal death falls back to the cancel sentinel,
+// preserving the prior behavior for that unreachable case.
+func signalExitCode(ee *exec.ExitError) int {
+	ws, ok := ee.Sys().(syscall.WaitStatus)
+	if !ok || !ws.Signaled() {
+		return jobstore.ExitSIGTERM
+	}
+	switch ws.Signal() {
+	case syscall.SIGTERM:
+		return jobstore.ExitSIGTERM
+	case syscall.SIGINT:
+		return jobstore.ExitSIGINT
+	default:
+		return 128 + int(ws.Signal())
+	}
 }
 
 // terminateGroup sends sig to the entire process group led by pid. A non-positive pid is

--- a/internal/supervisor/platform_other.go
+++ b/internal/supervisor/platform_other.go
@@ -3,14 +3,24 @@
 package supervisor
 
 import (
+	"errors"
 	"os/exec"
 	"syscall"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
-// Non-Linux stubs. The supervisor is spawned only by the manager's StartJob, which
-// refuses on non-Linux platforms, so Run is never invoked there; these exist so the
-// package builds on macOS and Windows.
+// Non-Linux stubs so the package builds on macOS and Windows. Run refuses early
+// here (platformSupported is false), so none of these are reached at runtime.
+
+const platformSupported = false
+
+// errPlatformUnsupported is what Run returns off Linux, where job supervision
+// (process groups, signal forwarding, /proc liveness) is unavailable.
+var errPlatformUnsupported = errors.New("agy-mcp: job supervision is only supported on Linux")
 
 func setProcessGroup(_ *exec.Cmd) {}
 
-func terminateGroup(_ int, _ syscall.Signal) error { return nil }
+func terminateGroup(_ int, _ syscall.Signal) error { return errPlatformUnsupported }
+
+func signalExitCode(_ *exec.ExitError) int { return jobstore.ExitSIGTERM }

--- a/internal/supervisor/signal_linux_test.go
+++ b/internal/supervisor/signal_linux_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package supervisor
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// TestSignalExitCode checks that a signal-terminated agy is classified by which
+// signal killed it: SIGTERM/SIGINT are the cancel sentinels, but an abnormal
+// death (SIGKILL from an OOM, SIGSEGV from a crash) maps to 128+signal so Status
+// reports a failure instead of a clean cancel. The old code mapped every signal
+// death to ExitSIGTERM, hiding OOM kills and crashes as cancels.
+func TestSignalExitCode(t *testing.T) {
+	cases := []struct {
+		name string
+		sig  syscall.Signal
+		want int
+	}{
+		{"SIGTERM stays a cancel sentinel", syscall.SIGTERM, jobstore.ExitSIGTERM},
+		{"SIGINT stays a cancel sentinel", syscall.SIGINT, jobstore.ExitSIGINT},
+		{"SIGKILL is a failure, not a cancel", syscall.SIGKILL, 128 + int(syscall.SIGKILL)},
+		{"SIGSEGV is a failure, not a cancel", syscall.SIGSEGV, 128 + int(syscall.SIGSEGV)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The process signals itself, so delivery is deterministic (no parent-to-
+			// child signal race). The trailing sleep never runs: the kill is fatal.
+			cmd := exec.Command("sh", "-c", fmt.Sprintf("kill -%d $$; sleep 60", int(tc.sig)))
+			ee, ok := errors.AsType[*exec.ExitError](cmd.Run())
+			if !ok {
+				t.Fatal("run did not return an *exec.ExitError")
+			}
+			if got := signalExitCode(ee); got != tc.want {
+				t.Errorf("signalExitCode = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -35,6 +35,37 @@ func effectiveTimeout(d time.Duration) time.Duration {
 	return d
 }
 
+// closed reports whether ch is already closed, without blocking.
+func closed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+// resolveExitCode applies the supervisor's termination overrides to the raw exit
+// code derived from agy's wait status. A supervisor-initiated termination keeps
+// its own meaning even when it escalated to SIGKILL: agy that ignores SIGTERM and
+// is then SIGKILLed dies with signal 9 (raw 137), but the job was timed out or
+// cancelled, not crashed, so it must report ExitTimeout or ExitSIGTERM rather
+// than the raw signal failure. A natural exit (waitFailed false, or neither flag
+// set) keeps its raw code. Timeout takes precedence; in practice only one flag is
+// ever set.
+func resolveExitCode(raw int, waitFailed, timedOut, cancelled bool) int {
+	if !waitFailed {
+		return raw
+	}
+	switch {
+	case timedOut:
+		return jobstore.ExitTimeout
+	case cancelled:
+		return jobstore.ExitSIGTERM
+	}
+	return raw
+}
+
 // Run executes the agy process described by jobDir/meta.json. It captures
 // stdout to jobDir/out and stderr to jobDir/err, redirects agy stdin from
 // /dev/null, and writes jobDir/exit_code on completion (including on cancel).
@@ -103,6 +134,7 @@ func Run(jobDir string) error {
 	// effectiveTimeout floors a non-positive meta timeout so the deadline always fires.
 	done := make(chan struct{})
 	timedOut := make(chan struct{})
+	cancelled := make(chan struct{})
 
 	go func() {
 		t := time.NewTimer(effectiveTimeout(m.Timeout))
@@ -111,7 +143,7 @@ func Run(jobDir string) error {
 		case <-done:
 			return
 		case <-sig:
-			// Cancel requested by the manager.
+			close(cancelled) // cancel requested by the manager
 		case <-t.C:
 			close(timedOut)
 		}
@@ -145,19 +177,12 @@ func Run(jobDir string) error {
 			code = 1
 		}
 	}
-	// If the hard timeout fired, record the timeout sentinel so Status can report
-	// a timeout distinctly from a user cancel. Guard on waitErr so a job that
-	// finished naturally at the exact instant the timer fired is not mislabeled
-	// as a timeout (a natural success has waitErr == nil). timedOut is closed
-	// before the kill, so it is observable by the time Wait returns.
-	if waitErr != nil {
-		select {
-		case <-timedOut:
-			code = jobstore.ExitTimeout
-		default:
-		}
-	}
-	return writeExit(jobDir, code)
+	// Apply the supervisor's termination overrides: a timeout or a cancel keeps its
+	// meaning even when it escalated to SIGKILL (raw 137). timedOut/cancelled are
+	// closed before the kill, so they are observable by the time Wait returns.
+	// Guarding on waitErr != nil keeps a job that finished naturally at the instant
+	// the timer fired (a natural success has waitErr == nil) from being mislabeled.
+	return writeExit(jobDir, resolveExitCode(code, waitErr != nil, closed(timedOut), closed(cancelled)))
 }
 
 func writeExit(jobDir string, code int) error {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -20,11 +20,33 @@ import (
 // SIGKILL when terminating the agy process group on cancel or timeout.
 const killGrace = 10 * time.Second
 
+// fallbackTimeout bounds a job whose meta records a non-positive timeout (a
+// misconfigured DefaultTimeout, or an old meta). The hard-timeout contract is
+// that the run is always bounded; without this a zero timeout would leave the
+// deadline disabled and cmd.Wait could block forever on a hung agy.
+const fallbackTimeout = time.Hour
+
+// effectiveTimeout floors a non-positive job timeout to fallbackTimeout so the
+// hard timeout always fires.
+func effectiveTimeout(d time.Duration) time.Duration {
+	if d <= 0 {
+		return fallbackTimeout
+	}
+	return d
+}
+
 // Run executes the agy process described by jobDir/meta.json. It captures
 // stdout to jobDir/out and stderr to jobDir/err, redirects agy stdin from
 // /dev/null, and writes jobDir/exit_code on completion (including on cancel).
 // Run returns an error only for setup failures, not for a non-zero agy exit.
 func Run(jobDir string) error {
+	if !platformSupported {
+		// Job supervision needs process groups, signal forwarding, and /proc, which
+		// only exist on Linux. The non-Linux terminateGroup stub cannot kill agy, so
+		// the timeout would "fire" without terminating anything and Run would block in
+		// cmd.Wait forever. Refuse here, matching StartJob's guard on the manager side.
+		return errPlatformUnsupported
+	}
 	var m jobstore.Meta
 	b, err := os.ReadFile(filepath.Join(jobDir, "meta.json"))
 	if err != nil {
@@ -59,6 +81,16 @@ func Run(jobDir string) error {
 	// Put agy in its own process group so we can signal it and its children.
 	setProcessGroup(cmd)
 
+	// Install the SIGTERM handler BEFORE starting agy. A SIGTERM landing in the
+	// window between Start and Notify would otherwise kill the supervisor with its
+	// default disposition, leaving agy detached with nobody to forward the signal,
+	// enforce the timeout, or write the sentinel. The channel is buffered, so a
+	// signal that arrives before the forwarding goroutine is reading is held, not
+	// lost.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM)
+	defer signal.Stop(sig)
+
 	if err := cmd.Start(); err != nil {
 		_ = writeExit(jobDir, jobstore.ExitSpawnFail)
 		return err
@@ -67,26 +99,20 @@ func Run(jobDir string) error {
 	// Terminate the agy process group on either an external SIGTERM (cancel from
 	// the manager) or the hard timeout, escalating to SIGKILL after a grace
 	// window. The hard timeout is the spec's guarantee that a hung agy (which can
-	// stall at 0 CPU and ignore its own --print-timeout) can never block forever.
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM)
-	defer signal.Stop(sig)
+	// stall at 0 CPU and ignore its own --print-timeout) can never block forever;
+	// effectiveTimeout floors a non-positive meta timeout so the deadline always fires.
 	done := make(chan struct{})
 	timedOut := make(chan struct{})
 
 	go func() {
-		var deadline <-chan time.Time
-		if m.Timeout > 0 {
-			t := time.NewTimer(m.Timeout)
-			defer t.Stop()
-			deadline = t.C
-		}
+		t := time.NewTimer(effectiveTimeout(m.Timeout))
+		defer t.Stop()
 		select {
 		case <-done:
 			return
 		case <-sig:
 			// Cancel requested by the manager.
-		case <-deadline:
+		case <-t.C:
 			close(timedOut)
 		}
 		_ = terminateGroup(cmd.Process.Pid, syscall.SIGTERM)
@@ -111,7 +137,9 @@ func Run(jobDir string) error {
 		if ee, ok := errors.AsType[*exec.ExitError](waitErr); ok {
 			code = ee.ExitCode()
 			if code < 0 {
-				code = jobstore.ExitSIGTERM // terminated by signal
+				// Killed by a signal. Classify by which signal so an OOM kill or a
+				// crash is reported as a failure, not mistaken for a user cancel.
+				code = signalExitCode(ee)
 			}
 		} else {
 			code = 1

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -20,6 +20,18 @@ func writeMeta(t *testing.T, dir string, m jobstore.Meta) {
 	}
 }
 
+func TestEffectiveTimeout(t *testing.T) {
+	if got := effectiveTimeout(0); got != fallbackTimeout {
+		t.Errorf("effectiveTimeout(0) = %v, want fallback %v", got, fallbackTimeout)
+	}
+	if got := effectiveTimeout(-5 * time.Second); got != fallbackTimeout {
+		t.Errorf("effectiveTimeout(negative) = %v, want fallback %v", got, fallbackTimeout)
+	}
+	if got := effectiveTimeout(5 * time.Minute); got != 5*time.Minute {
+		t.Errorf("effectiveTimeout(5m) = %v, want passthrough", got)
+	}
+}
+
 func TestSupervisorCapturesOutputAndSentinel(t *testing.T) {
 	dir := t.TempDir()
 	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "review text", Stderr: "warn", Exit: 0})

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -20,6 +20,32 @@ func writeMeta(t *testing.T, dir string, m jobstore.Meta) {
 	}
 }
 
+func TestResolveExitCode(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        int
+		waitFailed bool
+		timedOut   bool
+		cancelled  bool
+		want       int
+	}{
+		{"natural success is untouched", 0, false, false, false, 0},
+		{"natural failure is untouched", 5, true, false, false, 5},
+		{"crash with no supervisor termination stays a failure", 128 + 11, true, false, false, 128 + 11},
+		{"timeout that died by SIGTERM reports timeout", jobstore.ExitSIGTERM, true, true, false, jobstore.ExitTimeout},
+		{"timeout that escalated to SIGKILL reports timeout", 128 + 9, true, true, false, jobstore.ExitTimeout},
+		{"cancel that died by SIGTERM reports cancel", jobstore.ExitSIGTERM, true, false, true, jobstore.ExitSIGTERM},
+		{"cancel that escalated to SIGKILL still reports cancel", 128 + 9, true, false, true, jobstore.ExitSIGTERM},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveExitCode(tc.raw, tc.waitFailed, tc.timedOut, tc.cancelled); got != tc.want {
+				t.Errorf("resolveExitCode = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEffectiveTimeout(t *testing.T) {
 	if got := effectiveTimeout(0); got != fallbackTimeout {
 		t.Errorf("effectiveTimeout(0) = %v, want fallback %v", got, fallbackTimeout)


### PR DESCRIPTION
## Summary

Supervisor robustness fixes (issue #26):

- **Signal-handler window:** `signal.Notify(SIGTERM)` was installed *after* `cmd.Start()`. A SIGTERM landing in that window killed the supervisor with its default disposition, leaving agy detached with nobody to forward the signal, enforce the timeout, or write the sentinel. The (buffered) handler is now installed before starting agy.
- **Exit classification:** every signal death of agy was mapped to `ExitSIGTERM`, which `Status` reports as `cancelled`, so an OOM kill (SIGKILL) or a crash (SIGSEGV) was indistinguishable from a user cancel. `signalExitCode` now extracts the actual signal: TERM/INT stay the cancel sentinels; everything else maps to `128+signal`, which `Status` reports as a failure. It lives in the platform files so the package still builds on macOS and Windows.
- **Timeout floor:** the hard timeout silently disappeared when `meta.Timeout <= 0` (nil deadline, `cmd.Wait` could block forever, contradicting the contract). `effectiveTimeout` floors it.
- **Timeout cap:** a client timeout was validated positive but never capped, so `"1000h"` was accepted as both the agy `--print-timeout` and the supervisor window. Capped at `maxJobTimeout` (24h).
- **Off-Linux:** `run-job` was invocable off Linux, where `terminateGroup` is a no-op stub, so the timeout would "fire" without killing anything and `Run` would block forever. `Run` now refuses off Linux with `errPlatformUnsupported` (matching `StartJob`), and the non-Linux stub returns that error instead of nil.

## Related Issues
Closes #26

## Test Plan
- [x] `go test ./... -race`, `golangci-lint run`, `gofmt`, `go vet` clean
- [x] `GOOS=darwin go vet ./...` and `GOOS=windows go build ./...` clean (cross-platform compile)
- [x] New tests cover signal classification (TERM/INT as cancels; KILL/SEGV as failures), the timeout floor, and the client-timeout cap; the signal test verified to fail without the fix
- [x] Reviewed by a parallel Claude correctness/concurrency agent + Gemini 3.1 Pro cross-validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs now enforce a maximum 24-hour timeout limit.
  * Added an automatic fallback timeout so jobs always have a hard deadline.
  * Improved platform-specific signal handling to classify process terminations accurately.

* **Bug Fixes**
  * More accurate exit-code reporting for signal-terminated job processes.

* **Tests**
  * Added tests for timeout limit validation and fallback behavior.
  * Added tests for signal-to-exit-code classification and exit resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->