### PR TITLE
ci: ruleguard canary, SHA-pin actions, dedupe runs, version+linter fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,18 @@
 name: ci
 on:
+  # Filter push to main so a push to a PR branch does not run the matrix twice
+  # (once for push, once for pull_request); pull_request already covers PR branches.
   push:
+    branches: [main]
   pull_request:
 permissions:
   contents: read
+# Cancel superseded runs on the same ref so a rapid re-push does not pile up
+# duplicate in-flight runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
-  GO_VERSION: '1.26'
   # Pinned to match the local toolchain so local runs and CI use the same
   # linter version (and the same ruleguard behavior).
   GOLANGCI_LINT_VERSION: 'v2.11.4'
@@ -20,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       # build + vet on every OS proves the package compiles cross-platform (macOS gets
       # the unsupported-platform stubs). Tests run job supervision, which is Linux only,
       # so they (and the Windows cross-compile check) run on the ubuntu job.
@@ -39,8 +46,14 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+      # The ruleguard matchers in rules/*.go carry the //go:build ruleguard tag, so a
+      # syntax error in one compiles clean under the normal toolchain and silently
+      # disables the entire ruleguard layer while golangci-lint still reports 0 issues.
+      # Compile them explicitly so a broken rule fails CI instead of going unnoticed.
+      - name: Ruleguard rules compile
+        run: go build -tags ruleguard ./rules/
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,12 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
       - name: Test before release
         run: go test ./... -race
-      - uses: goreleaser/goreleaser-action@v7
+      # SHA-pinned: this job holds contents: write, so a moving tag on a third-party
+      # action is a supply-chain risk. Dependabot updates the SHA pin. (# v7.2.2)
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: '~> v2'
           args: release --clean

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,9 +39,8 @@ linters:
     - testifylint
     - thelper
     - unconvert
-    - wastedassign
-  disable:
     - unused
+    - wastedassign
   settings:
     gocognit:
       min-complexity: 50


### PR DESCRIPTION
## Summary

CI hardening (issue #32).

- **Ruleguard canary** — add a `go build -tags ruleguard ./rules/` step. The matchers in `rules/*.go` carry the `//go:build ruleguard` tag, so a syntax error in one compiles clean under the normal toolchain and silently disables the *entire* ruleguard layer (45+ matchers) while `golangci-lint` still reports `0 issues`. Reproduced locally: with a broken rule present, a bait violation passes and CI stays green. The new step compiles the rules so a broken rule fails CI.
- **SHA-pin actions** — pin `goreleaser/goreleaser-action` (the release job holds `contents: write`, so a moving tag is a real supply-chain risk) and `golangci-lint-action` to commit SHAs, with version comments dependabot can bump.
- **Dedupe runs** — filter `push` to `main` and add a `concurrency` group with `cancel-in-progress`, so a push to a PR branch no longer runs the 2-OS matrix twice (once for `push`, once for `pull_request`) and superseded runs cancel.
- **Version drift** — use `go-version-file: go.mod` in `setup-go` for both `ci.yml` and `release.yml`, so a release can't be built on a different toolchain than CI validated against.
- **unused linter** — re-enable it (probed clean: 0 issues) instead of disabling it with no explanation.

## Related Issues

Closes #32

## Test Plan

- [x] `go build -tags ruleguard ./rules/` builds clean; a deliberately broken rule makes it exit non-zero (canary works) while `golangci-lint` stays green (the bug it closes)
- [x] `golangci-lint run ./...` with `unused` re-enabled: 0 issues
- [x] YAML parses; `go build`/`go vet ./...` clean
- [x] This PR should run the matrix once (not twice), demonstrating the dedupe
- [x] Action SHAs resolve to `goreleaser-action` v7.2.2 and `golangci-lint-action` v9.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability through enhanced concurrency handling and tool version pinning.
  * Strengthened code quality checks with additional linter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->