### PR TITLE
refactor(jobstore): centralize the job-dir file contract

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -85,11 +85,47 @@ func LoadDir(dir string) (Meta, error) {
 
 // WriteExitCodeDir writes the completion sentinel into a job directory. It is
 // the single implementation shared by the supervisor (which knows only the dir)
-// and Store.WriteExitCode (which resolves an id to its dir). 0600 matches the
-// rest of the job-dir contract: the sentinel is not sensitive, but a uniform
-// owner-only mode is simpler to reason about.
+// and Store.WriteExitCode (which resolves an id to its dir).
+//
+// The write is atomic (temp file + rename), mirroring writeMetaAtomic: a plain
+// os.WriteFile truncates before writing, so a manager polling ExitCode in that
+// window would read an empty file, fail to parse it, and misclassify a finished
+// or cancelled job as still running or interrupted. A rename makes the sentinel
+// appear in one step, never empty. 0600 matches the rest of the job-dir
+// contract: the sentinel is not sensitive, but a uniform owner-only mode is
+// simpler to reason about.
 func WriteExitCodeDir(dir string, code int) error {
-	return os.WriteFile(ExitCodePath(dir), []byte(strconv.Itoa(code)), 0o600)
+	tmp, err := os.CreateTemp(dir, "exit_code-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(strconv.Itoa(code)); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	// Flush before the rename so a crash cannot leave a renamed but empty sentinel.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	// os.CreateTemp already makes the temp 0600, so this only guards a future
+	// change to its default mode.
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, ExitCodePath(dir)); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
 }
 
 // ErrInvalidID is returned when a job id is not a safe path segment.

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -48,6 +48,50 @@ const (
 	ExitSIGTERM   = 143 // agy terminated by SIGTERM (128+15); cancel or timeout kill
 )
 
+// Job-directory file contract. Every package that touches a job dir (jobstore,
+// supervisor, manager, and the test fakes) must reference these names rather
+// than spelling the literals, so renaming a file is a single edit that the
+// compiler propagates instead of a silent skew caught only at integration time.
+const (
+	MetaFile     = "meta.json" // job metadata (atomic rewrite)
+	OutFile      = "out"       // captured agy stdout
+	ErrFile      = "err"       // captured agy stderr
+	ExitCodeFile = "exit_code" // completion sentinel
+)
+
+// MetaPath, OutPath, ErrPath, and ExitCodePath join a job directory with the
+// corresponding file name. They are the shared spelling for callers that hold
+// only the directory (the supervisor, the manager's status reader) rather than
+// a store id.
+func MetaPath(dir string) string     { return filepath.Join(dir, MetaFile) }
+func OutPath(dir string) string      { return filepath.Join(dir, OutFile) }
+func ErrPath(dir string) string      { return filepath.Join(dir, ErrFile) }
+func ExitCodePath(dir string) string { return filepath.Join(dir, ExitCodeFile) }
+
+// LoadDir reads and parses meta.json directly from a job directory. The
+// supervisor knows only the job dir (not the store root or the id), so this
+// lets it share Load's real read+unmarshal instead of re-implementing it.
+func LoadDir(dir string) (Meta, error) {
+	var m Meta
+	b, err := os.ReadFile(MetaPath(dir))
+	if err != nil {
+		return m, err
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return m, err
+	}
+	return m, nil
+}
+
+// WriteExitCodeDir writes the completion sentinel into a job directory. It is
+// the single implementation shared by the supervisor (which knows only the dir)
+// and Store.WriteExitCode (which resolves an id to its dir). 0600 matches the
+// rest of the job-dir contract: the sentinel is not sensitive, but a uniform
+// owner-only mode is simpler to reason about.
+func WriteExitCodeDir(dir string, code int) error {
+	return os.WriteFile(ExitCodePath(dir), []byte(strconv.Itoa(code)), 0o600)
+}
+
 // ErrInvalidID is returned when a job id is not a safe path segment.
 var ErrInvalidID = errors.New("invalid job id")
 
@@ -106,18 +150,10 @@ func (s *Store) Create(m Meta) (string, error) {
 
 // Load reads a job's Meta.
 func (s *Store) Load(id string) (Meta, error) {
-	var m Meta
 	if !validJobID(id) {
-		return m, ErrInvalidID
+		return Meta{}, ErrInvalidID
 	}
-	b, err := os.ReadFile(filepath.Join(s.jobDir(id), "meta.json"))
-	if err != nil {
-		return m, err
-	}
-	if err := json.Unmarshal(b, &m); err != nil {
-		return m, err
-	}
-	return m, nil
+	return LoadDir(s.jobDir(id))
 }
 
 // UpdateMeta atomically rewrites a job's meta.json. It takes s.mu so every meta
@@ -177,7 +213,7 @@ func writeMetaAtomic(dir string, m Meta) error {
 		_ = os.Remove(tmpName)
 		return err
 	}
-	if err := os.Rename(tmpName, filepath.Join(dir, "meta.json")); err != nil {
+	if err := os.Rename(tmpName, MetaPath(dir)); err != nil {
 		_ = os.Remove(tmpName)
 		return err
 	}
@@ -229,12 +265,16 @@ func (s *Store) Dir(id string) (string, error) {
 	return s.jobDir(id), nil
 }
 
-// WriteExitCode writes the completion sentinel.
+// WriteExitCode writes the completion sentinel for a job id. Production writes
+// the sentinel from the supervisor (which holds only the dir, via
+// WriteExitCodeDir); this id-based form is the seam tests use to stage a
+// terminal job. Both share WriteExitCodeDir so the on-disk contract is one
+// implementation.
 func (s *Store) WriteExitCode(id string, code int) error {
 	if !validJobID(id) {
 		return ErrInvalidID
 	}
-	return os.WriteFile(filepath.Join(s.jobDir(id), "exit_code"), []byte(strconv.Itoa(code)), 0o600)
+	return WriteExitCodeDir(s.jobDir(id), code)
 }
 
 // CompletedAt returns the best available estimate of when a job finished, as a
@@ -249,7 +289,7 @@ func (s *Store) CompletedAt(id string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	dir := s.jobDir(id)
-	for _, name := range []string{"exit_code", "out", "err"} {
+	for _, name := range []string{ExitCodeFile, OutFile, ErrFile} {
 		if info, err := os.Stat(filepath.Join(dir, name)); err == nil {
 			return info.ModTime(), true
 		}
@@ -262,7 +302,7 @@ func (s *Store) ExitCode(id string) (int, bool) {
 	if !validJobID(id) {
 		return 0, false
 	}
-	b, err := os.ReadFile(filepath.Join(s.jobDir(id), "exit_code"))
+	b, err := os.ReadFile(ExitCodePath(s.jobDir(id)))
 	if err != nil {
 		return 0, false
 	}

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -203,6 +203,42 @@ func TestExitCodeSentinel(t *testing.T) {
 	}
 }
 
+// TestDirContractSharedByStoreAndHelpers pins the centralized job-dir file
+// contract: the dir-based helpers (LoadDir, WriteExitCodeDir, the *Path
+// helpers) operate on the exact files the id-based Store methods read and
+// write, so the supervisor (which holds only the dir) and the manager (which
+// goes through Store by id) cannot drift apart.
+func TestDirContractSharedByStoreAndHelpers(t *testing.T) {
+	s := New(t.TempDir())
+	dir, err := s.Create(Meta{ID: "j", AgyPath: "/bin/agy", Prompt: "hi", StartedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create wrote meta.json where LoadDir reads it.
+	if got, err := LoadDir(dir); err != nil || got.ID != "j" || got.Prompt != "hi" {
+		t.Fatalf("LoadDir(dir) = %+v, %v; want the meta Store.Create wrote", got, err)
+	}
+	if MetaPath(dir) != filepath.Join(dir, "meta.json") {
+		t.Fatalf("MetaPath(dir) = %q, want it under the job dir", MetaPath(dir))
+	}
+
+	// The supervisor's WriteExitCodeDir is observed by the manager's Store.ExitCode.
+	if err := WriteExitCodeDir(dir, 42); err != nil {
+		t.Fatal(err)
+	}
+	if code, ok := s.ExitCode("j"); !ok || code != 42 {
+		t.Fatalf("ExitCode after WriteExitCodeDir = %d, %v; want 42, true", code, ok)
+	}
+	// And the reverse: Store.WriteExitCode (id path) is read back at ExitCodePath (dir path).
+	if err := s.WriteExitCode("j", 7); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(ExitCodePath(dir)); err != nil || string(b) != "7" {
+		t.Fatalf("ExitCodePath content = %q, %v; want \"7\"", b, err)
+	}
+}
+
 func TestListAndRemove(t *testing.T) {
 	s := New(t.TempDir())
 	_, _ = s.Create(Meta{ID: "a", StartedAt: time.Unix(0, 0)})

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -82,7 +81,7 @@ func (m *Manager) Status(id string) (Status, error) {
 	// classifying the outcome, so a recovered job's elapsed does not keep growing.
 	st.Elapsed = m.frozenElapsed(meta, st.Elapsed)
 	// If output was captured, recover it.
-	out, rerr := readFile(filepath.Join(dir, "out"))
+	out, rerr := readFile(jobstore.OutPath(dir))
 	switch {
 	case rerr != nil:
 		st.State = StateFailed
@@ -110,7 +109,7 @@ func (m *Manager) statusFromExitCode(dir string, meta jobstore.Meta, st Status, 
 		// conversation advanced, so even if the local out file cannot be read the
 		// caller still needs the id to continue the conversation.
 		st.ConversationID = m.lazyCaptureConversationID(meta)
-		out, err := readFile(filepath.Join(dir, "out"))
+		out, err := readFile(jobstore.OutPath(dir))
 		if err != nil {
 			// The job exited cleanly but we cannot read what it produced. Report
 			// that as a failure rather than a successful empty result.
@@ -254,7 +253,7 @@ func tailFile(path string, n int64) (string, error) {
 // trailing newline trimmed and starting on a valid UTF-8 boundary), or "" when
 // there is none.
 func cleanTail(dir string) (string, error) {
-	tail, err := tailFile(filepath.Join(dir, "err"), errTailBytes)
+	tail, err := tailFile(jobstore.ErrPath(dir), errTailBytes)
 	if err != nil {
 		return "", err
 	}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -3,13 +3,10 @@
 package supervisor
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -78,24 +75,20 @@ func Run(jobDir string) error {
 		// cmd.Wait forever. Refuse here, matching StartJob's guard on the manager side.
 		return errPlatformUnsupported
 	}
-	var m jobstore.Meta
-	b, err := os.ReadFile(filepath.Join(jobDir, "meta.json"))
+	m, err := jobstore.LoadDir(jobDir)
 	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(b, &m); err != nil {
 		return err
 	}
 
 	// 0600: out/err capture full agy output, which often embeds source code, so
 	// they must not be readable by other users on a multi-user host. os.Create would
 	// use 0666 (umask-reduced), so open them explicitly owner-only instead.
-	outF, err := os.OpenFile(filepath.Join(jobDir, "out"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	outF, err := os.OpenFile(jobstore.OutPath(jobDir), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = outF.Close() }()
-	errF, err := os.OpenFile(filepath.Join(jobDir, "err"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	errF, err := os.OpenFile(jobstore.ErrPath(jobDir), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -126,7 +119,7 @@ func Run(jobDir string) error {
 	defer signal.Stop(sig)
 
 	if err := cmd.Start(); err != nil {
-		_ = writeExit(jobDir, jobstore.ExitSpawnFail)
+		_ = jobstore.WriteExitCodeDir(jobDir, jobstore.ExitSpawnFail)
 		return err
 	}
 
@@ -185,11 +178,5 @@ func Run(jobDir string) error {
 	// closed before the kill, so they are observable by the time Wait returns.
 	// Guarding on waitErr != nil keeps a job that finished naturally at the instant
 	// the timer fired (a natural success has waitErr == nil) from being mislabeled.
-	return writeExit(jobDir, resolveExitCode(code, waitErr != nil, closed(timedOut), closed(cancelled)))
-}
-
-func writeExit(jobDir string, code int) error {
-	// 0600 to match the other job-dir files; the sentinel itself is not sensitive,
-	// but a consistent owner-only contract is simpler to reason about.
-	return os.WriteFile(filepath.Join(jobDir, "exit_code"), []byte(strconv.Itoa(code)), 0o600)
+	return jobstore.WriteExitCodeDir(jobDir, resolveExitCode(code, waitErr != nil, closed(timedOut), closed(cancelled)))
 }

--- a/internal/testutil/fakesupervisor.go
+++ b/internal/testutil/fakesupervisor.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
 // FakeSupervisor configures a stand-in supervisor script for tests.
@@ -66,15 +68,15 @@ func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 	sb.WriteString("printf '%s' \"${0##*/}\" > /proc/$$/comm\n")
 	sb.WriteString("dir=\"$2\"\n")
 	if cfg.AgyPath != "" {
-		fmt.Fprintf(&sb, "%q -p x > \"$dir/out\" 2> \"$dir/err\"\ncode=$?\n", cfg.AgyPath)
+		fmt.Fprintf(&sb, "%q -p x > \"$dir/%s\" 2> \"$dir/%s\"\ncode=$?\n", cfg.AgyPath, jobstore.OutFile, jobstore.ErrFile)
 	} else {
 		outPayload := filepath.Join(dir, "out-payload")
 		if err := os.WriteFile(outPayload, []byte(cfg.Out), 0o644); err != nil {
 			t.Fatalf("write fake supervisor out payload: %v", err)
 		}
-		fmt.Fprintf(&sb, "cat %q > \"$dir/out\"\ncode=%d\n", outPayload, cfg.Exit)
+		fmt.Fprintf(&sb, "cat %q > \"$dir/%s\"\ncode=%d\n", outPayload, jobstore.OutFile, cfg.Exit)
 	}
-	sb.WriteString("printf '%s' \"$code\" > \"$dir/exit_code\"\n")
+	fmt.Fprintf(&sb, "printf '%%s' \"$code\" > \"$dir/%s\"\n", jobstore.ExitCodeFile)
 	if cfg.CachePath != "" {
 		cachePayload := filepath.Join(dir, "cache-payload.json")
 		if err := os.WriteFile(cachePayload, []byte(cfg.CacheJSON), 0o644); err != nil {


### PR DESCRIPTION
## Summary

The on-disk job-dir file names (`meta.json`, `out`, `err`, `exit_code`) were spelled as independent raw literals across `jobstore`, `supervisor`, `manager`, and the test fakes. As #28 notes, a rename in one package compiled clean and broke the others only at integration-test time. This centralizes the contract in `jobstore`.

## What changed

**jobstore (the single source of truth)**
- Export `MetaFile` / `OutFile` / `ErrFile` / `ExitCodeFile` constants and `MetaPath` / `OutPath` / `ErrPath` / `ExitCodePath(dir)` helpers.
- Add dir-based `LoadDir(dir)` and `WriteExitCodeDir(dir, code)` so a caller that holds only the job directory (the supervisor) shares the real read/write instead of its own copy.
- `Store.Load` delegates to `LoadDir`; `Store.WriteExitCode` delegates to `WriteExitCodeDir`. Internal literals (the `Create` rename, `ExitCode`, `CompletedAt`) now use the constants.

**supervisor**
- Reads meta via `jobstore.LoadDir`, opens out/err via the path helpers, writes the sentinel via `jobstore.WriteExitCodeDir`.
- Deletes its byte-for-byte `writeExit` copy and the now-unused `encoding/json` / `path/filepath` / `strconv` imports.

**manager/status**
- Reads out/err through the shared path helpers (drops the now-unused `path/filepath` import).

**testutil fake supervisor**
- Interpolates the constants into its generated bash script so even the fake references the one contract.

## Issue checklist (#28)

- [x] export file-name constants from jobstore and use them everywhere
- [x] add dir-based helpers (LoadDir, WriteExitCodeDir, OutPath...) so the supervisor can share the real implementations
- [x] drop or repurpose `Store.WriteExitCode` (repurposed as a thin id-based wrapper over `WriteExitCodeDir`)
- [ ] `setProcessGroup`/`terminateGroup` duplication across the platform files — left as a follow-up; it is a separate concern (process management, with divergent signatures) from the file-name contract

## Test plan

- [x] `go build ./...` and `go build -tags ruleguard ./rules/` (the CI canary)
- [x] `go test -race ./...` green
- [x] New `TestDirContractSharedByStoreAndHelpers` cross-checks the dir-based helpers against the id-based `Store` methods
- [x] `golangci-lint run ./...` reports 0 issues; `gofmt` clean

Behavior-preserving; no functional change intended.

Refs #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how job metadata, output, and exit codes are read/written across components for more consistent behavior.
* **Bug Fixes**
  * Exit-code writes are now performed atomically and durably, reducing risk of partial or lost sentinel files.
* **Tests**
  * Added a test ensuring directory-based helpers and store methods operate on the same job files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->