### PR TITLE
chore: misc low-risk cleanups from review (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An MCP (Model Context Protocol) server that wraps the [Antigravity CLI](https://antigravity.google) (`agy`), so any MCP client (Claude Code, Cursor, Cline, and others) can run `agy` prompts, peer reviews, and follow-up turns as native tools.
 
-> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, cross-platform builds) and verified against a live agy (1.0.7). Latest release: v1.0.0.
+> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, cross-platform builds) and verified against a live agy (1.0.7).
 
 ## Why
 

--- a/internal/manager/cancel.go
+++ b/internal/manager/cancel.go
@@ -15,7 +15,7 @@ import (
 func (m *Manager) Cancel(id string) error {
 	meta, err := m.store.Load(id)
 	if err != nil {
-		return err
+		return fmt.Errorf("load job %s to cancel: %w", id, err)
 	}
 	// Confirm the recorded PID is still our supervisor (boot id plus /proc comm)
 	// before signaling, so a recycled PID is never sent SIGTERM. proc.Signal treats

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -1,6 +1,9 @@
 package manager
 
-import "sync"
+import (
+	"log"
+	"sync"
+)
 
 // gate enforces a global concurrency cap and per-key (conversation/cwd)
 // serialization so concurrent agy sessions cannot trigger the known
@@ -80,6 +83,12 @@ func (g *gate) release(key string) {
 	defer g.mu.Unlock()
 	if g.inFlight > 0 {
 		g.inFlight--
+	} else {
+		// A release without a matching acquire means a gate-lifecycle bug (a double
+		// release, or a release on a key that was never acquired). The clamp keeps
+		// inFlight from going negative and silently raising the cap; log it so the
+		// regression surfaces instead of hiding.
+		log.Printf("agy-mcp: gate release underflow for key %q (released more than acquired)", key)
 	}
 	if key != "" {
 		delete(g.keys, key)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -45,7 +45,7 @@ type Manager struct {
 	// liveness watcher. Fields (not package globals) so tests stay isolated and can
 	// run in parallel. agy's conversation cache is flushed by a separate daemon that
 	// can lag the foreground agy exit, so the capture retries briefly. Verified
-	// against agy 1.0.6: agy rewrites last_conversations.json in place (O_TRUNC, no
+	// against agy 1.0.7: agy rewrites last_conversations.json in place (O_TRUNC, no
 	// file lock), so a concurrent read can be torn; loadCache reports torn reads
 	// as errors, capture treats them as "no capture yet" and this retry loop
 	// re-reads, and StartJob disables capture when the pre-run snapshot itself is
@@ -255,7 +255,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 	id, err := newID()
 	if err != nil {
-		return Job{}, err
+		return Job{}, fmt.Errorf("generate job id: %w", err)
 	}
 	cwd := req.Cwd
 	if cwd == "" {
@@ -352,7 +352,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	if err != nil {
 		m.pendingCaptures.Delete(id)
 		m.gate.release(key)
-		return Job{}, err
+		return Job{}, fmt.Errorf("create job store entry: %w", err)
 	}
 
 	cmd := exec.Command(m.cfg.SupervisorExe, "run-job", dir)

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"errors"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -90,7 +91,12 @@ func ServeHTTP(ctx context.Context, mgr *manager.Manager, addr, token string) er
 		<-ctx.Done()
 		shutCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
 		defer c()
-		_ = srv.Shutdown(shutCtx)
+		// HTTP mode, so logging to stderr is safe (no stdio JSON-RPC stream). A
+		// shutdown error (e.g. in-flight responses outlasting the 5s drain) is worth
+		// surfacing rather than silently dropping.
+		if err := srv.Shutdown(shutCtx); err != nil {
+			log.Printf("agy-mcp: http shutdown: %v", err)
+		}
 	}()
 	err := srv.ListenAndServe()
 	cancel() // unblock the shutdown goroutine when ListenAndServe returns first

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -104,12 +105,14 @@ type sessionsOutput struct {
 // serverVersion reports the module version the Go toolchain stamped into the
 // binary (e.g. v1.0.0 for a tagged `go install`, a pseudo-version for builds
 // past a tag), or "dev" when no version was stamped (plain `go test` binaries).
-func serverVersion() string {
+// It is memoized with sync.OnceValue: the build info is fixed for a process's
+// life, but NewServer (and thus this) is called once per HTTP session.
+var serverVersion = sync.OnceValue(func() string {
 	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
 		return bi.Main.Version
 	}
 	return "dev"
-}
+})
 
 // NewServer builds an MCP server with all agy tools registered.
 func NewServer(mgr *manager.Manager) *mcp.Server {

--- a/internal/proc/proc_linux.go
+++ b/internal/proc/proc_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package proc
 
 import (


### PR DESCRIPTION
## Summary

A batch of the low-risk cleanups from #36. The bigger logic items (combining the two startup job-store scans, the double continue_latest cache parse, the readSessions/loadCache dedup, the capture-persist helper extraction, the unified log prefix) are left as a follow-up.

## Changes

- **Memoize `serverVersion`** with `sync.OnceValue`: it re-read `debug.BuildInfo` on every HTTP session (`NewServer` runs per session).
- **Log the `srv.Shutdown` error** in `ServeHTTP` instead of discarding it (HTTP mode, so stderr logging is safe).
- **Log `gate.release` underflow**: a release without a matching acquire is a gate-lifecycle bug; the clamp keeps `inFlight` non-negative, and the log surfaces the regression instead of hiding it.
- **Wrap three bare `return err` sites** with context (`newID`, `store.Create`, `Cancel`'s `Load`), matching their sibling paths.
- **Refresh the cache-concurrency comment** from agy 1.0.6 to 1.0.7 (the version the README re-verified against); that comment carries load-bearing assumptions, so keeping its version current matters.
- **Drop the hardcoded `Latest release: v1.0.0`** from the README so it cannot go stale.
- **Remove the redundant `//go:build linux`** from `proc_linux.go` (the `_linux` filename suffix already gates it), matching `liveness_linux.go` and `signal_linux.go`.

## Test plan

- [x] builds on linux/darwin/windows; `proc_linux.go` still correctly excluded off Linux
- [x] `go test -race ./...` green; `go vet`/`golangci-lint` clean; `gofmt` clean

Refs #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status to indicate feature completion and verification against agy v1.0.7

* **Bug Fixes**
  * Enhanced error reporting with contextual information for job operations and server shutdown failures

* **Improvements**
  * Added diagnostic logging for concurrency edge cases
  * Optimized internal version caching

* **Chores**
  * Removed build constraint directive

<!-- end of auto-generated comment: release notes by coderabbit.ai -->