### PR TITLE
test: inject cache file in StartJob tests, cover conversation-id wiring (#34, #33)

### DIFF
--- a/internal/manager/job_linux_test.go
+++ b/internal/manager/job_linux_test.go
@@ -21,6 +21,9 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 		MaxConcurrency: 4,
 	}
 	m := New(c)
+	// Inject a test-owned cache file so the fresh run's id capture does not read
+	// the developer's real agy cache or leak a capture goroutine racing cleanup.
+	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
 
 	job, err := m.StartJob(StartRequest{Prompt: "review main.go", Model: "Gemini 3.1 Pro (High)"})
 	if err != nil {
@@ -58,6 +61,40 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 	}
 }
 
+// TestStartJobWiresConversationID covers the continue-a-conversation path that
+// no other StartJob test drives: an explicit conversation id must be threaded
+// into the returned job, the persisted meta, and the agy --conversation arg.
+func TestStartJobWiresConversationID(t *testing.T) {
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		StateDir:       t.TempDir(),
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+
+	const convID = "11111111-2222-3333-4444-555555555555"
+	job, err := m.StartJob(StartRequest{Prompt: "follow up", ConversationID: convID, Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	if job.ConversationID != convID {
+		t.Errorf("returned conversation id = %q, want %q", job.ConversationID, convID)
+	}
+	meta, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.ConversationID != convID {
+		t.Errorf("meta conversation id = %q, want %q", meta.ConversationID, convID)
+	}
+	if !hasArg(meta.Args, "--conversation", convID) {
+		t.Errorf("args missing --conversation %s: %v", convID, meta.Args)
+	}
+}
+
 func TestStartJobCleansUpDirOnSpawnFailure(t *testing.T) {
 	c := config.Config{
 		AgyPath:        "/usr/bin/agy",
@@ -67,6 +104,7 @@ func TestStartJobCleansUpDirOnSpawnFailure(t *testing.T) {
 		MaxConcurrency: 4,
 	}
 	m := New(c)
+	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
 	cwd := t.TempDir()
 
 	_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})


### PR DESCRIPTION
## Summary

Two small test-correctness/coverage fixes. Test-only.

- **#34** — `TestStartJobPersistsMetaAndSpawns` and `TestStartJobCleansUpDirOnSpawnFailure` did not override `m.cacheFile`, so they read the developer's real agy cache; the former also leaked a 2s capture goroutine racing `t.TempDir` cleanup. They now inject a test-owned cache file, matching the other StartJob tests.
- **#33** (item 3) — `TestStartJobWiresConversationID`: no StartJob test drove the continue-a-conversation path. It asserts an explicit conversation id is threaded into the returned job, the persisted meta, and the agy `--conversation` arg.

## Test plan

- [x] `go test -race ./...` green; `go vet`/`golangci-lint` clean; `gofmt` clean

Refs #34, #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation by using injected cache files to prevent interference with developer environments.
  * Added validation to ensure conversation IDs are correctly propagated through job creation, metadata storage, and system invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->