### PR TITLE
test(mcptools): cover list_models and list_sessions handlers (#33)

### DIFF
--- a/internal/mcptools/tools_linux_test.go
+++ b/internal/mcptools/tools_linux_test.go
@@ -14,6 +14,43 @@ import (
 // validation, HTTP serving) live in tools_test.go / serve_http_test.go so
 // `go test ./...` stays green on macOS and Windows.
 
+// TestListModelsOverMCP exercises the list_models tool end to end: the handler
+// runs `agy models` (the fake agy prints two lines) and returns them on the
+// wire. This handler had no MCP-layer test.
+func TestListModelsOverMCP(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "Model A\nModel B"})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: "list_models"})
+	if err != nil || res.IsError {
+		t.Fatalf("list_models: err=%v res=%+v", err, res)
+	}
+	models, _ := structMap(t, res.StructuredContent)["models"].([]any)
+	if len(models) != 2 || models[0] != "Model A" || models[1] != "Model B" {
+		t.Fatalf("models = %v, want [Model A, Model B]", models)
+	}
+}
+
+// TestListSessionsOverMCP exercises the list_sessions tool: with an empty cache
+// the handler must return a non-nil empty array on the wire (not null), and the
+// tool must be registered and wired. This handler had no MCP-layer test.
+func TestListSessionsOverMCP(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "x"})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: "list_sessions"})
+	if err != nil || res.IsError {
+		t.Fatalf("list_sessions: err=%v res=%+v", err, res)
+	}
+	sessions, ok := structMap(t, res.StructuredContent)["sessions"].([]any)
+	if !ok {
+		t.Fatalf("sessions field is not an array: %v", res.StructuredContent)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("sessions = %v, want empty for an empty cache", sessions)
+	}
+}
+
 func TestAgyRunAndStatusOverMCP(t *testing.T) {
 	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
 	cs := connect(t, mgr, nil)


### PR DESCRIPTION
## Summary

The `list_models` and `list_sessions` MCP tool handlers had no test at the MCP layer (#33 item 8). Test-only.

- **TestListModelsOverMCP** — drives `list_models` end to end: the fake agy prints two model lines and the handler returns them on the wire.
- **TestListSessionsOverMCP** — with an empty cache the handler must return a non-nil empty array (not `null`), confirming the tool is registered and wired.

Gated to `_linux` because the shared `connect`/`newTestManager` helpers live in the StartJob-only test file.

## Test plan

- [x] `go test -race ./...` green; `go vet`/`golangci-lint` clean; `gofmt` clean

Refs #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests to verify MCP tool functionality for model listing and session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->