### PR TITLE
fix(gc): harden job-store GC, liveness, and meta writes

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -54,7 +54,11 @@ var ErrInvalidID = errors.New("invalid job id")
 // Store is a directory-backed collection of jobs.
 type Store struct {
 	root string
-	mu   sync.Mutex // serializes SetConversationID's read-modify-write
+	// mu serializes every meta rewrite (UpdateMeta and SetConversationID). It is
+	// what lets SetConversationID's read-modify-write be atomic: it holds mu across
+	// the Load and the rewrite, and because UpdateMeta also takes mu a concurrent
+	// UpdateMeta cannot land between the two and be clobbered.
+	mu sync.Mutex
 }
 
 // New returns a Store rooted at dir/jobs.
@@ -85,13 +89,13 @@ func (s *Store) Create(m Meta) (string, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
-	b, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	if err := os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644); err != nil {
+	// Write meta.json with the same temp+rename pattern UpdateMeta uses, so a crash
+	// mid-write can never leave a torn or zero-length meta.json that Load fails to
+	// parse (which would orphan the dir). A unique id is being created, so no other
+	// writer touches this dir and no lock is needed.
+	if err := writeMetaAtomic(dir, m); err != nil {
 		// Remove the just-created dir so a failed Create leaves no orphan: a dir
-		// without a readable meta.json is skipped forever by GarbageCollect.
+		// without a readable meta.json is reaped only after the TTL by GarbageCollect.
 		_ = os.RemoveAll(dir)
 		return "", err
 	}
@@ -114,15 +118,32 @@ func (s *Store) Load(id string) (Meta, error) {
 	return m, nil
 }
 
-// UpdateMeta atomically rewrites a job's meta.json by writing a uniquely-named
-// temp file and renaming it into place, so a concurrent reader (such as the
-// freshly spawned supervisor) never observes a partially written file, and two
-// concurrent writers never corrupt a shared temp file.
+// UpdateMeta atomically rewrites a job's meta.json. It takes s.mu so every meta
+// rewrite is serialized: a concurrent reader (such as the freshly spawned
+// supervisor) never observes a partially written file, and SetConversationID's
+// read-modify-write cannot be clobbered by a concurrent UpdateMeta landing
+// between its Load and its rewrite.
 func (s *Store) UpdateMeta(m Meta) error {
 	if !validJobID(m.ID) {
 		return ErrInvalidID
 	}
-	dir := s.jobDir(m.ID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.updateMetaLocked(m)
+}
+
+// updateMetaLocked performs the atomic rewrite. The caller must hold s.mu. It is
+// the shared body of UpdateMeta (which acquires the lock) and SetConversationID
+// (which already holds it), so the two never deadlock by re-locking.
+func (s *Store) updateMetaLocked(m Meta) error {
+	return writeMetaAtomic(s.jobDir(m.ID), m)
+}
+
+// writeMetaAtomic writes m to dir/meta.json by writing a uniquely-named temp file
+// and renaming it into place, so a reader never observes a partially written file
+// and a crash mid-write leaves either the old meta.json or none, never a torn one.
+// It assumes the caller has validated m.ID and that dir already exists.
+func writeMetaAtomic(dir string, m Meta) error {
 	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err
@@ -177,7 +198,9 @@ func (s *Store) SetConversationID(id, convID string) (string, error) {
 		return m.ConversationID, nil
 	}
 	m.ConversationID = convID
-	if err := s.UpdateMeta(m); err != nil {
+	// Already holding s.mu, so rewrite via the locked variant; calling UpdateMeta
+	// here would re-acquire s.mu and deadlock.
+	if err := s.updateMetaLocked(m); err != nil {
 		return "", err
 	}
 	return convID, nil
@@ -192,7 +215,15 @@ func (s *Store) Remove(id string) error {
 }
 
 // Dir returns the on-disk directory for a job (out, err, exit_code live here).
-func (s *Store) Dir(id string) string { return s.jobDir(id) }
+// Like the other Store methods it guards the id, so a malicious client-supplied
+// job_id can never produce a path that escapes the store root, even for a future
+// caller that does not Load (and thus validate) the id first.
+func (s *Store) Dir(id string) (string, error) {
+	if !validJobID(id) {
+		return "", ErrInvalidID
+	}
+	return s.jobDir(id), nil
+}
 
 // WriteExitCode writes the completion sentinel.
 func (s *Store) WriteExitCode(id string, code int) error {

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -21,9 +21,23 @@ func TestRejectsUnsafeJobID(t *testing.T) {
 		if err := s.Remove(id); !errors.Is(err, ErrInvalidID) {
 			t.Errorf("Remove(%q) err = %v, want ErrInvalidID", id, err)
 		}
+		if _, err := s.Dir(id); !errors.Is(err, ErrInvalidID) {
+			t.Errorf("Dir(%q) err = %v, want ErrInvalidID", id, err)
+		}
 		if _, ok := s.ExitCode(id); ok {
 			t.Errorf("ExitCode(%q) ok = true, want false", id)
 		}
+	}
+}
+
+func TestDirReturnsJobPathForValidID(t *testing.T) {
+	s := New(t.TempDir())
+	got, err := s.Dir("job123")
+	if err != nil {
+		t.Fatalf("Dir(valid) err = %v, want nil", err)
+	}
+	if want := s.jobDir("job123"); got != want {
+		t.Fatalf("Dir = %q, want %q", got, want)
 	}
 }
 

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -2,12 +2,171 @@ package manager
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
+
+// reReadExitStore reports "no sentinel" on the first ExitCode(id) call and
+// "exited 0" on every later call for one job id, simulating a supervisor that
+// writes its sentinel and exits between GarbageCollect's two ExitCode checks.
+type reReadExitStore struct {
+	jobStore
+	id    string
+	calls int
+}
+
+func (r *reReadExitStore) ExitCode(id string) (int, bool) {
+	if id == r.id {
+		r.calls++
+		if r.calls == 1 {
+			return 0, false
+		}
+		return 0, true
+	}
+	return r.jobStore.ExitCode(id)
+}
+
+func TestGarbageCollectReapsExpiredOrphanDir(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	// A job dir with no meta.json: a crash between Create's MkdirAll and its meta
+	// write, or a partial RemoveAll. Load fails on it, so the old GC skipped it
+	// forever and orphan dirs accumulated without bound.
+	dir, err := m.store.Dir("orphan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "orphan" {
+		t.Fatalf("removed = %v, want [orphan]", removed)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("expired orphan dir should be removed; stat err = %v", err)
+	}
+}
+
+func TestGarbageCollectKeepsRecentOrphanDir(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	// A meta-less dir younger than the TTL may be a job mid-Create (MkdirAll done,
+	// meta write pending), so it must not be reaped.
+	dir, err := m.store.Dir("fresh-orphan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("a recent orphan should be kept, removed %v", removed)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("recent orphan dir should remain: %v", err)
+	}
+}
+
+func TestGarbageCollectKeepsExpiredJobWithUnreadableMeta(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	// meta.json is present but unparseable (a transient read error, or a legacy
+	// corrupt write). This is NOT an orphan: only a genuinely missing meta.json is.
+	// A valid long-running job's dir mtime is old because writing to out/err does
+	// not bump the directory mtime, so reaping on mtime here would delete a live job
+	// the moment a transient Load error coincided with it being past the TTL.
+	dir, err := m.store.Dir("corrupt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte("{ not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("a job with a corrupt-but-present meta must not be reaped, removed %v", removed)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("dir should remain: %v", err)
+	}
+}
+
+func TestGarbageCollectKeepsTerminalJobWithCapturePending(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	// A fresh run that exited 0 and is past the TTL, but whose conversation-id
+	// capture is still in flight: the manager's post-cmd.Wait goroutine is inside
+	// captureFreshConversationID, still writing this dir (the sentinel is already on
+	// disk because the supervisor writes it before exiting, so the first ExitCode
+	// read sees it). Removing the dir now would make SetConversationID fail and lose
+	// the captured id, so GC must keep the job until the capture settles.
+	if _, err := m.store.Create(jobstore.Meta{ID: "capturing", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("capturing", 0); err != nil {
+		t.Fatal(err)
+	}
+	m.pendingCaptures.Store("capturing", struct{}{})
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("a terminal job with capture still pending must not be removed, removed %v", removed)
+	}
+	if ids, _ := m.store.List(); len(ids) != 1 || ids[0] != "capturing" {
+		t.Fatalf("capturing job should survive the sweep, List = %v", ids)
+	}
+}
+
+func TestGarbageCollectRereadsSentinelBeforeRemoval(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	// Old enough to collect, PID 0 so processAlive is false (the process has
+	// exited). The first ExitCode read sees no sentinel; the re-read after the
+	// liveness check sees the sentinel the supervisor wrote on its way out, so the
+	// job must be kept this sweep rather than collected with its results unread.
+	if _, err := m.store.Create(jobstore.Meta{ID: "racer", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	m.store = &reReadExitStore{jobStore: m.store, id: "racer"}
+	removed, err := m.GarbageCollect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("a job that wrote its sentinel between GC's two checks must not be removed; removed %v", removed)
+	}
+	ids, err := m.store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "racer" {
+		t.Fatalf("racer should survive the sweep, List = %v", ids)
+	}
+}
 
 func TestGarbageCollectRemovesExpired(t *testing.T) {
 	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -31,8 +31,16 @@ func (m *Manager) processAlive(meta jobstore.Meta) bool {
 	if meta.PID <= 0 {
 		return false
 	}
-	// A PID from a previous boot is meaningless (PID recycling).
-	if meta.BootID != "" && meta.BootID != readBootID() {
+	// The recorded boot id must match the current boot, otherwise the PID is from a
+	// previous boot and meaningless (PID recycling across reboots). This also fails
+	// closed in the issue's scenario: an empty recorded boot id (boot_id was
+	// unreadable at start) does not match a readable current one, so a recycled PID
+	// after a reboot cannot read as alive (which would keep the job uncollectable and
+	// its gate key held). When boot_id is unreadable host-wide (e.g. a restricted
+	// container) both are "" and compare equal, so liveness falls through to the PID
+	// and start-time checks rather than failing every job; there is no boot to
+	// disambiguate there anyway.
+	if meta.BootID != readBootID() {
 		return false
 	}
 	if err := syscall.Kill(meta.PID, 0); err != nil {

--- a/internal/manager/liveness_linux_test.go
+++ b/internal/manager/liveness_linux_test.go
@@ -79,6 +79,13 @@ func TestProcessAliveStartTimeCheck(t *testing.T) {
 }
 
 func TestProcessAliveEmptyBootIDFailsClosed(t *testing.T) {
+	if readBootID() == "" {
+		// boot_id is unreadable host-wide here (e.g. a restricted container). With no
+		// current boot to compare against, an empty recorded boot id correctly falls
+		// through to the PID and start-time checks rather than failing closed, so this
+		// test's premise does not hold. Skip rather than assert a false expectation.
+		t.Skip("boot_id unreadable in this environment; empty-vs-empty correctly falls through")
+	}
 	pid, exePath := startFakeLiveSupervisor(t)
 	m := New(config.Config{SupervisorExe: exePath, StateDir: t.TempDir(), MaxConcurrency: 4})
 	actual, ok := readStartTimeTicks(pid)

--- a/internal/manager/liveness_linux_test.go
+++ b/internal/manager/liveness_linux_test.go
@@ -78,6 +78,24 @@ func TestProcessAliveStartTimeCheck(t *testing.T) {
 	}
 }
 
+func TestProcessAliveEmptyBootIDFailsClosed(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := New(config.Config{SupervisorExe: exePath, StateDir: t.TempDir(), MaxConcurrency: 4})
+	actual, ok := readStartTimeTicks(pid)
+	if !ok {
+		t.Fatalf("could not read start time for live pid %d", pid)
+	}
+	// An empty recorded boot id cannot be confirmed to belong to the current boot
+	// (boot_id was unreadable when the job started). After a reboot a recycled pid
+	// could otherwise pass the kill and start-time checks and read as alive, keeping
+	// the dead job uncollectable and its gate key held forever. Fail closed: an empty
+	// boot id reads as not alive even for a live, exactly-matching pid.
+	meta := jobstore.Meta{PID: pid, BootID: "", StartTimeTicks: actual}
+	if m.processAlive(meta) {
+		t.Error("empty BootID must fail closed (read as not alive)")
+	}
+}
+
 func TestReadStartTimeTicks(t *testing.T) {
 	// Our own pid has a readable, non-zero start time.
 	got, ok := readStartTimeTicks(os.Getpid())

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -303,6 +305,15 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		BootID:         readBootID(),
 		Timeout:        req.Timeout,
 	}
+	if meta.BootID == "" {
+		// boot_id was unreadable, so this job's PID cannot be pinned to a boot. While
+		// boot_id stays unreadable (e.g. a restricted container) liveness still works
+		// via the PID and start-time checks; but if boot_id becomes readable later
+		// (notably after a reboot) this job reads as not-alive, so it cannot be
+		// restored across a manager restart and a recycled PID is never mistaken for
+		// it. Surface the unreadable boot_id since it degrades cross-boot liveness.
+		log.Printf("agy-mcp: job %s: kernel boot id unreadable; cross-boot liveness degraded for this job", id)
+	}
 	// Whenever the run has no resolved conversation id (a fresh run, or a
 	// continue_latest that found no prior conversation), agy will create a new
 	// conversation. Snapshot the cwd's current conversation id so a later diff
@@ -404,20 +415,86 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 	for _, id := range ids {
 		meta, err := m.store.Load(id)
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// meta.json is genuinely missing: an orphan from a crash between
+				// Create's MkdirAll and its meta write, or a partial RemoveAll. It can
+				// never be a live, attributable job (there is no PID or boot id to
+				// check), so the old behavior of skipping it silently and forever let
+				// orphans accumulate without bound. Reap it once it is older than the
+				// TTL, judged by the dir mtime since there is no StartedAt; a fresh one
+				// may be a job still mid-Create, so it is kept.
+				if m.orphanExpired(id, cutoff) {
+					if rerr := m.store.Remove(id); rerr != nil {
+						log.Printf("agy-mcp: GC: remove orphan job dir %s: %v", id, rerr)
+					} else {
+						removed = append(removed, id)
+						m.untrackCapture(id)
+					}
+				} else {
+					log.Printf("agy-mcp: GC: orphan job dir %s (no meta.json) kept until older than the TTL", id)
+				}
+				continue
+			}
+			// meta.json exists but could not be read or parsed: a transient error
+			// (e.g. EMFILE/EIO) or a corrupt write. This is NOT an orphan and must not
+			// be reaped by dir mtime: a valid long-running job's dir mtime is old
+			// (writing to out/err does not bump the directory mtime), so reaping here
+			// could delete a live job. Log and keep; a later sweep retries the Load.
+			log.Printf("agy-mcp: GC: job %s meta unreadable (not reaping, may be transient): %v", id, err)
 			continue
 		}
 		if !meta.StartedAt.Before(cutoff) {
 			continue // too recent to collect
 		}
-		if _, terminal := m.store.ExitCode(id); !terminal && m.processAlive(meta) {
-			continue // still running; keep it
+		_, terminal := m.store.ExitCode(id)
+		if !terminal {
+			if m.processAlive(meta) {
+				continue // still running; keep it
+			}
+			// Not alive and not terminal at the first read. The supervisor may have
+			// written its sentinel and exited between the ExitCode and processAlive
+			// checks above (the same race Status guards against); re-read once. If it
+			// is now terminal the job just finished, so its result is freshly written
+			// and unread; keep it this sweep and collect it on the next one (where the
+			// first read sees the sentinel). This covers runs with no pending capture
+			// (e.g. a continued conversation), which the CapturePending guard below
+			// does not.
+			if _, terminal = m.store.ExitCode(id); terminal {
+				continue
+			}
+		} else if m.CapturePending(id) {
+			// Terminal, but the manager's post-cmd.Wait completion goroutine is still
+			// capturing the conversation id into this dir (the supervisor writes the
+			// sentinel before it exits, so an in-flight capture always sees the
+			// sentinel already present at the first read). Removing the dir now would
+			// make SetConversationID fail with ENOENT and lose the captured id, so
+			// keep the job until the capture settles; the next sweep collects it.
+			continue
 		}
-		if err := m.store.Remove(id); err == nil {
-			removed = append(removed, id)
-			m.untrackCapture(id)
+		if err := m.store.Remove(id); err != nil {
+			log.Printf("agy-mcp: GC: remove expired job %s: %v", id, err)
+			continue
 		}
+		removed = append(removed, id)
+		m.untrackCapture(id)
 	}
 	return removed, nil
+}
+
+// orphanExpired reports whether the job dir for id, whose meta.json is missing,
+// is older than the GC cutoff. It judges age by the directory's mtime because
+// there is no StartedAt to read. A Dir or stat failure returns false, so a
+// transient error never removes a dir that might still be in use.
+func (m *Manager) orphanExpired(id string, cutoff time.Time) bool {
+	dir, err := m.store.Dir(id)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	return info.ModTime().Before(cutoff)
 }
 
 // gcInterval returns how often a long-lived server should sweep finished jobs:
@@ -511,6 +588,12 @@ func (m *Manager) RestoreGate() error {
 	for _, id := range ids {
 		meta, err := m.store.Load(id)
 		if err != nil {
+			// A job whose meta cannot be read cannot have its gate key recomputed or
+			// its liveness checked, so its slot cannot be restored. Log it rather than
+			// skipping silently: if such a job's supervisor is somehow still alive its
+			// gate is not held, the one gap in this method's fail-closed contract.
+			// GarbageCollect reaps the dir once it is older than the TTL.
+			log.Printf("agy-mcp: restore gate: skipping job %s with unreadable meta: %v", id, err)
 			continue
 		}
 		if _, terminal := m.store.ExitCode(id); terminal {

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -48,7 +48,10 @@ func (m *Manager) Status(id string) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	dir := m.store.Dir(id)
+	dir, err := m.store.Dir(id)
+	if err != nil {
+		return Status{}, err
+	}
 	st := Status{
 		Elapsed:        time.Since(meta.StartedAt),
 		ConversationID: meta.ConversationID,

--- a/internal/manager/store.go
+++ b/internal/manager/store.go
@@ -17,7 +17,7 @@ type jobStore interface {
 	UpdateMeta(m jobstore.Meta) error
 	SetConversationID(id, convID string) (string, error)
 	Remove(id string) error
-	Dir(id string) string
+	Dir(id string) (string, error)
 	WriteExitCode(id string, code int) error
 	ExitCode(id string) (int, bool)
 	List() ([]string, error)


### PR DESCRIPTION
## Summary

Robustness fixes for garbage collection, the job store, and liveness detection (issue #27).

**GarbageCollect**
- Reap meta-less orphan dirs (a crash between `Create`'s `MkdirAll` and the meta write, or a partial `RemoveAll`) once older than the TTL, judged by dir mtime. Only `fs.ErrNotExist` counts as an orphan; a transient or corrupt-meta read error is logged and kept, so a valid long-running job (whose dir mtime is old because writes to out/err do not bump it) is never deleted out from under its supervisor.
- Re-read the exit-code sentinel after `processAlive` returns false, so a job that finished between the two checks is kept this sweep instead of removed with results unread. Also keep a terminal job while its conversation-id capture is still pending (`CapturePending`): the supervisor writes the sentinel before exiting, so removing the dir mid-capture would fail `SetConversationID` and lose the captured id.
- Log skipped unreadable jobs and `store.Remove` failures instead of dropping them silently. `RestoreGate` logs its skips too.

**Job store**
- `Store.Dir` now returns `(string, error)` and guards the id with `validJobID`, so a client-supplied `job_id` cannot escape the store root even for a caller that does not `Load` first.
- `UpdateMeta` takes `s.mu` (via a shared `updateMetaLocked` that `SetConversationID` also calls, avoiding a re-lock deadlock), so `SetConversationID`'s read-modify-write can no longer be clobbered by a concurrent `UpdateMeta`. `Create` now writes `meta.json` with the same temp+rename+fsync helper, so a crash mid-write cannot leave a torn or zero-length `meta.json`.

**Liveness**
- `processAlive` treats a recorded boot id that does not match the current one as not-alive, including an empty recorded id vs a readable current one (boot_id unreadable at start, then a reboot): a recycled PID can no longer read as alive and strand the gate key. When boot_id is unreadable host-wide (e.g. a restricted container) both are empty and compare equal, so liveness still works via the PID and start-time checks.

## Related Issues

Closes #27

## Test Plan

- [x] `go test ./... -race`
- [x] `go vet ./...`, `GOOS=darwin go vet ./...`, `GOOS=windows go build ./...`
- [x] `gofmt -l .` clean, `golangci-lint run ./...` 0 issues
- [x] New tests cover: orphan reap by mtime, corrupt-meta kept, sentinel re-read, capture-pending kept, empty-BootID fail-closed, `Dir` rejects unsafe ids
- [x] Reviewed by an independent Gemini 3.1 Pro pass; its findings (transient-error reaping, container boot_id, capture-window removal) were folded in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job metadata now uses atomic writes to prevent partial-write corruption.
  * Garbage collection more safely handles expired/missing/unreadable job data and defers removal when capture is pending.
  * Store directory lookup now validates job IDs and surfaces errors to callers.
  * Stricter boot-ID checks for cross-reboot liveness and improved logging for unreadable metadata.

* **Tests**
  * Added unit tests covering GC edge cases, liveness boot-ID behavior, and store directory validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->