### PR TITLE
test: cover lifecycle safety-net gaps (#33)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,11 @@ func fakeAgyOnPath(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "agy"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// On Windows exec.LookPath resolves via PATHEXT, so a bare "agy" is not found;
+	// the extra agy.exe makes the helper work there too and is ignored on Unix.
+	if err := os.WriteFile(filepath.Join(dir, "agy.exe"), nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("PATH", dir)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,9 +3,68 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+// fakeAgyOnPath puts an executable named "agy" on PATH and clears the path
+// override, so Resolve's PATH lookup succeeds without depending on a real agy.
+func fakeAgyOnPath(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "agy"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+// TestResolveStateDirOverride: AGY_MCP_STATE_DIR is used verbatim and takes
+// precedence over the XDG fallback (no "/agy-mcp" suffix is appended).
+func TestResolveStateDirOverride(t *testing.T) {
+	t.Setenv("AGY_MCP_STATE_DIR", "/custom/state")
+	t.Setenv("XDG_STATE_HOME", "/should/be/ignored")
+	fakeAgyOnPath(t)
+
+	c, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.StateDir != "/custom/state" {
+		t.Errorf("StateDir = %q, want the AGY_MCP_STATE_DIR override verbatim", c.StateDir)
+	}
+}
+
+// TestResolveDefaultModelAndJobTTL: AGY_MCP_DEFAULT_MODEL flows into the config,
+// and JobTTL defaults to 24h (a regression to 0 would silently disable GC).
+func TestResolveDefaultModelAndJobTTL(t *testing.T) {
+	t.Setenv("AGY_MCP_DEFAULT_MODEL", "Gemini 3.1 Pro (High)")
+	t.Setenv("AGY_MCP_STATE_DIR", t.TempDir())
+	fakeAgyOnPath(t)
+
+	c, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.DefaultModel != "Gemini 3.1 Pro (High)" {
+		t.Errorf("DefaultModel = %q, want the AGY_MCP_DEFAULT_MODEL value", c.DefaultModel)
+	}
+	if c.JobTTL != 24*time.Hour {
+		t.Errorf("JobTTL = %v, want the 24h default", c.JobTTL)
+	}
+}
+
+// TestResolveAgyNotOnPath: with no override and no agy on PATH, Resolve fails
+// fast with a clear error rather than deferring to exec time.
+func TestResolveAgyNotOnPath(t *testing.T) {
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	t.Setenv("PATH", t.TempDir()) // empty dir: no agy anywhere on PATH
+
+	if _, err := Resolve(); err == nil || !strings.Contains(err.Error(), "agy not found on PATH") {
+		t.Fatalf("err = %v, want an 'agy not found on PATH' error", err)
+	}
+}
 
 func TestResolveDefaults(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", "/tmp/xdgstate")

--- a/internal/manager/cancel_linux_test.go
+++ b/internal/manager/cancel_linux_test.go
@@ -45,3 +45,27 @@ func TestCancelSignalsSupervisor(t *testing.T) {
 		t.Fatalf("state = %q, want %q", st.State, StateCancelled)
 	}
 }
+
+// TestCancelDeadSupervisorNoOp: when the recorded supervisor is no longer alive
+// (a stale PID from a previous boot), Cancel is a no-op success; there is
+// nothing to signal and Status reports the terminal state from disk.
+func TestCancelDeadSupervisorNoOp(t *testing.T) {
+	m := newTestManager(t)
+	// A dead PID from a previous boot: processAlive is false, so Cancel must not
+	// signal anything and must return nil.
+	if _, err := m.store.Create(jobstore.Meta{ID: "j", PID: 999999, BootID: "old-boot", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Cancel("j"); err != nil {
+		t.Fatalf("Cancel on a dead supervisor = %v, want nil (no-op)", err)
+	}
+}
+
+// TestCancelLoadError: cancelling an unknown job surfaces the store's load
+// error rather than silently succeeding.
+func TestCancelLoadError(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.Cancel("does-not-exist"); err == nil {
+		t.Fatal("Cancel on an unknown job must return the load error")
+	}
+}

--- a/internal/manager/concurrency_test.go
+++ b/internal/manager/concurrency_test.go
@@ -34,6 +34,41 @@ func TestGateBlocksSameKey(t *testing.T) {
 	}
 }
 
+// TestNewGateClampsNonPositive: a non-positive cap is clamped to 1, so a
+// misconfigured MaxConcurrency cannot disable the gate (which would let every
+// run proceed concurrently and re-expose the session-lock hang).
+func TestNewGateClampsNonPositive(t *testing.T) {
+	for _, max := range []int{0, -1, -100} {
+		g := newGate(max)
+		if g.cap() != 1 {
+			t.Fatalf("newGate(%d).cap() = %d, want 1", max, g.cap())
+		}
+		if g.tryAcquire("a") != acquireOK {
+			t.Fatalf("newGate(%d): first acquire should succeed", max)
+		}
+		if g.tryAcquire("b") != acquireAtCap {
+			t.Fatalf("newGate(%d): a second distinct key must hit the clamped cap of 1", max)
+		}
+	}
+}
+
+// TestGateReleaseUnderflow: releasing more than was acquired must not drive
+// inFlight negative (which would silently raise the effective cap). An extra
+// release is absorbed, and the cap accounting stays correct afterward.
+func TestGateReleaseUnderflow(t *testing.T) {
+	g := newGate(1)
+	g.release("never-acquired") // underflow: inFlight is already 0
+	g.release("")               // and again with an empty key
+
+	// The cap is still 1: one acquire works, the next is refused.
+	if g.tryAcquire("a") != acquireOK {
+		t.Fatal("acquire after underflow releases should succeed")
+	}
+	if g.tryAcquire("b") != acquireAtCap {
+		t.Fatal("cap must still be 1 after underflow releases (inFlight not negative)")
+	}
+}
+
 func TestGateForceAcquire(t *testing.T) {
 	g := newGate(2)
 	// A restored job is already running, so forceAcquire tracks it even past the cap.

--- a/internal/manager/start_test.go
+++ b/internal/manager/start_test.go
@@ -1,11 +1,44 @@
 package manager
 
 import (
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tphakala/agy-mcp/internal/config"
 )
+
+// TestBuildAgyArgs pins the agy command line: the fixed flags, then --model,
+// repeated --add-dir, --conversation, and finally -p with the prompt, with the
+// optional flags omitted when their fields are empty.
+func TestBuildAgyArgs(t *testing.T) {
+	got := buildAgyArgs(StartRequest{
+		Prompt:         "review this",
+		Model:          "Gemini 3.1 Pro (High)",
+		Dirs:           []string{"/a", "/b"},
+		ConversationID: "cid-123",
+		Timeout:        20 * time.Minute,
+	})
+	want := []string{
+		"--dangerously-skip-permissions",
+		"--print-timeout", "20m0s",
+		"--model", "Gemini 3.1 Pro (High)",
+		"--add-dir", "/a", "--add-dir", "/b",
+		"--conversation", "cid-123",
+		"-p", "review this",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("buildAgyArgs full =\n  %q\nwant\n  %q", got, want)
+	}
+
+	// Minimal request: no model, dirs, or conversation -> only timeout and prompt.
+	got = buildAgyArgs(StartRequest{Prompt: "hi", Timeout: time.Minute})
+	want = []string{"--dangerously-skip-permissions", "--print-timeout", "1m0s", "-p", "hi"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("buildAgyArgs minimal =\n  %q\nwant\n  %q", got, want)
+	}
+}
 
 // TestStartJobRejectsConversationIDWithContinueLatest: supplying both an
 // explicit conversation_id and continue_latest is ambiguous (continue_latest

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -7,10 +7,59 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
+
+// TestStatusInterruptedNoOutput: a job whose process is gone with no sentinel
+// and no out file is a genuine interruption, reported failed (not done). This
+// is the branch TestStatusInterruptedAfterReboot does not cover (that one has
+// recovered output and asserts done).
+func TestStatusInterruptedNoOutput(t *testing.T) {
+	m := newTestManager(t)
+	// Dead PID from a previous boot, and no out/err/exit_code files at all.
+	if _, err := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), PID: 999999, BootID: "old-boot"}); err != nil {
+		t.Fatal(err)
+	}
+
+	st, _ := m.Status("j")
+	if st.State != StateFailed {
+		t.Fatalf("state = %q, want failed (interrupted, no output)", st.State)
+	}
+	if !strings.Contains(st.Error, "interrupted") {
+		t.Fatalf("error = %q, want it to mention the interruption", st.Error)
+	}
+	if st.Partial {
+		t.Fatalf("a no-output interruption is not a partial result: %+v", st)
+	}
+}
+
+// TestErrorSummaryTruncatesOnUTF8Boundary: when the trailing stderr is larger
+// than errTailBytes and the cut falls mid-rune, the reported error is advanced
+// to a valid UTF-8 boundary rather than emitting a split multi-byte rune.
+func TestErrorSummaryTruncatesOnUTF8Boundary(t *testing.T) {
+	m := newTestManager(t)
+	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	// 3-byte runes so the last errTailBytes window starts mid-rune (2000 % 3 != 0).
+	content := strings.Repeat("€", 1000) // 3000 bytes
+	if err := os.WriteFile(filepath.Join(dir, "err"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.store.WriteExitCode("j", 5)
+
+	st, _ := m.Status("j")
+	if st.State != StateFailed {
+		t.Fatalf("state = %q, want failed", st.State)
+	}
+	if !utf8.ValidString(st.Error) {
+		t.Fatalf("error is not valid UTF-8 (tail split mid-rune): %q", st.Error)
+	}
+	if len(st.Error) > len("exit 5: ")+errTailBytes {
+		t.Fatalf("error length %d exceeds the tail bound", len(st.Error))
+	}
+}
 
 func newTestManager(t *testing.T) *Manager {
 	t.Helper()

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -156,7 +156,19 @@ func TestHTTPServeListsTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list tools: %v", err)
 	}
-	if len(tools.Tools) < 5 {
-		t.Fatalf("expected >=5 tools, got %d", len(tools.Tools))
+	// Assert the exact registered set, not a lower bound: a dropped or renamed
+	// tool is a wire-contract regression that "len >= 5" would miss.
+	got := make(map[string]bool, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		got[tool.Name] = true
+	}
+	want := []string{"agy_run", "agy_status", "agy_cancel", "agy_run_sync", "list_models", "list_sessions"}
+	if len(tools.Tools) != len(want) {
+		t.Fatalf("registered %d tools, want %d (%v)", len(tools.Tools), len(want), want)
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Errorf("tool %q is not registered", name)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds deterministic tests for core-lifecycle paths that #33 flagged as having no coverage. Test-only; no production code changed.

## Coverage added

- **Status** — the genuinely-interrupted branch (process gone, no sentinel, no out file -> `failed`), which `TestStatusInterruptedAfterReboot` did not cover (it asserts the recovered-output `done` branch); and `errorSummary`'s UTF-8 boundary truncation when the trailing stderr exceeds `errTailBytes` and the cut lands mid-rune.
- **Gate** — `newGate` clamps a non-positive cap to 1; `release` underflow is absorbed so `inFlight` never goes negative (which would silently raise the cap).
- **buildAgyArgs** — pins the agy command line: `--print-timeout`, `--model`, repeated `--add-dir`, `--conversation`, and `-p` ordering, with optional flags omitted when empty.
- **Cancel** — the dead/stale-supervisor no-op and the `Load`-error path (only the live-supervisor path was covered).
- **config.Resolve** — the `AGY_MCP_STATE_DIR` override, `AGY_MCP_DEFAULT_MODEL`, the `JobTTL` default (a regression to 0 would silently disable GC), and the agy-not-on-PATH error.
- **serve_http** — assert the exact registered tool set (names + count) instead of a `>= 5` lower bound that would miss a dropped or renamed tool.

## Deferred (need a production change, not pure test additions)

Left as a follow-up so this PR stays test-only:
- Supervisor SIGKILL-escalation-after-killGrace test (needs `killGrace` injectable) and the spawn-failure (127) path.
- GC's keep-an-expired-but-alive-job invariant (needs a live process in the test).
- Platform-gating the `mcptools` tests so `go test ./...` passes on macOS/Windows (CI gates tests to ubuntu today).

## Test plan

- [x] `go test -race ./...` green; `go vet` clean; `golangci-lint` 0 issues; `gofmt` clean

Refs #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage: config resolution (state-dir override, default model and job TTL, behavior when agy is absent), job cancellation edge cases and load-error handling, concurrency gate edge cases (non‑positive caps and release underflow), argument construction for job starts, status reporting edge cases (interrupted/no-output and UTF‑8-safe truncation), and exact tool-listing verification for the HTTP tools endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->