### PR TITLE
fix(security): private job-dir perms, loopback resolution, agy-path validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,8 +40,7 @@ func Resolve() (Config, error) {
 		// Resolve the override with LookPath, symmetric with the PATH branch below, so
 		// a typo, a non-executable file, or a bad PATH-relative name fails fast at
 		// startup instead of only at exec time on the first job. LookPath also handles
-		// a bare name (PATH lookup) and locks in an absolute path, shrinking the window
-		// for a PATH change between resolution and exec.
+		// a bare name (PATH lookup).
 		resolved, err := exec.LookPath(p)
 		if err != nil {
 			return Config{}, fmt.Errorf("AGY_MCP_AGY_PATH %q: %w", p, err)
@@ -54,6 +53,15 @@ func Resolve() (Config, error) {
 		}
 		c.AgyPath = p
 	}
+	// agy runs under the supervisor with cmd.Dir set to the job's cwd, so AgyPath
+	// must be absolute or it would resolve against the wrong directory; LookPath can
+	// return a relative path (a relative override, or a relative PATH entry). Report
+	// the pre-Abs value on failure since Abs returns "" then.
+	abs, err := filepath.Abs(c.AgyPath)
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve agy path %q: %w", c.AgyPath, err)
+	}
+	c.AgyPath = abs
 
 	self, err := os.Executable()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,7 +37,16 @@ func Resolve() (Config, error) {
 	}
 
 	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {
-		c.AgyPath = p
+		// Resolve the override with LookPath, symmetric with the PATH branch below, so
+		// a typo, a non-executable file, or a bad PATH-relative name fails fast at
+		// startup instead of only at exec time on the first job. LookPath also handles
+		// a bare name (PATH lookup) and locks in an absolute path, shrinking the window
+		// for a PATH change between resolution and exec.
+		resolved, err := exec.LookPath(p)
+		if err != nil {
+			return Config{}, fmt.Errorf("AGY_MCP_AGY_PATH %q: %w", p, err)
+		}
+		c.AgyPath = resolved
 	} else {
 		p, err := exec.LookPath("agy")
 		if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,18 +37,48 @@ func TestResolveDefaults(t *testing.T) {
 }
 
 func TestResolveAgyPathOverride(t *testing.T) {
-	t.Setenv("AGY_MCP_AGY_PATH", "/opt/custom/agy")
+	agy := filepath.Join(t.TempDir(), "agy")
+	if err := os.WriteFile(agy, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGY_MCP_AGY_PATH", agy)
 	c, err := Resolve()
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if c.AgyPath != "/opt/custom/agy" {
-		t.Errorf("AgyPath = %q", c.AgyPath)
+	if c.AgyPath != agy {
+		t.Errorf("AgyPath = %q, want %q", c.AgyPath, agy)
+	}
+}
+
+func TestResolveAgyPathOverrideMissing(t *testing.T) {
+	// A typo'd override should fail fast at startup (symmetric with the PATH-lookup
+	// branch) rather than only surfacing as an exec error on the first job.
+	t.Setenv("AGY_MCP_AGY_PATH", filepath.Join(t.TempDir(), "does-not-exist"))
+	if _, err := Resolve(); err == nil {
+		t.Fatal("Resolve should fail when AGY_MCP_AGY_PATH points at a missing file")
+	}
+}
+
+func TestResolveAgyPathOverrideNotExecutable(t *testing.T) {
+	// An override that exists but is not executable would fail at exec time, so it
+	// must be rejected at startup too (existence alone is not enough).
+	agy := filepath.Join(t.TempDir(), "agy")
+	if err := os.WriteFile(agy, []byte("not a program"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGY_MCP_AGY_PATH", agy)
+	if _, err := Resolve(); err == nil {
+		t.Fatal("Resolve should fail when AGY_MCP_AGY_PATH is not executable")
 	}
 }
 
 func TestResolveHTTPToken(t *testing.T) {
-	t.Setenv("AGY_MCP_AGY_PATH", "/opt/custom/agy") // skip PATH lookup
+	agy := filepath.Join(t.TempDir(), "agy")
+	if err := os.WriteFile(agy, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGY_MCP_AGY_PATH", agy) // skip PATH lookup
 
 	t.Run("default empty", func(t *testing.T) {
 		t.Setenv("AGY_MCP_HTTP_TOKEN", "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,6 +60,25 @@ func TestResolveAgyPathOverrideMissing(t *testing.T) {
 	}
 }
 
+func TestResolveAgyPathOverrideMadeAbsolute(t *testing.T) {
+	// agy runs under the supervisor with cmd.Dir set to the job's cwd, so a
+	// relative AgyPath would resolve against the wrong directory. A relative
+	// override must be made absolute at resolution time.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "agy"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	t.Setenv("AGY_MCP_AGY_PATH", "./agy")
+	c, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !filepath.IsAbs(c.AgyPath) {
+		t.Errorf("AgyPath = %q, want an absolute path", c.AgyPath)
+	}
+}
+
 func TestResolveAgyPathOverrideNotExecutable(t *testing.T) {
 	// An override that exists but is not executable would fail at exec time, so it
 	// must be rejected at startup too (existence alone is not enough).

--- a/internal/jobstore/perms_unix_test.go
+++ b/internal/jobstore/perms_unix_test.go
@@ -1,0 +1,71 @@
+//go:build unix
+
+package jobstore
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// clearUmask sets the process umask to 0 for the duration of the test and
+// restores it afterward, so a permission assertion isolates the explicit mode
+// the code requests from the ambient umask. Without it a regression that drops
+// the explicit mode (e.g. back to os.Create's 0666) could still pass under a
+// tight umask that happens to mask the extra bits away. Tests run sequentially
+// within a package, so toggling the process-global umask here is safe.
+func clearUmask(t *testing.T) {
+	t.Helper()
+	old := syscall.Umask(0)
+	t.Cleanup(func() { syscall.Umask(old) })
+}
+
+func TestCreateAndWriteExitCodeUsePrivatePerms(t *testing.T) {
+	// Job dirs and files hold prompts and full agy output, which often embed
+	// source code. On a multi-user host with a traversable home, 0755/0644 would
+	// let other users read them; 0700 dirs and 0600 files keep them private.
+	clearUmask(t)
+	s := New(t.TempDir())
+	dir, err := s.Create(Meta{ID: "j"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if di, err := os.Stat(dir); err != nil {
+		t.Fatal(err)
+	} else if got := di.Mode().Perm(); got != 0o700 {
+		t.Errorf("job dir perm = %o, want 700", got)
+	}
+	if mi, err := os.Stat(filepath.Join(dir, "meta.json")); err != nil {
+		t.Fatal(err)
+	} else if got := mi.Mode().Perm(); got != 0o600 {
+		t.Errorf("meta.json perm = %o, want 600", got)
+	}
+	if err := s.WriteExitCode("j", 0); err != nil {
+		t.Fatal(err)
+	}
+	if ei, err := os.Stat(filepath.Join(dir, "exit_code")); err != nil {
+		t.Fatal(err)
+	} else if got := ei.Mode().Perm(); got != 0o600 {
+		t.Errorf("exit_code perm = %o, want 600", got)
+	}
+}
+
+func TestUpdateMetaPreservesPrivatePerms(t *testing.T) {
+	// A rewrite via the temp+rename path must not loosen meta.json back to 0644.
+	clearUmask(t)
+	s := New(t.TempDir())
+	if _, err := s.Create(Meta{ID: "j"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateMeta(Meta{ID: "j", PID: 7}); err != nil {
+		t.Fatal(err)
+	}
+	mi, err := os.Stat(filepath.Join(s.jobDir("j"), "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mi.Mode().Perm(); got != 0o600 {
+		t.Errorf("meta.json perm after UpdateMeta = %o, want 600", got)
+	}
+}

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -86,7 +86,9 @@ func (s *Store) Create(m Meta) (string, error) {
 		return "", ErrInvalidID
 	}
 	dir := s.jobDir(m.ID)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// 0700: job dirs hold prompts and full agy output (which often embed source
+	// code), so they must not be readable by other users on a multi-user host.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	// Write meta.json with the same temp+rename pattern UpdateMeta uses, so a crash
@@ -169,7 +171,9 @@ func writeMetaAtomic(dir string, m Meta) error {
 		_ = os.Remove(tmpName)
 		return err
 	}
-	if err := os.Chmod(tmpName, 0o644); err != nil {
+	// 0600: meta.json records the prompt and cwd; keep it owner-only. os.CreateTemp
+	// already makes the temp 0600, so this only guards against a future mode change.
+	if err := os.Chmod(tmpName, 0o600); err != nil {
 		_ = os.Remove(tmpName)
 		return err
 	}
@@ -230,7 +234,7 @@ func (s *Store) WriteExitCode(id string, code int) error {
 	if !validJobID(id) {
 		return ErrInvalidID
 	}
-	return os.WriteFile(filepath.Join(s.jobDir(id), "exit_code"), []byte(strconv.Itoa(code)), 0o644)
+	return os.WriteFile(filepath.Join(s.jobDir(id), "exit_code"), []byte(strconv.Itoa(code)), 0o600)
 }
 
 // ExitCode returns the recorded exit code and whether it is present.

--- a/internal/supervisor/perms_unix_test.go
+++ b/internal/supervisor/perms_unix_test.go
@@ -1,0 +1,39 @@
+//go:build unix
+
+package supervisor
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+func TestSupervisorWritesPrivatePerms(t *testing.T) {
+	// out/err capture agy output (which often embeds source code) and exit_code is
+	// the supervisor's own write; all must be owner-only on a multi-user host.
+	// Clear the umask so the assertion checks the explicit mode the code sets, not
+	// whatever the ambient umask happens to mask away.
+	old := syscall.Umask(0)
+	t.Cleanup(func() { syscall.Umask(old) })
+
+	dir := t.TempDir()
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Stderr: "y", Exit: 0})
+	writeMeta(t, dir, jobstore.Meta{ID: "j", AgyPath: agy, Args: []string{"-p", "x"}, StartedAt: time.Now()})
+	if err := Run(dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, name := range []string{"out", "err", "exit_code"} {
+		fi, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("%s perm = %o, want 600", name, got)
+		}
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -87,12 +87,15 @@ func Run(jobDir string) error {
 		return err
 	}
 
-	outF, err := os.Create(filepath.Join(jobDir, "out"))
+	// 0600: out/err capture full agy output, which often embeds source code, so
+	// they must not be readable by other users on a multi-user host. os.Create would
+	// use 0666 (umask-reduced), so open them explicitly owner-only instead.
+	outF, err := os.OpenFile(filepath.Join(jobDir, "out"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = outF.Close() }()
-	errF, err := os.Create(filepath.Join(jobDir, "err"))
+	errF, err := os.OpenFile(filepath.Join(jobDir, "err"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -186,5 +189,7 @@ func Run(jobDir string) error {
 }
 
 func writeExit(jobDir string, code int) error {
-	return os.WriteFile(filepath.Join(jobDir, "exit_code"), []byte(strconv.Itoa(code)), 0o644)
+	// 0600 to match the other job-dir files; the sentinel itself is not sensitive,
+	// but a consistent owner-only contract is simpler to reason about.
+	return os.WriteFile(filepath.Join(jobDir, "exit_code"), []byte(strconv.Itoa(code)), 0o600)
 }

--- a/main.go
+++ b/main.go
@@ -115,6 +115,15 @@ func serve() error {
 // rather than relying on the user reading the docs (set -http-token to add auth, but
 // the loopback restriction holds regardless).
 func checkLoopbackAddr(addr string) error {
+	return checkLoopbackAddrResolved(addr, net.LookupHost)
+}
+
+// checkLoopbackAddrResolved is checkLoopbackAddr with the name resolver injected so
+// it is testable without DNS. A literal IP is checked directly; a hostname (such as
+// "localhost") is resolved and EVERY resolved address must be loopback, so a
+// hosts-file remap of "localhost" to a routable IP cannot silently expose the
+// server (the bare-string "localhost" check this replaces trusted the name blindly).
+func checkLoopbackAddrResolved(addr string, lookup func(string) ([]string, error)) error {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = addr // no port; treat the whole value as the host
@@ -122,11 +131,25 @@ func checkLoopbackAddr(addr string) error {
 	if host == "" {
 		return fmt.Errorf("http address %q binds all interfaces; specify a loopback host (e.g. 127.0.0.1:8765) for HTTP mode", addr)
 	}
-	if host == "localhost" {
-		return nil
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() {
+			return nil
+		}
+		return fmt.Errorf("http address %q must be loopback only (localhost, 127.0.0.1, or ::1) for HTTP mode", addr)
 	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
-		return nil
+	// A hostname: resolve it and require every address to be loopback.
+	addrs, err := lookup(host)
+	if err != nil {
+		return fmt.Errorf("resolve http host %q: %w", host, err)
 	}
-	return fmt.Errorf("http address %q must be loopback only (localhost, 127.0.0.1, or ::1) for HTTP mode", addr)
+	if len(addrs) == 0 {
+		return fmt.Errorf("http host %q resolves to no addresses; specify a loopback host for HTTP mode", host)
+	}
+	for _, a := range addrs {
+		ip := net.ParseIP(a)
+		if ip == nil || !ip.IsLoopback() {
+			return fmt.Errorf("http host %q resolves to non-loopback address %s; specify a loopback host (e.g. 127.0.0.1:8765) for HTTP mode", host, a)
+		}
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -114,6 +114,12 @@ func serve() error {
 // non-loopback bind could expose an unauthenticated server. This refuses to do so
 // rather than relying on the user reading the docs (set -http-token to add auth, but
 // the loopback restriction holds regardless).
+//
+// A hostname is re-resolved by net.Listen at bind time, so a hosts-file or DNS
+// change between this check and the bind could in principle bind non-loopback (a
+// TOCTOU). That is not defended here: changing /etc/hosts or DNS requires root,
+// and a root attacker can bypass any loopback restriction anyway. This check
+// guards against an accidental non-loopback bind, not a privileged attacker.
 func checkLoopbackAddr(addr string) error {
 	return checkLoopbackAddrResolved(addr, net.LookupHost)
 }
@@ -127,6 +133,12 @@ func checkLoopbackAddrResolved(addr string, lookup func(string) ([]string, error
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = addr // no port; treat the whole value as the host
+	}
+	// A bracketed IPv6 literal with no port (e.g. "[::1]") keeps its brackets after
+	// the no-port fallback above; strip them so net.ParseIP recognizes it (with a
+	// port, SplitHostPort already removed them).
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
 	}
 	if host == "" {
 		return fmt.Errorf("http address %q binds all interfaces; specify a loopback host (e.g. 127.0.0.1:8765) for HTTP mode", addr)

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,14 +83,47 @@ func TestRunJobCancelViaSignal(t *testing.T) {
 }
 
 func TestCheckLoopbackAddr(t *testing.T) {
+	// Literal IPs and localhost (resolved via the real /etc/hosts) are loopback;
+	// hostname resolution corner cases are covered hermetically below.
 	for _, addr := range []string{"127.0.0.1:8765", "localhost:8765", "[::1]:8765", "127.0.0.1:0"} {
 		if err := checkLoopbackAddr(addr); err != nil {
 			t.Errorf("checkLoopbackAddr(%q) = %v, want nil", addr, err)
 		}
 	}
-	for _, addr := range []string{":8765", "0.0.0.0:8765", "192.168.1.10:8765", "example.com:8765"} {
+	for _, addr := range []string{":8765", "0.0.0.0:8765", "192.168.1.10:8765"} {
 		if err := checkLoopbackAddr(addr); err == nil {
 			t.Errorf("checkLoopbackAddr(%q) = nil, want error", addr)
 		}
+	}
+}
+
+func TestCheckLoopbackAddrResolvesHostnames(t *testing.T) {
+	loopback := func(string) ([]string, error) { return []string{"127.0.0.1", "::1"}, nil }
+	remapped := func(string) ([]string, error) { return []string{"127.0.0.1", "10.0.0.5"}, nil }
+	failing := func(string) ([]string, error) { return nil, errors.New("no such host") }
+	empty := func(string) ([]string, error) { return nil, nil }
+
+	if err := checkLoopbackAddrResolved("localhost:8765", loopback); err != nil {
+		t.Errorf("localhost resolving to loopback should pass, got %v", err)
+	}
+	// A hosts-file remap of localhost to a routable IP must be rejected even though
+	// one resolved address is still loopback: any non-loopback address exposes it.
+	if err := checkLoopbackAddrResolved("localhost:8765", remapped); err == nil {
+		t.Error("localhost remapped to a non-loopback address must be rejected")
+	}
+	if err := checkLoopbackAddrResolved("localhost:8765", failing); err == nil {
+		t.Error("a resolve failure must be rejected, not silently allowed")
+	}
+	if err := checkLoopbackAddrResolved("localhost:8765", empty); err == nil {
+		t.Error("a host resolving to no addresses must be rejected")
+	}
+	// A literal IP needs no resolution and must not call the resolver.
+	called := false
+	spy := func(string) ([]string, error) { called = true; return nil, nil }
+	if err := checkLoopbackAddrResolved("127.0.0.1:8765", spy); err != nil {
+		t.Errorf("literal loopback IP should pass, got %v", err)
+	}
+	if called {
+		t.Error("a literal IP must not trigger a hostname lookup")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -85,7 +85,7 @@ func TestRunJobCancelViaSignal(t *testing.T) {
 func TestCheckLoopbackAddr(t *testing.T) {
 	// Literal IPs and localhost (resolved via the real /etc/hosts) are loopback;
 	// hostname resolution corner cases are covered hermetically below.
-	for _, addr := range []string{"127.0.0.1:8765", "localhost:8765", "[::1]:8765", "127.0.0.1:0"} {
+	for _, addr := range []string{"127.0.0.1:8765", "localhost:8765", "[::1]:8765", "127.0.0.1:0", "[::1]"} {
 		if err := checkLoopbackAddr(addr); err != nil {
 			t.Errorf("checkLoopbackAddr(%q) = %v, want nil", addr, err)
 		}


### PR DESCRIPTION
## Summary

Three security-hardening items (issue #35).

**Private permissions** — job dirs and files hold prompts and full agy output, which often embed source code, and were world/group-readable (`0755`/`0644`) on multi-user hosts. Tighten to owner-only:
- job dirs `0700` (`jobstore.Store.Create`)
- `meta.json` `0600` (`writeMetaAtomic`)
- `exit_code` `0600` (`jobstore.WriteExitCode` and the supervisor's `writeExit`)
- the supervisor's `out`/`err` opened `0600` via `os.OpenFile` instead of `os.Create` (which used `0666`)

Pre-existing dirs from an older binary are not re-tightened by `MkdirAll`, but they age out within one `JobTTL` and new jobs are private immediately.

**Loopback bind check** — `checkLoopbackAddr` accepted the literal `"localhost"` without resolving it, so a hosts-file remap to a routable IP defeated the loopback-only intent. It now resolves a hostname and requires *every* resolved address to be loopback; a literal IP is still checked directly. The resolver is injected (`checkLoopbackAddrResolved`) so the corner cases (remapped localhost, resolve error, empty result, literal-IP fast path) test hermetically without DNS.

**agy path validation** — the `AGY_MCP_AGY_PATH` override was taken verbatim while the PATH-lookup branch failed fast. It is now resolved with `exec.LookPath`, symmetric with that branch: a typo, a non-executable file, or a bad PATH-relative name fails at startup instead of at exec time on the first job, and a bare name still resolves via PATH.

## Related Issues

Closes #35

## Test Plan

- [x] `go test ./... -race`
- [x] `go vet ./...`, `GOOS=darwin go vet ./...`, `GOOS=windows go build/vet ./...`
- [x] `gofmt -l .` clean, `golangci-lint run ./...` 0 issues
- [x] New tests: dir/file perms (in `unix`-tagged files with a cleared umask so they verify the explicit mode, not the ambient umask), loopback hostname resolution (hermetic, injected resolver), and `AGY_MCP_AGY_PATH` missing + non-executable rejection
- [x] Reviewed by a Claude correctness agent and an independent Gemini 3.1 Pro pass; both flagged using `exec.LookPath` over `os.Stat` (adopted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate configured agent binary path at startup and normalize to an absolute path.
  * Restrict job data, metadata, output and exit files to owner-only permissions.
  * Tighten loopback bind validation to require all resolved addresses be loopback.

* **Tests**
  * Added and updated tests covering path override validation, permission enforcement, and loopback resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->