### PR TITLE
test(supervisor): cover SIGKILL escalation and spawn-failure (#33)

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -15,7 +15,9 @@ import (
 )
 
 // killGrace is how long the supervisor waits after SIGTERM before escalating to
-// SIGKILL when terminating the agy process group on cancel or timeout.
+// SIGKILL when terminating the agy process group on cancel or timeout. Run
+// passes it to run; a test injects a smaller grace to exercise the escalation
+// without a 10s wait.
 const killGrace = 10 * time.Second
 
 // fallbackTimeout bounds a job whose meta records a non-positive timeout (a
@@ -69,6 +71,14 @@ func resolveExitCode(raw int, waitFailed, timedOut, cancelled bool) int {
 // /dev/null, and writes jobDir/exit_code on completion (including on cancel).
 // Run returns an error only for setup failures, not for a non-zero agy exit.
 func Run(jobDir string) error {
+	return run(jobDir, killGrace)
+}
+
+// run is Run with an injectable SIGTERM->SIGKILL grace, so a test can exercise
+// the escalation without the 10s production wait. Passing grace as a parameter
+// (rather than mutating a package global) keeps the timer goroutine's read
+// race-free.
+func run(jobDir string, grace time.Duration) error {
 	if !proc.Supported {
 		// Job supervision needs process groups, signal forwarding, and /proc, which
 		// only exist on Linux. The non-Linux proc.TerminateGroup stub cannot kill agy,
@@ -147,7 +157,7 @@ func Run(jobDir string) error {
 		_ = proc.TerminateGroup(cmd.Process.Pid, syscall.SIGTERM)
 		select {
 		case <-done:
-		case <-time.After(killGrace):
+		case <-time.After(grace):
 			// Do not signal a process group that may have already been reaped
 			// (and whose pgid could be recycled) once Wait has returned.
 			select {

--- a/internal/supervisor/supervisor_linux_test.go
+++ b/internal/supervisor/supervisor_linux_test.go
@@ -1,0 +1,66 @@
+package supervisor
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// These tests drive Run, which only supervises on Linux (process groups, signal
+// forwarding). They are _linux-gated; the pure tests (resolveExitCode,
+// effectiveTimeout) stay in supervisor_test.go so they run everywhere.
+
+// TestSupervisorEscalatesToSIGKILL: when agy ignores SIGTERM, the supervisor
+// must escalate to SIGKILL after the grace window. A tiny injected grace
+// exercises the escalation in milliseconds instead of the 10s production wait.
+func TestSupervisorEscalatesToSIGKILL(t *testing.T) {
+	dir := t.TempDir()
+	// A fake agy that traps and ignores SIGTERM, so the hard timeout's SIGTERM
+	// cannot stop it; only the SIGKILL escalation can.
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{IgnoreSIGTERM: true})
+	writeMeta(t, dir, jobstore.Meta{
+		ID: "j", AgyPath: agy, Args: []string{"-p", "x"},
+		StartedAt: time.Now(), Timeout: 300 * time.Millisecond,
+	})
+
+	start := time.Now()
+	if err := run(dir, 200*time.Millisecond); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// With the injected 200ms grace this ends in well under a second; the 10s
+	// default would blow past 5s, so this also proves the injected grace was used.
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Run took %v; the SIGKILL escalation did not fire promptly", elapsed)
+	}
+	// A SIGTERM-ignoring agy can only have been stopped by the escalation, and the
+	// timeout override maps that kill to the timeout sentinel.
+	code, _ := os.ReadFile(jobstore.ExitCodePath(dir))
+	if got := strings.TrimSpace(string(code)); got != strconv.Itoa(jobstore.ExitTimeout) {
+		t.Fatalf("exit_code = %q, want %d (timeout via SIGKILL escalation)", got, jobstore.ExitTimeout)
+	}
+}
+
+// TestSupervisorSpawnFailureWrites127: when agy cannot be exec'd, the supervisor
+// writes the spawn-failure sentinel and returns the exec error, so Status can
+// report "agy did not start" rather than a bare interruption.
+func TestSupervisorSpawnFailureWrites127(t *testing.T) {
+	dir := t.TempDir()
+	writeMeta(t, dir, jobstore.Meta{
+		ID: "j", AgyPath: filepath.Join(dir, "nonexistent-agy"), Args: []string{"-p", "x"},
+		StartedAt: time.Now(), Timeout: time.Minute,
+	})
+
+	if err := Run(dir); err == nil {
+		t.Fatal("Run should return the spawn error when agy cannot be exec'd")
+	}
+	code, _ := os.ReadFile(jobstore.ExitCodePath(dir))
+	if got := strings.TrimSpace(string(code)); got != strconv.Itoa(jobstore.ExitSpawnFail) {
+		t.Fatalf("exit_code = %q, want %d (spawn failure)", got, jobstore.ExitSpawnFail)
+	}
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -72,8 +72,11 @@ func TestSupervisorCapturesOutputAndSentinel(t *testing.T) {
 		t.Fatalf("out = %q", out)
 	}
 	// The configured stderr must actually be captured to the err file, not just
-	// configured and ignored.
-	errOut, _ := os.ReadFile(filepath.Join(dir, "err"))
+	// configured and ignored. Use the shared job-dir path contract.
+	errOut, err := os.ReadFile(jobstore.ErrPath(dir))
+	if err != nil {
+		t.Fatalf("read err file: %v", err)
+	}
 	if strings.TrimSpace(string(errOut)) != "warn" {
 		t.Fatalf("err = %q, want %q", errOut, "warn")
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -71,6 +71,12 @@ func TestSupervisorCapturesOutputAndSentinel(t *testing.T) {
 	if strings.TrimSpace(string(out)) != "review text" {
 		t.Fatalf("out = %q", out)
 	}
+	// The configured stderr must actually be captured to the err file, not just
+	// configured and ignored.
+	errOut, _ := os.ReadFile(filepath.Join(dir, "err"))
+	if strings.TrimSpace(string(errOut)) != "warn" {
+		t.Fatalf("err = %q, want %q", errOut, "warn")
+	}
 	code, err := os.ReadFile(filepath.Join(dir, "exit_code"))
 	if err != nil || strings.TrimSpace(string(code)) != "0" {
 		t.Fatalf("exit_code = %q, err=%v", code, err)

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -14,6 +14,11 @@ type FakeAgy struct {
 	Stderr    string // printed to stderr
 	Exit      int    // exit code
 	SleepSecs int    // seconds to sleep before printing (simulate a long run)
+	// IgnoreSIGTERM makes the script trap and ignore SIGTERM and loop forever, so
+	// only SIGKILL can stop it. Used to exercise the supervisor's SIGKILL
+	// escalation after killGrace. Mutually exclusive with Stdout/Stderr/Exit
+	// (the process never reaches them).
+	IgnoreSIGTERM bool
 }
 
 // WriteFakeAgy writes an executable shell script that mimics agy's print mode
@@ -25,6 +30,18 @@ func WriteFakeAgy(t *testing.T, cfg FakeAgy) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "fake-agy")
+
+	if cfg.IgnoreSIGTERM {
+		// Trap and ignore SIGTERM, then loop forever. The inner sleep is killed by
+		// the supervisor's group SIGTERM, but bash ignores it and restarts the
+		// loop, so the process survives until the supervisor escalates to SIGKILL.
+		script := "#!/usr/bin/env bash\ntrap '' TERM\nwhile :; do sleep 1; done\n"
+		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+			t.Fatalf("write fake agy: %v", err)
+		}
+		return path
+	}
+
 	outPath := filepath.Join(dir, "fake-agy.out")
 	errPath := filepath.Join(dir, "fake-agy.err")
 	if err := os.WriteFile(outPath, []byte(cfg.Stdout), 0o644); err != nil {


### PR DESCRIPTION
## Summary

The supervisor's SIGTERM -> SIGKILL escalation (after `killGrace`) and its spawn-failure (127) sentinel were untested. #33 item 4. Mostly test code, with a small behavior-preserving refactor for the injectable grace.

## Changes

- Split `Run` into a thin `Run(jobDir)` plus an internal `run(jobDir, grace)`, so a test can inject a small grace and exercise the escalation in milliseconds instead of the 10s production wait. **Passing `grace` as a parameter rather than mutating a package global keeps the timer goroutine's read race-free** under `go test -race` (the global approach tripped the race detector).
- `FakeAgy.IgnoreSIGTERM`: a fake agy that traps `SIGTERM` and loops, so only `SIGKILL` can stop it.
- `TestSupervisorEscalatesToSIGKILL`: a `SIGTERM`-ignoring agy past its hard timeout must be `SIGKILL`ed and report the timeout sentinel; the run completes promptly, proving the injected grace was used.
- `TestSupervisorSpawnFailureWrites127`: a non-exec'able agy makes `Run` write the spawn-failure sentinel and return the error.
- These drive `Run` (Linux-only), so they live in `supervisor_linux_test.go`; the pure `resolveExitCode`/`effectiveTimeout` tests stay ungated.
- Also assert the captured stderr is read back in `TestSupervisorCapturesOutputAndSentinel` (it was configured but never checked).

## Test plan

- [x] `go test -race -count=3` on the new tests (no race, no flake); full `go test -race ./...` green
- [x] `go vet` clean; `golangci-lint` 0 issues; `gofmt` clean; `GOOS=darwin` builds

Refs #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for signal-escalation and spawn-failure scenarios.
  * Enhanced validation of stderr capture in existing tests.

* **Refactor**
  * Made supervisor timeout behavior injectable for faster, more reliable test timing while preserving production behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->