### PR TITLE
fix(status): freeze elapsed, mark partial output, classify gate refusals

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -237,20 +237,24 @@ func (s *Store) WriteExitCode(id string, code int) error {
 	return os.WriteFile(filepath.Join(s.jobDir(id), "exit_code"), []byte(strconv.Itoa(code)), 0o600)
 }
 
-// CompletedAt returns when the supervisor recorded the job's completion, taken
-// from the exit_code sentinel's modification time. The sentinel is written once
-// at exit and never rewritten, so its mtime is a stable end timestamp. ok is
-// false when the sentinel is absent or cannot be stat'd, in which case callers
-// fall back to treating the job as still in progress for timing purposes.
+// CompletedAt returns the best available estimate of when a job finished, as a
+// file modification time. It prefers the exit_code sentinel (written once at a
+// clean exit and never rewritten, so its mtime is a stable end timestamp) and
+// falls back to the out then err file for a job recovered without a sentinel
+// (e.g. a supervisor killed by a reboot), whose last write still bounds when it
+// stopped producing. ok is false only when none of the three exist, in which
+// case callers treat the job as still in progress for timing purposes.
 func (s *Store) CompletedAt(id string) (time.Time, bool) {
 	if !validJobID(id) {
 		return time.Time{}, false
 	}
-	info, err := os.Stat(filepath.Join(s.jobDir(id), "exit_code"))
-	if err != nil {
-		return time.Time{}, false
+	dir := s.jobDir(id)
+	for _, name := range []string{"exit_code", "out", "err"} {
+		if info, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return info.ModTime(), true
+		}
 	}
-	return info.ModTime(), true
+	return time.Time{}, false
 }
 
 // ExitCode returns the recorded exit code and whether it is present.

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -237,6 +237,22 @@ func (s *Store) WriteExitCode(id string, code int) error {
 	return os.WriteFile(filepath.Join(s.jobDir(id), "exit_code"), []byte(strconv.Itoa(code)), 0o600)
 }
 
+// CompletedAt returns when the supervisor recorded the job's completion, taken
+// from the exit_code sentinel's modification time. The sentinel is written once
+// at exit and never rewritten, so its mtime is a stable end timestamp. ok is
+// false when the sentinel is absent or cannot be stat'd, in which case callers
+// fall back to treating the job as still in progress for timing purposes.
+func (s *Store) CompletedAt(id string) (time.Time, bool) {
+	if !validJobID(id) {
+		return time.Time{}, false
+	}
+	info, err := os.Stat(filepath.Join(s.jobDir(id), "exit_code"))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
+}
+
 // ExitCode returns the recorded exit code and whether it is present.
 func (s *Store) ExitCode(id string) (int, bool) {
 	if !validJobID(id) {

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -19,23 +19,41 @@ func newGate(maxJobs int) *gate {
 	return &gate{max: maxJobs, keys: map[string]bool{}}
 }
 
+// acquireOutcome reports whether tryAcquire reserved a slot and, when it did
+// not, why. The caller turns the cause into a precise error instead of always
+// blaming a conversation/directory conflict (a refusal can also be the global
+// cap, which is a different thing to tell the user).
+type acquireOutcome int
+
+const (
+	acquireOK      acquireOutcome = iota // slot reserved
+	acquireKeyBusy                       // another job already holds this conversation/cwd key
+	acquireAtCap                         // the global concurrency cap is reached
+)
+
 // tryAcquire reserves a slot. An empty key skips per-key serialization but still
-// counts against the global cap.
-func (g *gate) tryAcquire(key string) bool {
+// counts against the global cap. The per-key check comes first so that when both
+// causes apply (the cap is full and this key is already held) the more specific
+// key conflict is reported.
+func (g *gate) tryAcquire(key string) acquireOutcome {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.inFlight >= g.max {
-		return false
-	}
 	if key != "" && g.keys[key] {
-		return false
+		return acquireKeyBusy
+	}
+	if g.inFlight >= g.max {
+		return acquireAtCap
 	}
 	g.inFlight++
 	if key != "" {
 		g.keys[key] = true
 	}
-	return true
+	return acquireOK
 }
+
+// cap returns the configured global concurrency cap, so callers can name the
+// limit in an at-capacity error. It is set once in newGate and never mutated.
+func (g *gate) cap() int { return g.max }
 
 // forceAcquire reserves a slot and key for a job that is already running (a
 // restored job whose agy session exists regardless of the gate), so the gate

--- a/internal/manager/concurrency_test.go
+++ b/internal/manager/concurrency_test.go
@@ -22,14 +22,14 @@ func TestKeyForRequest(t *testing.T) {
 
 func TestGateBlocksSameKey(t *testing.T) {
 	g := newGate(4)
-	if !g.tryAcquire("conv:x") {
+	if g.tryAcquire("conv:x") != acquireOK {
 		t.Fatal("first acquire should succeed")
 	}
-	if g.tryAcquire("conv:x") {
-		t.Fatal("second acquire on same key must fail while first is held")
+	if g.tryAcquire("conv:x") != acquireKeyBusy {
+		t.Fatal("second acquire on same key must report acquireKeyBusy while first is held")
 	}
 	g.release("conv:x")
-	if !g.tryAcquire("conv:x") {
+	if g.tryAcquire("conv:x") != acquireOK {
 		t.Fatal("acquire after release should succeed")
 	}
 }
@@ -46,34 +46,54 @@ func TestGateForceAcquire(t *testing.T) {
 	if g.forceAcquire("cwd:c") {
 		t.Fatal("forceAcquire on a held key must return false")
 	}
-	// inFlight is now past the cap, so a new normal run is refused.
-	if g.tryAcquire("cwd:d") {
-		t.Fatal("a new run must be refused while forced jobs exceed the cap")
+	// inFlight is now past the cap, so a new normal run is refused for cap reasons.
+	if g.tryAcquire("cwd:d") != acquireAtCap {
+		t.Fatal("a new run must be refused (acquireAtCap) while forced jobs exceed the cap")
 	}
 	// Drain below the cap; the still-held forced key cwd:c must keep blocking a
 	// same-key run even though a slot is now free (key block, not cap block).
 	g.release("cwd:a")
 	g.release("cwd:b")
-	if g.tryAcquire("cwd:c") {
-		t.Fatal("a forced key must keep blocking a same-key run with a free slot")
+	if g.tryAcquire("cwd:c") != acquireKeyBusy {
+		t.Fatal("a forced key must keep blocking a same-key run (acquireKeyBusy) with a free slot")
 	}
 	// A different key with a free slot is still acquirable.
-	if !g.tryAcquire("cwd:d") {
+	if g.tryAcquire("cwd:d") != acquireOK {
 		t.Fatal("a free key under the cap should be acquirable")
 	}
 }
 
 func TestGateGlobalCap(t *testing.T) {
 	g := newGate(2)
-	if !g.tryAcquire("conv:a") || !g.tryAcquire("conv:b") {
+	if g.tryAcquire("conv:a") != acquireOK || g.tryAcquire("conv:b") != acquireOK {
 		t.Fatal("two distinct keys should fill the cap")
 	}
 	// The cap is full even though the third key is distinct.
-	if g.tryAcquire("conv:c") {
-		t.Fatal("acquire past the global cap must fail")
+	if g.tryAcquire("conv:c") != acquireAtCap {
+		t.Fatal("acquire past the global cap must report acquireAtCap")
 	}
 	g.release("conv:a")
-	if !g.tryAcquire("conv:c") {
+	if g.tryAcquire("conv:c") != acquireOK {
 		t.Fatal("acquire after a release should succeed")
+	}
+}
+
+// TestGateRejectionDistinguishesCause: tryAcquire must report whether a refusal
+// was a per-key conflict or the global cap, so the caller can give a precise
+// error instead of always blaming a conversation/directory conflict. When both
+// apply (cap full and the key already held) the more specific key conflict wins.
+func TestGateRejectionDistinguishesCause(t *testing.T) {
+	g := newGate(1)
+	if g.tryAcquire("conv:a") != acquireOK {
+		t.Fatal("first acquire should succeed")
+	}
+	if got := g.tryAcquire("conv:a"); got != acquireKeyBusy {
+		t.Fatalf("same-key acquire = %v, want acquireKeyBusy even when also at cap", got)
+	}
+	if got := g.tryAcquire("conv:b"); got != acquireAtCap {
+		t.Fatalf("distinct-key acquire at cap = %v, want acquireAtCap", got)
+	}
+	if g.cap() != 1 {
+		t.Fatalf("cap() = %d, want 1", g.cap())
 	}
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -236,6 +236,14 @@ func (m *Manager) hasLaterSameCwdRun(meta jobstore.Meta) (bool, error) {
 
 // StartJob persists meta and spawns the detached supervisor.
 func (m *Manager) StartJob(req StartRequest) (Job, error) {
+	// conversation_id and continue_latest are mutually exclusive: continue_latest
+	// resolves to a conversation id that would otherwise silently overwrite the
+	// explicit one, and the precedence even flips depending on whether the cache
+	// resolves. Reject the combination outright (before any platform or filesystem
+	// work) so the caller gets a deterministic error instead of a confusing winner.
+	if req.ContinueLatest && req.ConversationID != "" {
+		return Job{}, fmt.Errorf("conversation_id and continue_latest are mutually exclusive: pass one or the other")
+	}
 	// Job supervision needs process groups and /proc, which only exist on Linux. On
 	// other platforms refuse before doing any work, so the failure is a clear error
 	// rather than a half-spawned job. stdio/HTTP serve, list_models, and list_sessions
@@ -288,8 +296,13 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 
 	key := keyFor(req)
-	if !m.gate.tryAcquire(key) {
+	switch m.gate.tryAcquire(key) {
+	case acquireOK:
+		// Slot reserved; proceed to spawn below.
+	case acquireKeyBusy:
 		return Job{}, fmt.Errorf("a conflicting agy job for this conversation or directory is already running")
+	case acquireAtCap:
+		return Job{}, fmt.Errorf("agy-mcp is at its concurrency cap of %d running job(s); retry once one finishes", m.gate.cap())
 	}
 
 	args := buildAgyArgs(req)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -296,13 +296,17 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 
 	key := keyFor(req)
-	switch m.gate.tryAcquire(key) {
+	switch outcome := m.gate.tryAcquire(key); outcome {
 	case acquireOK:
 		// Slot reserved; proceed to spawn below.
 	case acquireKeyBusy:
 		return Job{}, fmt.Errorf("a conflicting agy job for this conversation or directory is already running")
 	case acquireAtCap:
 		return Job{}, fmt.Errorf("agy-mcp is at its concurrency cap of %d running job(s); retry once one finishes", m.gate.cap())
+	default:
+		// Fail closed: a future acquireOutcome must never fall through and start a
+		// job without a reserved slot or key.
+		return Job{}, fmt.Errorf("internal admission error: unknown acquire outcome %d", outcome)
 	}
 
 	args := buildAgyArgs(req)

--- a/internal/manager/start_test.go
+++ b/internal/manager/start_test.go
@@ -1,0 +1,31 @@
+package manager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+)
+
+// TestStartJobRejectsConversationIDWithContinueLatest: supplying both an
+// explicit conversation_id and continue_latest is ambiguous (continue_latest
+// resolves to an id that would silently overwrite the explicit one, and the
+// precedence flips depending on whether the cache resolves). StartJob must
+// reject the combination outright rather than pick a confusing winner. The
+// check runs before the platform gate, so it is exercised on every OS.
+func TestStartJobRejectsConversationIDWithContinueLatest(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	_, err := m.StartJob(StartRequest{
+		Prompt:         "hi",
+		Cwd:            t.TempDir(),
+		ConversationID: "abc",
+		ContinueLatest: true,
+	})
+	if err == nil {
+		t.Fatal("StartJob must reject conversation_id + continue_latest together")
+	}
+	if !strings.Contains(err.Error(), "continue_latest") || !strings.Contains(err.Error(), "conversation_id") {
+		t.Fatalf("error = %v, want it to name both conflicting fields", err)
+	}
+}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -40,6 +40,11 @@ type Status struct {
 	Result         string // present when done: captured stdout
 	Error          string // present when failed: stderr tail + exit code
 	ConversationID string
+	// Partial marks a done job whose result was recovered from the out file
+	// without a completion sentinel (the supervisor died before writing one,
+	// e.g. across a reboot). The captured output may be truncated, so a caller
+	// should not treat it as a guaranteed-complete result.
+	Partial bool
 }
 
 // Status derives a job's status from the on-disk store.
@@ -81,6 +86,7 @@ func (m *Manager) Status(id string) (Status, error) {
 	case out != "":
 		st.State = StateDone
 		st.Result = out
+		st.Partial = true // recovered without a sentinel; the output may be truncated
 		st.ConversationID = m.lazyCaptureConversationID(meta)
 	default:
 		st.State = StateFailed
@@ -91,6 +97,9 @@ func (m *Manager) Status(id string) (Status, error) {
 
 // statusFromExitCode fills st from a recorded exit-code sentinel.
 func (m *Manager) statusFromExitCode(dir string, meta jobstore.Meta, st Status, code int) Status {
+	// The job is terminal, so freeze Elapsed at the completion time rather than
+	// letting it grow forever as time.Since(StartedAt).
+	st.Elapsed = m.frozenElapsed(meta, st.Elapsed)
 	switch code {
 	case 0:
 		// Capture the conversation id first: a clean exit means the backend
@@ -123,6 +132,63 @@ func (m *Manager) statusFromExitCode(dir string, meta jobstore.Meta, st Status, 
 		st.Error = errorSummary(dir, code)
 	}
 	return st
+}
+
+// State returns just the job's state, without paying to read its (potentially
+// large) out file when the state can be decided from the exit-code sentinel
+// alone. agy_cancel uses it: every actual cancel leaves a non-zero sentinel
+// (SIGTERM/SIGINT, or a timeout/spawn-fail kill), so the common path reads no
+// out/err at all. State never disagrees with Status: the one terminal case
+// whose done-vs-failed split depends on out readability (a clean exit, code 0)
+// is not fast-pathed but deferred to Status, as is the running/recovery path.
+func (m *Manager) State(id string) (string, error) {
+	// Fast path: a terminal sentinel other than a clean exit decides the state
+	// from the code alone. A clean exit (0) is excluded because Status downgrades
+	// a successful-but-unreadable out to failed, a distinction that requires the
+	// read State is trying to avoid.
+	if code, ok := m.store.ExitCode(id); ok && code != 0 {
+		return stateForCode(code), nil
+	}
+	// Clean exit, or no sentinel yet: defer to Status, which reads the out file to
+	// tell a clean/recovered result (done) from an unreadable or absent one
+	// (failed) and handles the running and post-exit race exactly as the poller
+	// sees it. Deferring here keeps State and Status from ever diverging.
+	st, err := m.Status(id)
+	if err != nil {
+		return "", err
+	}
+	return st.State, nil
+}
+
+// stateForCode maps a terminal exit-code sentinel to a job state. It is the
+// shared source of truth for the code->state mapping; State uses it for the
+// non-zero terminal codes (a clean exit's done-vs-failed split also depends on
+// out readability, so State handles 0 via Status rather than this mapping).
+func stateForCode(code int) string {
+	switch code {
+	case 0:
+		return StateDone
+	case jobstore.ExitSIGTERM, jobstore.ExitSIGINT:
+		return StateCancelled
+	default: // timeout, spawn-fail, or any other nonzero code
+		return StateFailed
+	}
+}
+
+// frozenElapsed returns a terminal job's run duration measured to when the
+// supervisor recorded completion (the exit_code sentinel's mtime), so a
+// long-finished job does not report an ever-growing elapsed. It falls back to
+// the passed-in running duration (time.Since(StartedAt)) when the completion
+// time is unavailable or implausibly precedes StartedAt (clock skew).
+func (m *Manager) frozenElapsed(meta jobstore.Meta, running time.Duration) time.Duration {
+	end, ok := m.store.CompletedAt(meta.ID)
+	if !ok {
+		return running
+	}
+	if d := end.Sub(meta.StartedAt); d >= 0 {
+		return d
+	}
+	return running
 }
 
 // readFile returns the file's contents (trailing newline trimmed), capped at

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -77,7 +77,11 @@ func (m *Manager) Status(id string) (Status, error) {
 	if code, ok := m.store.ExitCode(id); ok {
 		return m.statusFromExitCode(dir, meta, st, code), nil
 	}
-	// Process is gone without a sentinel. If output was captured, recover it.
+	// Process is gone without a sentinel. The job is terminal (no supervisor is
+	// left to write one), so freeze elapsed at the best available end time before
+	// classifying the outcome, so a recovered job's elapsed does not keep growing.
+	st.Elapsed = m.frozenElapsed(meta, st.Elapsed)
+	// If output was captured, recover it.
 	out, rerr := readFile(filepath.Join(dir, "out"))
 	switch {
 	case rerr != nil:
@@ -175,11 +179,13 @@ func stateForCode(code int) string {
 	}
 }
 
-// frozenElapsed returns a terminal job's run duration measured to when the
-// supervisor recorded completion (the exit_code sentinel's mtime), so a
-// long-finished job does not report an ever-growing elapsed. It falls back to
-// the passed-in running duration (time.Since(StartedAt)) when the completion
-// time is unavailable or implausibly precedes StartedAt (clock skew).
+// frozenElapsed returns a terminal job's run duration measured to its recorded
+// completion time (see jobstore.CompletedAt), so a long-finished job does not
+// report an ever-growing elapsed. It falls back to the passed-in running
+// duration (time.Since(StartedAt)) only when no completion time exists at all;
+// if the completion time implausibly precedes StartedAt (clock skew) it clamps
+// to 0, because the job is terminal and elapsed must stay frozen rather than
+// resume growing.
 func (m *Manager) frozenElapsed(meta jobstore.Meta, running time.Duration) time.Duration {
 	end, ok := m.store.CompletedAt(meta.ID)
 	if !ok {
@@ -188,7 +194,7 @@ func (m *Manager) frozenElapsed(meta jobstore.Meta, running time.Duration) time.
 	if d := end.Sub(meta.StartedAt); d >= 0 {
 		return d
 	}
-	return running
+	return 0
 }
 
 // readFile returns the file's contents (trailing newline trimmed), capped at

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -28,6 +29,9 @@ func TestStatusDone(t *testing.T) {
 	}
 	if st.State != "done" || st.Result != "the review" {
 		t.Fatalf("status = %+v", st)
+	}
+	if st.Partial {
+		t.Fatalf("a cleanly-exited job must not be marked partial: %+v", st)
 	}
 }
 
@@ -151,5 +155,97 @@ func TestStatusInterruptedAfterReboot(t *testing.T) {
 	}
 	if st.Result != "partial" {
 		t.Fatalf("result = %q", st.Result)
+	}
+	// The supervisor never wrote a sentinel, so the recovered output may be
+	// truncated; it must be flagged so a caller does not treat it as complete.
+	if !st.Partial {
+		t.Fatalf("recovered output without a sentinel must be marked partial: %+v", st)
+	}
+}
+
+// TestStatusElapsedFrozenAtCompletion: a terminal job's elapsed must reflect the
+// run's real duration (start to the sentinel's completion time), not an
+// ever-growing time.Since(StartedAt) for a job that finished long ago.
+func TestStatusElapsedFrozenAtCompletion(t *testing.T) {
+	m := newTestManager(t)
+	start := time.Now().Add(-time.Hour)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: start, BootID: readBootID()})
+	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644)
+	_ = m.store.WriteExitCode("j", 0)
+	// Pin the sentinel mtime to 10 minutes after start: completion is well in the
+	// past, so a correct Elapsed is ~10m, not the ~1h time.Since(start) would give.
+	end := start.Add(10 * time.Minute)
+	if err := os.Chtimes(filepath.Join(dir, "exit_code"), end, end); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := m.Status("j")
+	if st.State != StateDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if d := st.Elapsed; d < 9*time.Minute || d > 11*time.Minute {
+		t.Fatalf("elapsed = %v, want ~10m frozen at completion (not time.Since start)", d)
+	}
+}
+
+// TestStateMatchesStatusState: the cheap State accessor (used by agy_cancel,
+// which only needs the state and must not pay to read a large out file) must
+// agree with Status's full state across every terminal exit code.
+func TestStateMatchesStatusState(t *testing.T) {
+	cases := []struct {
+		code int
+		want string
+	}{
+		{0, StateDone},
+		{jobstore.ExitSIGTERM, StateCancelled},
+		{jobstore.ExitSIGINT, StateCancelled},
+		{jobstore.ExitTimeout, StateFailed},
+		{jobstore.ExitSpawnFail, StateFailed},
+		{5, StateFailed},
+	}
+	m := newTestManager(t)
+	for _, c := range cases {
+		id := "code-" + strconv.Itoa(c.code)
+		dir, _ := m.store.Create(jobstore.Meta{ID: id, StartedAt: time.Now(), BootID: readBootID()})
+		_ = os.WriteFile(filepath.Join(dir, "out"), []byte("x"), 0o644)
+		_ = m.store.WriteExitCode(id, c.code)
+
+		gotState, err := m.State(id)
+		if err != nil {
+			t.Fatalf("State(%d): %v", c.code, err)
+		}
+		if gotState != c.want {
+			t.Fatalf("State for exit %d = %q, want %q", c.code, gotState, c.want)
+		}
+		st, _ := m.Status(id)
+		if gotState != st.State {
+			t.Fatalf("State %q disagrees with Status.State %q for exit %d", gotState, st.State, c.code)
+		}
+	}
+}
+
+// TestStateMatchesStatusOnUnreadableCleanExit pins the one edge case where a
+// naive cheap path would diverge: a job that exited 0 but whose out file cannot
+// be read. Status downgrades that to failed (an unreadable success is not a
+// success), and State must report the same, not a bare "done" from the code.
+// Making out a directory lets os.Open succeed while the read fails.
+func TestStateMatchesStatusOnUnreadableCleanExit(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	if err := os.Mkdir(filepath.Join(dir, "out"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.store.WriteExitCode("j", 0)
+
+	gotState, err := m.State("j")
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, _ := m.Status("j")
+	if gotState != StateFailed {
+		t.Fatalf("State = %q, want failed when a clean exit's output is unreadable", gotState)
+	}
+	if gotState != st.State {
+		t.Fatalf("State %q disagrees with Status.State %q", gotState, st.State)
 	}
 }

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -188,6 +188,55 @@ func TestStatusElapsedFrozenAtCompletion(t *testing.T) {
 	}
 }
 
+// TestStatusRecoveredElapsedFrozen: a job recovered without a completion
+// sentinel (process gone, output present) is terminal, so its elapsed must
+// freeze at the best available end time (the out file's mtime) rather than
+// growing forever as time.Since(StartedAt).
+func TestStatusRecoveredElapsedFrozen(t *testing.T) {
+	m := newTestManager(t)
+	start := time.Now().Add(-time.Hour)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: start, PID: 999999, BootID: "old-boot"})
+	outPath := filepath.Join(dir, "out")
+	_ = os.WriteFile(outPath, []byte("recovered"), 0o644)
+	// Pin the out mtime to 10 minutes after start; a correct elapsed is ~10m, not
+	// the ~1h time.Since(start) would give for a job that "finished" an hour ago.
+	end := start.Add(10 * time.Minute)
+	if err := os.Chtimes(outPath, end, end); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := m.Status("j")
+	if st.State != StateDone || !st.Partial {
+		t.Fatalf("status = %+v, want done+partial", st)
+	}
+	if d := st.Elapsed; d < 9*time.Minute || d > 11*time.Minute {
+		t.Fatalf("elapsed = %v, want ~10m frozen at the recovered end", d)
+	}
+}
+
+// TestStatusElapsedClampedOnClockSkew: when the recorded completion time
+// implausibly precedes StartedAt (clock skew), a terminal job's elapsed must
+// stay frozen (clamped to 0), not fall back to an ever-growing time.Since.
+func TestStatusElapsedClampedOnClockSkew(t *testing.T) {
+	m := newTestManager(t)
+	start := time.Now().Add(-time.Hour)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: start, BootID: readBootID()})
+	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644)
+	_ = m.store.WriteExitCode("j", 0)
+	skewed := start.Add(-time.Hour) // sentinel mtime before StartedAt
+	if err := os.Chtimes(filepath.Join(dir, "exit_code"), skewed, skewed); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := m.Status("j")
+	if st.State != StateDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.Elapsed != 0 {
+		t.Fatalf("elapsed = %v, want 0 (clamped under clock skew, not time.Since)", st.Elapsed)
+	}
+}
+
 // TestStateMatchesStatusState: the cheap State accessor (used by agy_cancel,
 // which only needs the state and must not pay to read a large out file) must
 // agree with Status's full state across every terminal exit code.

--- a/internal/manager/store.go
+++ b/internal/manager/store.go
@@ -1,6 +1,10 @@
 package manager
 
-import "github.com/tphakala/agy-mcp/internal/jobstore"
+import (
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
 
 // jobStore is the subset of *jobstore.Store that the Manager depends on. It is an
 // interface (not the concrete type) so tests can inject a store whose methods fail
@@ -20,5 +24,6 @@ type jobStore interface {
 	Dir(id string) (string, error)
 	WriteExitCode(id string, code int) error
 	ExitCode(id string) (int, bool)
+	CompletedAt(id string) (time.Time, bool)
 	List() ([]string, error)
 }

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -63,6 +63,9 @@ type statusOutput struct {
 	Result         string `json:"result,omitempty"`
 	Error          string `json:"error,omitempty"`
 	ConversationID string `json:"conversation_id,omitempty"`
+	// Partial is set when a done job's result was recovered without a completion
+	// sentinel and so may be truncated; see manager.Status.Partial.
+	Partial bool `json:"partial,omitempty"`
 }
 
 // toStatusOutput converts a manager status into its wire shape, shared by
@@ -74,6 +77,7 @@ func toStatusOutput(st manager.Status) statusOutput {
 		Result:         st.Result,
 		Error:          st.Error,
 		ConversationID: st.ConversationID,
+		Partial:        st.Partial,
 	}
 }
 
@@ -128,7 +132,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "agy_status",
-		Description: "Poll an agy job. Returns running, done (with result), failed, or cancelled.",
+		Description: `Poll an agy job. Returns running, done (with result), failed, or cancelled. A done result with "partial": true was recovered without a completion sentinel and may be truncated.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in statusInput) (*mcp.CallToolResult, statusOutput, error) {
 		st, err := mgr.Status(in.JobID)
 		if err != nil {
@@ -145,10 +149,12 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 			return nil, cancelOutput{}, err
 		}
 		// Cancel itself succeeded; report the resulting state, or "unknown" if the
-		// job state is no longer readable.
+		// job state is no longer readable. State (not Status) is used here: the
+		// follow-up only needs the state, and reading the full result would mean
+		// loading a potentially large out file just to discard it.
 		state := "unknown"
-		if st, err := mgr.Status(in.JobID); err == nil {
-			state = st.State
+		if s, err := mgr.State(in.JobID); err == nil {
+			state = s
 		}
 		return nil, cancelOutput{State: state}, nil
 	})


### PR DESCRIPTION
Finishes the remaining items of #29. The other items (the 32 MiB stderr-tail bug, IO-error handling, the spawn-fail message, the documented agy_cancel "unknown" state, and list_models stderr) were already resolved in #42; this PR covers the rest.

## What changed

**`agy_cancel` no longer reads the full out file just to get a state (item 2)**
Added `Manager.State`, a state-only accessor. Every actual cancel leaves a non-zero sentinel (SIGTERM/SIGINT, timeout, spawn-fail), so the common path decides the state from the exit code alone with no out/err read. A clean exit (code 0), whose done-vs-failed split depends on whether the out file is readable, is deferred to `Status` so `State` can never disagree with it (including `Status`'s "successful but unreadable output -> failed" downgrade).

Note: this targets the `agy_cancel` lookup the issue called out. `agy_status` still reads the result on each poll of a terminal job by design, since the caller wants the result; in practice clients stop polling once a job is terminal.

**Recovered-without-sentinel output is marked partial (item 5)**
A job whose process died before writing a completion sentinel but left an out file was reported plain `done`. It now sets `Partial`, surfaced on the `agy_status` wire output (`"partial": true`) and noted in the tool description, so a caller does not treat possibly-truncated output as a complete result.

**Elapsed is frozen at completion (item 6)**
`Elapsed` was `time.Since(StartedAt)` even for jobs that finished hours ago. It is now measured to the `exit_code` sentinel's mtime (`jobstore.CompletedAt`), falling back to `time.Since` when the completion time is missing or implausibly precedes `StartedAt` (clock skew). This derives the end time from the write-once sentinel rather than adding a new persisted field or a supervisor write.

**Gate refusals name the real cause (item 7)**
`gate.tryAcquire` returned a bare bool, so a refusal always blamed "a conflicting agy job for this conversation or directory" even when the global concurrency cap was the cause. It now returns an `acquireOutcome` (`acquireOK` / `acquireKeyBusy` / `acquireAtCap`) and `StartJob` emits a distinct message per cause. The per-key check runs first, so when both apply the more specific key conflict wins (telling the user to wait for capacity would be misleading there).

**`conversation_id` + `continue_latest` are rejected together (item 9)**
Supplying both was ambiguous: `continue_latest` would silently overwrite the explicit id, and the precedence even flipped depending on whether the cache resolved. `StartJob` now rejects the combination up front (before the platform check, so the contract is enforced on every OS).

## Tests
- `TestGateRejectionDistinguishesCause` + updated gate tests for the new outcome type.
- `TestStatusElapsedFrozenAtCompletion` (pins the sentinel mtime and asserts ~frozen elapsed, not `time.Since`).
- `TestStatusInterruptedAfterReboot` now asserts `Partial`; `TestStatusDone` asserts a clean job is not partial.
- `TestStateMatchesStatusState` (State agrees with Status across every exit code) and `TestStateMatchesStatusOnUnreadableCleanExit` (the clean-exit-but-unreadable-output edge case, surfaced during peer review).
- `TestStartJobRejectsConversationIDWithContinueLatest`.

`go vet`, `golangci-lint` (0 issues), and `go test -race ./...` all pass.

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job completion timestamp estimation from on-disk sentinels.
  * Lightweight state accessor for faster job state checks.
  * MCP tools expose a "partial" flag when recovered without a completion sentinel.

* **Bug Fixes**
  * Concurrency responses now distinguish same-key conflicts from global capacity limits.
  * Rejections for invalid parameter combinations are returned immediately.
  * Job elapsed time freezes at completion.

* **Tests**
  * Expanded tests for concurrency causes, capacity, and partial/recovered statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->