### PR TITLE
test: hygiene fixes (checked casts, constants, env isolation, reaping) (#34)

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,8 @@ func TestResolveAgyNotOnPath(t *testing.T) {
 func TestResolveDefaults(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", "/tmp/xdgstate")
 	t.Setenv("AGY_MCP_AGY_PATH", "")
+	t.Setenv("AGY_MCP_STATE_DIR", "")
+	t.Setenv("AGY_MCP_DEFAULT_MODEL", "")
 	// Put a fake agy on PATH.
 	dir := t.TempDir()
 	agy := filepath.Join(dir, "agy")

--- a/internal/manager/cancel_linux_test.go
+++ b/internal/manager/cancel_linux_test.go
@@ -19,7 +19,10 @@ func TestCancelSignalsSupervisor(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = cmd.Process.Kill() }()
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
 
 	if _, err := m.store.Create(jobstore.Meta{
 		ID: "j", PID: cmd.Process.Pid, BootID: readBootID(), StartedAt: time.Now(),

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -76,7 +76,7 @@ func TestStatusDone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.State != "done" || st.Result != "the review" {
+	if st.State != StateDone || st.Result != "the review" {
 		t.Fatalf("status = %+v", st)
 	}
 	if st.Partial {
@@ -91,7 +91,7 @@ func TestStatusFailed(t *testing.T) {
 	_ = m.store.WriteExitCode("j", 5)
 
 	st, _ := m.Status("j")
-	if st.State != "failed" || st.Error == "" {
+	if st.State != StateFailed || st.Error == "" {
 		t.Fatalf("status = %+v", st)
 	}
 }
@@ -199,7 +199,7 @@ func TestStatusInterruptedAfterReboot(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("partial"), 0o644)
 
 	st, _ := m.Status("j")
-	if st.State != "done" { // no sentinel, but output present and process cannot be alive
+	if st.State != StateDone { // no sentinel, but output present and process cannot be alive
 		t.Fatalf("state = %q, want done (recovered output)", st.State)
 	}
 	if st.Result != "partial" {

--- a/internal/mcptools/run_sync_linux_test.go
+++ b/internal/mcptools/run_sync_linux_test.go
@@ -65,6 +65,18 @@ func newTestManager(t *testing.T, fake testutil.FakeAgy) (mgr *manager.Manager, 
 	return manager.New(c), stateDir
 }
 
+// structMap returns a tool result's structured content as a map, failing the
+// test (rather than panicking) when the payload is not the expected shape, so a
+// response-shape regression reports cleanly instead of crashing the test.
+func structMap(t *testing.T, sc any) map[string]any {
+	t.Helper()
+	m, ok := sc.(map[string]any)
+	if !ok {
+		t.Fatalf("structured content is %T, want map[string]any: %v", sc, sc)
+	}
+	return m
+}
+
 // waitForDone polls the manager directly until the job reports done with the
 // wanted result, or fails the test at the deadline.
 func waitForDone(t *testing.T, mgr *manager.Manager, jobID, want string, timeout time.Duration) {
@@ -111,7 +123,7 @@ func TestAgyRunSyncCompletesInline(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
 	}
-	sc := res.StructuredContent.(map[string]any)
+	sc := structMap(t, res.StructuredContent)
 	if sc["state"] != manager.StateDone {
 		t.Fatalf("state = %v, want done", sc["state"])
 	}
@@ -157,7 +169,7 @@ func TestAgyRunSyncOverrunReturnsJobID(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
 	}
-	sc := res.StructuredContent.(map[string]any)
+	sc := structMap(t, res.StructuredContent)
 	if sc["state"] != manager.StateRunning {
 		t.Fatalf("state = %v, want running", sc["state"])
 	}
@@ -198,7 +210,7 @@ func TestAgyRunSyncSendsProgress(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
 	}
-	if sc := res.StructuredContent.(map[string]any); sc["state"] != manager.StateDone {
+	if sc := structMap(t, res.StructuredContent); sc["state"] != manager.StateDone {
 		t.Fatalf("state = %v, want done", sc["state"])
 	}
 
@@ -316,7 +328,7 @@ func TestAgyRunSyncReturnsLateCapturedConversationID(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
 	}
-	sc := res.StructuredContent.(map[string]any)
+	sc := structMap(t, res.StructuredContent)
 	if sc["state"] != manager.StateDone {
 		t.Fatalf("state = %v, want done", sc["state"])
 	}

--- a/internal/mcptools/tools_linux_test.go
+++ b/internal/mcptools/tools_linux_test.go
@@ -26,7 +26,7 @@ func TestAgyRunAndStatusOverMCP(t *testing.T) {
 	if err != nil || res.IsError {
 		t.Fatalf("agy_run: err=%v res=%+v", err, res)
 	}
-	jobID := res.StructuredContent.(map[string]any)["job_id"].(string)
+	jobID, _ := structMap(t, res.StructuredContent)["job_id"].(string)
 	if jobID == "" {
 		t.Fatal("empty job id")
 	}
@@ -38,12 +38,17 @@ func TestAgyRunAndStatusOverMCP(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sc := s.StructuredContent.(map[string]any)
+		sc := structMap(t, s.StructuredContent)
 		if sc["state"] == manager.StateDone {
 			if sc["result"] != "REVIEW OK" {
 				t.Fatalf("result = %v", sc["result"])
 			}
 			return
+		}
+		// Fail fast on a terminal failure/cancel instead of burning the deadline
+		// and reporting an opaque timeout.
+		if state := sc["state"]; state == manager.StateFailed || state == manager.StateCancelled {
+			t.Fatalf("job reached terminal %v, want done; error=%v", state, sc["error"])
 		}
 		time.Sleep(20 * time.Millisecond)
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -106,7 +107,7 @@ func TestSupervisorHardTimeoutKillsAgy(t *testing.T) {
 		t.Fatalf("Run took %v; the hard timeout did not kill agy", elapsed)
 	}
 	code, _ := os.ReadFile(filepath.Join(dir, "exit_code"))
-	if strings.TrimSpace(string(code)) != "124" {
-		t.Fatalf("exit_code = %q, want 124 (timeout)", code)
+	if got := strings.TrimSpace(string(code)); got != strconv.Itoa(jobstore.ExitTimeout) {
+		t.Fatalf("exit_code = %q, want %d (timeout)", got, jobstore.ExitTimeout)
 	}
 }


### PR DESCRIPTION
## Summary

A batch of the low-risk test-hygiene items from #34. Test-only.

## Changes

- **mcptools** — add a `structMap(t, sc)` helper and route the `StructuredContent` casts through it, so a response-shape regression fails the test cleanly instead of panicking (`tools_test.go`/`run_sync_test.go` sites from the issue). Also make the `agy_status` poll loop in `TestAgyRunAndStatusOverMCP` fail fast on a terminal `failed`/`cancelled` state instead of burning the deadline into an opaque timeout (the follow-up I noted on #51).
- **supervisor_test** — assert the timeout exit code against `jobstore.ExitTimeout` instead of the raw `"124"` literal.
- **status_test** — assert `StateDone`/`StateFailed` instead of raw `"done"`/`"failed"` in the state checks.
- **cancel_linux_test** — `Kill` then `Wait` the spawned `sleep` so it is reaped, not left as a zombie.
- **config_test** — neutralize `AGY_MCP_STATE_DIR` and `AGY_MCP_DEFAULT_MODEL` in `TestResolveDefaults` so ambient env on a dev machine cannot break it.

## Deferred

The larger refactors stay as a follow-up: a shared `waitFor`/poll helper to consolidate the ~10 hand-rolled poll loops, building the `main_test` binary once, the `job_linux_test` cache-file override, subprocess context timeouts/stderr capture, and `FakeAgy` fractional (`time.Duration`) sleeps.

## Test plan

- [x] `go test -race ./...` green; `go vet` clean; `golangci-lint` 0 issues; `gofmt` clean
- [x] `GOOS=darwin` test binary still compiles (cast helper changes nothing cross-platform)

Refs #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability through enhanced environment isolation
  * Fixed process cleanup in spawned tests
  * Standardized assertions using exported constants instead of hard-coded values
  * Added helper utilities for more robust test assertions
  * Implemented fail-fast error handling for terminal test states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->