### PR TITLE
refactor(manager): fuse startup GC and gate restore into one scan (#36)

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -417,6 +417,79 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	return Job{ID: id, ConversationID: req.ConversationID, State: StateRunning}, nil
 }
 
+// loadedJob is one job's meta from a single meta.json read, the shared input the
+// GC and gate-restore decisions both need. Loading it once lets the fused startup
+// pass (RestoreAndCollect) make both decisions without re-reading every job dir.
+type loadedJob struct {
+	id      string
+	meta    jobstore.Meta
+	metaErr error // non-nil if meta.json could not be loaded (missing, corrupt, or transient)
+}
+
+// loadJob reads one job's meta with a single store.Load.
+func (m *Manager) loadJob(id string) loadedJob {
+	meta, err := m.store.Load(id)
+	return loadedJob{id: id, meta: meta, metaErr: err}
+}
+
+// terminalChecker returns a memoized predicate reporting whether job id has an
+// exit_code sentinel, reading it from the store at most once. Both the GC and the
+// restore decisions need this fact; memoizing lets the fused startup pass share a
+// single read while each standalone caller (GarbageCollect, RestoreGate) still
+// reads the sentinel at most once. The closure is used within a single loop
+// iteration, so it needs no synchronization. The GC re-read race deliberately
+// bypasses this memo with a fresh store.ExitCode call (see gcEvaluate).
+func (m *Manager) terminalChecker(id string) func() bool {
+	var (
+		read     bool
+		terminal bool
+	)
+	return func() bool {
+		if !read {
+			_, terminal = m.store.ExitCode(id)
+			read = true
+		}
+		return terminal
+	}
+}
+
+// RestoreAndCollect runs startup garbage collection and concurrency-gate
+// restoration in a single job-store scan, halving the meta.json + exit_code reads
+// versus calling GarbageCollect and RestoreGate back to back. Each job's
+// keep/remove and restore decisions are independent and mutually exclusive (GC
+// only removes terminal or dead jobs; restore only re-occupies the gate for live
+// ones), so one pass produces the same result as the two sequential scans it
+// replaces.
+//
+// It fails closed like RestoreGate: if the jobs cannot be scanned the gate cannot
+// be made safe, so it returns an error and startup should refuse rather than serve
+// with an unrestored gate (a stricter contract than GarbageCollect alone, whose
+// scan failure was previously only logged). The returned ids are the jobs GC
+// removed (empty when JobTTL disables collection). Intended to run once at startup.
+func (m *Manager) RestoreAndCollect() (removed []string, err error) {
+	ids, err := m.store.List()
+	if err != nil {
+		return nil, fmt.Errorf("scan jobs for startup recovery: %w", err)
+	}
+	// Mirror GarbageCollect's JobTTL<=0 short-circuit: collection is disabled, but
+	// the gate still must be restored, so the scan continues with GC skipped.
+	gcEnabled := m.cfg.JobTTL > 0
+	var cutoff time.Time
+	if gcEnabled {
+		cutoff = time.Now().Add(-m.cfg.JobTTL)
+	}
+	for _, id := range ids {
+		l := m.loadJob(id)
+		terminal := m.terminalChecker(id)
+		if gcEnabled && m.gcEvaluate(l, cutoff, terminal) {
+			removed = append(removed, id)
+			continue // removed; nothing to restore (a removed job was terminal or dead)
+		}
+		m.restoreEvaluate(l, terminal)
+	}
+	return removed, nil
+}
+
 // GarbageCollect removes jobs older than the configured TTL. A job whose
 // supervisor is still alive (including one that survived a manager restart) is
 // never removed, even past the TTL, so a live job is never deleted out from
@@ -432,72 +505,82 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 	cutoff := time.Now().Add(-m.cfg.JobTTL)
 	var removed []string
 	for _, id := range ids {
-		meta, err := m.store.Load(id)
-		if err != nil {
-			if errors.Is(err, fs.ErrNotExist) {
-				// meta.json is genuinely missing: an orphan from a crash between
-				// Create's MkdirAll and its meta write, or a partial RemoveAll. It can
-				// never be a live, attributable job (there is no PID or boot id to
-				// check), so the old behavior of skipping it silently and forever let
-				// orphans accumulate without bound. Reap it once it is older than the
-				// TTL, judged by the dir mtime since there is no StartedAt; a fresh one
-				// may be a job still mid-Create, so it is kept.
-				if m.orphanExpired(id, cutoff) {
-					if rerr := m.store.Remove(id); rerr != nil {
-						log.Printf("agy-mcp: GC: remove orphan job dir %s: %v", id, rerr)
-					} else {
-						removed = append(removed, id)
-						m.untrackCapture(id)
-					}
-				} else {
-					log.Printf("agy-mcp: GC: orphan job dir %s (no meta.json) kept until older than the TTL", id)
-				}
-				continue
-			}
-			// meta.json exists but could not be read or parsed: a transient error
-			// (e.g. EMFILE/EIO) or a corrupt write. This is NOT an orphan and must not
-			// be reaped by dir mtime: a valid long-running job's dir mtime is old
-			// (writing to out/err does not bump the directory mtime), so reaping here
-			// could delete a live job. Log and keep; a later sweep retries the Load.
-			log.Printf("agy-mcp: GC: job %s meta unreadable (not reaping, may be transient): %v", id, err)
-			continue
+		if m.gcEvaluate(m.loadJob(id), cutoff, m.terminalChecker(id)) {
+			removed = append(removed, id)
 		}
-		if !meta.StartedAt.Before(cutoff) {
-			continue // too recent to collect
-		}
-		_, terminal := m.store.ExitCode(id)
-		if !terminal {
-			if m.processAlive(meta) {
-				continue // still running; keep it
-			}
-			// Not alive and not terminal at the first read. The supervisor may have
-			// written its sentinel and exited between the ExitCode and processAlive
-			// checks above (the same race Status guards against); re-read once. If it
-			// is now terminal the job just finished, so its result is freshly written
-			// and unread; keep it this sweep and collect it on the next one (where the
-			// first read sees the sentinel). This covers runs with no pending capture
-			// (e.g. a continued conversation), which the CapturePending guard below
-			// does not.
-			if _, terminal = m.store.ExitCode(id); terminal {
-				continue
-			}
-		} else if m.CapturePending(id) {
-			// Terminal, but the manager's post-cmd.Wait completion goroutine is still
-			// capturing the conversation id into this dir (the supervisor writes the
-			// sentinel before it exits, so an in-flight capture always sees the
-			// sentinel already present at the first read). Removing the dir now would
-			// make SetConversationID fail with ENOENT and lose the captured id, so
-			// keep the job until the capture settles; the next sweep collects it.
-			continue
-		}
-		if err := m.store.Remove(id); err != nil {
-			log.Printf("agy-mcp: GC: remove expired job %s: %v", id, err)
-			continue
-		}
-		removed = append(removed, id)
-		m.untrackCapture(id)
 	}
 	return removed, nil
+}
+
+// gcEvaluate applies the keep-or-remove decision to one already-loaded job,
+// removing its dir when collectable and reporting whether it did. cutoff is
+// now-TTL; terminal is the memoized exit_code predicate from terminalChecker.
+// Callers must already have established JobTTL>0. It is the body of
+// GarbageCollect's loop, factored out so the fused startup pass can reuse it
+// without re-reading the job dir.
+func (m *Manager) gcEvaluate(l loadedJob, cutoff time.Time, terminal func() bool) bool {
+	if l.metaErr != nil {
+		if errors.Is(l.metaErr, fs.ErrNotExist) {
+			// meta.json is genuinely missing: an orphan from a crash between
+			// Create's MkdirAll and its meta write, or a partial RemoveAll. It can
+			// never be a live, attributable job (there is no PID or boot id to
+			// check), so the old behavior of skipping it silently and forever let
+			// orphans accumulate without bound. Reap it once it is older than the
+			// TTL, judged by the dir mtime since there is no StartedAt; a fresh one
+			// may be a job still mid-Create, so it is kept.
+			if m.orphanExpired(l.id, cutoff) {
+				if rerr := m.store.Remove(l.id); rerr != nil {
+					log.Printf("agy-mcp: GC: remove orphan job dir %s: %v", l.id, rerr)
+					return false
+				}
+				m.untrackCapture(l.id)
+				return true
+			}
+			log.Printf("agy-mcp: GC: orphan job dir %s (no meta.json) kept until older than the TTL", l.id)
+			return false
+		}
+		// meta.json exists but could not be read or parsed: a transient error
+		// (e.g. EMFILE/EIO) or a corrupt write. This is NOT an orphan and must not
+		// be reaped by dir mtime: a valid long-running job's dir mtime is old
+		// (writing to out/err does not bump the directory mtime), so reaping here
+		// could delete a live job. Log and keep; a later sweep retries the Load.
+		log.Printf("agy-mcp: GC: job %s meta unreadable (not reaping, may be transient): %v", l.id, l.metaErr)
+		return false
+	}
+	if !l.meta.StartedAt.Before(cutoff) {
+		return false // too recent to collect (and so the exit_code sentinel is never read)
+	}
+	if !terminal() {
+		if m.processAlive(l.meta) {
+			return false // still running; keep it
+		}
+		// Not alive and not terminal at the first read. The supervisor may have
+		// written its sentinel and exited between the ExitCode and processAlive
+		// checks above (the same race Status guards against); re-read once with a
+		// fresh store call (not the memo, which would return the stale first read).
+		// If it is now terminal the job just finished, so its result is freshly
+		// written and unread; keep it this sweep and collect it on the next one
+		// (where the first read sees the sentinel). This covers runs with no
+		// pending capture (e.g. a continued conversation), which the CapturePending
+		// guard below does not.
+		if _, t := m.store.ExitCode(l.id); t {
+			return false
+		}
+	} else if m.CapturePending(l.id) {
+		// Terminal, but the manager's post-cmd.Wait completion goroutine is still
+		// capturing the conversation id into this dir (the supervisor writes the
+		// sentinel before it exits, so an in-flight capture always sees the
+		// sentinel already present at the first read). Removing the dir now would
+		// make SetConversationID fail with ENOENT and lose the captured id, so
+		// keep the job until the capture settles; the next sweep collects it.
+		return false
+	}
+	if err := m.store.Remove(l.id); err != nil {
+		log.Printf("agy-mcp: GC: remove expired job %s: %v", l.id, err)
+		return false
+	}
+	m.untrackCapture(l.id)
+	return true
 }
 
 // orphanExpired reports whether the job dir for id, whose meta.json is missing,
@@ -594,7 +677,9 @@ func reqFromMeta(meta jobstore.Meta) StartRequest {
 // survived a manager restart, so a new agy_run is serialized against them and the
 // global cap accounts for them. Without this, a restored job is invisible to the
 // gate and the cap could be bypassed, re-exposing the session-lock hang the gate
-// prevents. Intended to run once at startup, after GarbageCollect.
+// prevents. The startup path uses RestoreAndCollect, which fuses this with
+// GarbageCollect into one scan; this method remains for restore-only use and is
+// exercised directly by tests.
 //
 // It fails closed: if the on-disk jobs cannot be scanned the gate cannot be made
 // safe, so it returns an error and the caller should refuse to start rather than
@@ -605,38 +690,45 @@ func (m *Manager) RestoreGate() error {
 		return fmt.Errorf("scan jobs to restore concurrency gate: %w", err)
 	}
 	for _, id := range ids {
-		meta, err := m.store.Load(id)
-		if err != nil {
-			// A job whose meta cannot be read cannot have its gate key recomputed or
-			// its liveness checked, so its slot cannot be restored. Log it rather than
-			// skipping silently: if such a job's supervisor is somehow still alive its
-			// gate is not held, the one gap in this method's fail-closed contract.
-			// GarbageCollect reaps the dir once it is older than the TTL.
-			log.Printf("agy-mcp: restore gate: skipping job %s with unreadable meta: %v", id, err)
-			continue
-		}
-		if _, terminal := m.store.ExitCode(id); terminal {
-			continue // already finished; nothing to hold
-		}
-		if !m.processAlive(meta) {
-			continue // supervisor gone; GarbageCollect will reap it
-		}
-		// forceAcquire counts the job and holds its key unconditionally: a restored
-		// job is already running, so it must be tracked even past the cap (otherwise a
-		// new same-key run could start once a slot frees and run concurrently with it,
-		// the bypass this method prevents). A false return means another restored job
-		// already holds this key, so it is already watched.
-		key := keyFor(reqFromMeta(meta))
-		if m.gate.forceAcquire(key) {
-			if meta.ConversationID == "" && !meta.CaptureDisabled {
-				// Mirror StartJob: arm the capture so pollers can tell this
-				// restored fresh run's id is still being settled.
-				m.pendingCaptures.Store(meta.ID, struct{}{})
-			}
-			m.watchRestored(meta, key)
-		}
+		m.restoreEvaluate(m.loadJob(id), m.terminalChecker(id))
 	}
 	return nil
+}
+
+// restoreEvaluate re-occupies the gate for one already-loaded job whose detached
+// supervisor outlived a manager restart. terminal is the memoized exit_code
+// predicate from terminalChecker. It is the body of RestoreGate's loop, factored
+// out so the fused startup pass can reuse it without re-reading the job dir.
+func (m *Manager) restoreEvaluate(l loadedJob, terminal func() bool) {
+	if l.metaErr != nil {
+		// A job whose meta cannot be read cannot have its gate key recomputed or
+		// its liveness checked, so its slot cannot be restored. Log it rather than
+		// skipping silently: if such a job's supervisor is somehow still alive its
+		// gate is not held, the one gap in this method's fail-closed contract.
+		// GarbageCollect reaps the dir once it is older than the TTL.
+		log.Printf("agy-mcp: restore gate: skipping job %s with unreadable meta: %v", l.id, l.metaErr)
+		return
+	}
+	if terminal() {
+		return // already finished; nothing to hold
+	}
+	if !m.processAlive(l.meta) {
+		return // supervisor gone; GarbageCollect will reap it
+	}
+	// forceAcquire counts the job and holds its key unconditionally: a restored
+	// job is already running, so it must be tracked even past the cap (otherwise a
+	// new same-key run could start once a slot frees and run concurrently with it,
+	// the bypass this method prevents). A false return means another restored job
+	// already holds this key, so it is already watched.
+	key := keyFor(reqFromMeta(l.meta))
+	if m.gate.forceAcquire(key) {
+		if l.meta.ConversationID == "" && !l.meta.CaptureDisabled {
+			// Mirror StartJob: arm the capture so pollers can tell this
+			// restored fresh run's id is still being settled.
+			m.pendingCaptures.Store(l.meta.ID, struct{}{})
+		}
+		m.watchRestored(l.meta, key)
+	}
 }
 
 // watchRestored releases a restored job's gate key once its detached supervisor

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -432,33 +432,15 @@ func (m *Manager) loadJob(id string) loadedJob {
 	return loadedJob{id: id, meta: meta, metaErr: err}
 }
 
-// terminalChecker returns a memoized predicate reporting whether job id has an
-// exit_code sentinel, reading it from the store at most once. Both the GC and the
-// restore decisions need this fact; memoizing lets the fused startup pass share a
-// single read while each standalone caller (GarbageCollect, RestoreGate) still
-// reads the sentinel at most once. The closure is used within a single loop
-// iteration, so it needs no synchronization. The GC re-read race deliberately
-// bypasses this memo with a fresh store.ExitCode call (see gcEvaluate).
-func (m *Manager) terminalChecker(id string) func() bool {
-	var (
-		read     bool
-		terminal bool
-	)
-	return func() bool {
-		if !read {
-			_, terminal = m.store.ExitCode(id)
-			read = true
-		}
-		return terminal
-	}
-}
-
 // RestoreAndCollect runs startup garbage collection and concurrency-gate
-// restoration in a single job-store scan, halving the meta.json + exit_code reads
-// versus calling GarbageCollect and RestoreGate back to back. Each job's
-// keep/remove and restore decisions are independent and mutually exclusive (GC
-// only removes terminal or dead jobs; restore only re-occupies the gate for live
-// ones), so one pass produces the same result as the two sequential scans it
+// restoration in a single job-store scan, halving the meta.json reads versus
+// calling GarbageCollect and RestoreGate back to back (each previously loaded
+// every job's meta). The single loadJob result is shared by both decisions; each
+// still reads the exit_code sentinel itself, fresh, exactly as the two methods
+// did standalone, so the sentinel's read count and freshness are unchanged. Each
+// job's keep/remove and restore decisions are independent and mutually exclusive
+// (GC only removes terminal or dead jobs; restore only re-occupies the gate for
+// live ones), so one pass produces the same result as the two sequential scans it
 // replaces.
 //
 // It fails closed like RestoreGate: if the jobs cannot be scanned the gate cannot
@@ -480,12 +462,11 @@ func (m *Manager) RestoreAndCollect() (removed []string, err error) {
 	}
 	for _, id := range ids {
 		l := m.loadJob(id)
-		terminal := m.terminalChecker(id)
-		if gcEnabled && m.gcEvaluate(l, cutoff, terminal) {
+		if gcEnabled && m.gcEvaluate(l, cutoff) {
 			removed = append(removed, id)
 			continue // removed; nothing to restore (a removed job was terminal or dead)
 		}
-		m.restoreEvaluate(l, terminal)
+		m.restoreEvaluate(l)
 	}
 	return removed, nil
 }
@@ -505,7 +486,7 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 	cutoff := time.Now().Add(-m.cfg.JobTTL)
 	var removed []string
 	for _, id := range ids {
-		if m.gcEvaluate(m.loadJob(id), cutoff, m.terminalChecker(id)) {
+		if m.gcEvaluate(m.loadJob(id), cutoff) {
 			removed = append(removed, id)
 		}
 	}
@@ -514,11 +495,10 @@ func (m *Manager) GarbageCollect() ([]string, error) {
 
 // gcEvaluate applies the keep-or-remove decision to one already-loaded job,
 // removing its dir when collectable and reporting whether it did. cutoff is
-// now-TTL; terminal is the memoized exit_code predicate from terminalChecker.
-// Callers must already have established JobTTL>0. It is the body of
-// GarbageCollect's loop, factored out so the fused startup pass can reuse it
-// without re-reading the job dir.
-func (m *Manager) gcEvaluate(l loadedJob, cutoff time.Time, terminal func() bool) bool {
+// now-TTL. Callers must already have established JobTTL>0. It is the body of
+// GarbageCollect's loop, factored out so the fused startup pass can reuse the one
+// loadJob result without re-reading meta.json.
+func (m *Manager) gcEvaluate(l loadedJob, cutoff time.Time) bool {
 	if l.metaErr != nil {
 		if errors.Is(l.metaErr, fs.ErrNotExist) {
 			// meta.json is genuinely missing: an orphan from a crash between
@@ -550,19 +530,19 @@ func (m *Manager) gcEvaluate(l loadedJob, cutoff time.Time, terminal func() bool
 	if !l.meta.StartedAt.Before(cutoff) {
 		return false // too recent to collect (and so the exit_code sentinel is never read)
 	}
-	if !terminal() {
+	_, terminal := m.store.ExitCode(l.id)
+	if !terminal {
 		if m.processAlive(l.meta) {
 			return false // still running; keep it
 		}
 		// Not alive and not terminal at the first read. The supervisor may have
 		// written its sentinel and exited between the ExitCode and processAlive
-		// checks above (the same race Status guards against); re-read once with a
-		// fresh store call (not the memo, which would return the stale first read).
-		// If it is now terminal the job just finished, so its result is freshly
-		// written and unread; keep it this sweep and collect it on the next one
-		// (where the first read sees the sentinel). This covers runs with no
-		// pending capture (e.g. a continued conversation), which the CapturePending
-		// guard below does not.
+		// checks above (the same race Status guards against); re-read once. If it
+		// is now terminal the job just finished, so its result is freshly written
+		// and unread; keep it this sweep and collect it on the next one (where the
+		// first read sees the sentinel). This covers runs with no pending capture
+		// (e.g. a continued conversation), which the CapturePending guard below
+		// does not.
 		if _, t := m.store.ExitCode(l.id); t {
 			return false
 		}
@@ -690,16 +670,17 @@ func (m *Manager) RestoreGate() error {
 		return fmt.Errorf("scan jobs to restore concurrency gate: %w", err)
 	}
 	for _, id := range ids {
-		m.restoreEvaluate(m.loadJob(id), m.terminalChecker(id))
+		m.restoreEvaluate(m.loadJob(id))
 	}
 	return nil
 }
 
 // restoreEvaluate re-occupies the gate for one already-loaded job whose detached
-// supervisor outlived a manager restart. terminal is the memoized exit_code
-// predicate from terminalChecker. It is the body of RestoreGate's loop, factored
-// out so the fused startup pass can reuse it without re-reading the job dir.
-func (m *Manager) restoreEvaluate(l loadedJob, terminal func() bool) {
+// supervisor outlived a manager restart. It is the body of RestoreGate's loop,
+// factored out so the fused startup pass can reuse the one loadJob result without
+// re-reading meta.json. It reads the exit_code sentinel itself, fresh, so a job
+// that finished since the meta was loaded is not restored into the gate.
+func (m *Manager) restoreEvaluate(l loadedJob) {
 	if l.metaErr != nil {
 		// A job whose meta cannot be read cannot have its gate key recomputed or
 		// its liveness checked, so its slot cannot be restored. Log it rather than
@@ -709,7 +690,7 @@ func (m *Manager) restoreEvaluate(l loadedJob, terminal func() bool) {
 		log.Printf("agy-mcp: restore gate: skipping job %s with unreadable meta: %v", l.id, l.metaErr)
 		return
 	}
-	if terminal() {
+	if _, terminal := m.store.ExitCode(l.id); terminal {
 		return // already finished; nothing to hold
 	}
 	if !m.processAlive(l.meta) {

--- a/internal/manager/restore_linux_test.go
+++ b/internal/manager/restore_linux_test.go
@@ -214,6 +214,62 @@ func TestRestoreGateSkipsTerminalJobs(t *testing.T) {
 	}
 }
 
+// RestoreAndCollect must do both halves in a single startup pass: garbage-collect
+// an expired, finished job while re-occupying the gate for a live job whose
+// supervisor outlived the restart. The live job is itself past the TTL, so this
+// also confirms the fused pass keeps (never collects) a still-alive job, and that
+// removing one job does not disturb restoring another.
+func TestRestoreAndCollectCollectsExpiredAndRestoresLive(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  exePath,
+		StateDir:       t.TempDir(),
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+		JobTTL:         time.Hour,
+	})
+	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+
+	// An expired, finished job: past the TTL with an exit sentinel, so GC removes it.
+	if _, err := m.store.Create(jobstore.Meta{ID: "old-done", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("old-done", 0); err != nil {
+		t.Fatal(err)
+	}
+	// A live job whose supervisor survived the restart, itself past the TTL: GC must
+	// keep it (alive), and the gate must re-occupy its key.
+	liveCwd := t.TempDir()
+	if _, err := m.store.Create(jobstore.Meta{
+		ID:        "live-1",
+		Cwd:       liveCwd,
+		PID:       pid,
+		BootID:    readBootID(),
+		StartedAt: time.Now().Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := m.RestoreAndCollect()
+	if err != nil {
+		t.Fatalf("RestoreAndCollect: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "old-done" {
+		t.Fatalf("removed = %v, want [old-done]", removed)
+	}
+	if _, err := m.store.Load("old-done"); err == nil {
+		t.Fatal("the expired finished job should have been removed")
+	}
+	if _, err := m.store.Load("live-1"); err != nil {
+		t.Fatalf("the expired-but-alive job must be kept: %v", err)
+	}
+	// The live job's gate key is held, so a same-cwd run is blocked.
+	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: liveCwd}); err == nil {
+		t.Fatal("the restored live job must block a same-cwd run")
+	}
+}
+
 // A restored fresh run must have its conversation id captured by the watcher
 // when its supervisor finishes, exactly like the StartJob completion path, and
 // the id must land on disk without any Status call (the watcher, not a poller,

--- a/internal/manager/restore_test.go
+++ b/internal/manager/restore_test.go
@@ -1,0 +1,115 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// countingStore records how many times Load and ExitCode are called per job id,
+// so a test can prove the fused startup pass reads each job dir once rather than
+// the two reads the back-to-back GarbageCollect+RestoreGate scans would do.
+type countingStore struct {
+	jobStore
+	loads     map[string]int
+	exitReads map[string]int
+}
+
+func newCountingStore(inner jobStore) *countingStore {
+	return &countingStore{jobStore: inner, loads: map[string]int{}, exitReads: map[string]int{}}
+}
+
+func (c *countingStore) Load(id string) (jobstore.Meta, error) {
+	c.loads[id]++
+	return c.jobStore.Load(id)
+}
+
+func (c *countingStore) ExitCode(id string) (int, bool) {
+	c.exitReads[id]++
+	return c.jobStore.ExitCode(id)
+}
+
+// RestoreAndCollect must read each job's meta.json once and its exit_code at most
+// once, the IO win it exists for: the two scans it replaces read meta.json twice
+// (once per scan) and, for an old terminal job, exit_code twice as well. Terminal
+// jobs keep this test pure (no processAlive / proc dependency), so it runs on every
+// platform.
+func TestRestoreAndCollectScansEachJobOnce(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	// An expired terminal job (GC removes it) and a recent terminal job (kept).
+	if _, err := m.store.Create(jobstore.Meta{ID: "old-done", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("old-done", 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.store.Create(jobstore.Meta{ID: "recent-done", StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("recent-done", 0); err != nil {
+		t.Fatal(err)
+	}
+	// Wrap only after creation so the Create-time writes are not counted.
+	cs := newCountingStore(m.store)
+	m.store = cs
+
+	removed, err := m.RestoreAndCollect()
+	if err != nil {
+		t.Fatalf("RestoreAndCollect: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "old-done" {
+		t.Fatalf("removed = %v, want [old-done]", removed)
+	}
+	for _, id := range []string{"old-done", "recent-done"} {
+		if cs.loads[id] != 1 {
+			t.Errorf("job %s: meta loaded %d times, want exactly 1 (the fused scan must not re-read)", id, cs.loads[id])
+		}
+		if cs.exitReads[id] > 1 {
+			t.Errorf("job %s: exit_code read %d times, want at most 1", id, cs.exitReads[id])
+		}
+	}
+}
+
+// With JobTTL<=0, collection is disabled, so RestoreAndCollect must remove nothing
+// even for a long-expired job, while still completing its (restore) scan. A
+// terminal job needs no live supervisor, keeping this pure.
+func TestRestoreAndCollectSkipsRemovalWhenTTLDisabled(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4}) // JobTTL 0
+	if _, err := m.store.Create(jobstore.Meta{ID: "expired-job", StartedAt: time.Now().Add(-100 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("expired-job", 0); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := m.RestoreAndCollect()
+	if err != nil {
+		t.Fatalf("RestoreAndCollect: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("TTL 0 must disable removal, removed %v", removed)
+	}
+	if ids, _ := m.store.List(); len(ids) != 1 || ids[0] != "expired-job" {
+		t.Fatalf("the job must survive a TTL-disabled sweep, List = %v", ids)
+	}
+}
+
+// RestoreAndCollect must fail closed: if the on-disk jobs cannot be scanned the
+// gate cannot be made safe, so it returns an error and startup refuses rather than
+// serving with an unrestored gate (a stricter contract than GarbageCollect's, whose
+// scan failure was only logged).
+func TestRestoreAndCollectFailsClosedOnScanError(t *testing.T) {
+	state := t.TempDir()
+	// Make the jobs path a file so the directory scan errors (distinct from the
+	// benign "directory does not exist yet" case, which is not an error).
+	if err := os.WriteFile(filepath.Join(state, "jobs"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(config.Config{StateDir: state, MaxConcurrency: 4, JobTTL: time.Hour})
+	if _, err := m.RestoreAndCollect(); err == nil {
+		t.Fatal("RestoreAndCollect must return an error when the jobs dir cannot be scanned")
+	}
+}

--- a/internal/manager/restore_test.go
+++ b/internal/manager/restore_test.go
@@ -33,11 +33,13 @@ func (c *countingStore) ExitCode(id string) (int, bool) {
 	return c.jobStore.ExitCode(id)
 }
 
-// RestoreAndCollect must read each job's meta.json once and its exit_code at most
-// once, the IO win it exists for: the two scans it replaces read meta.json twice
-// (once per scan) and, for an old terminal job, exit_code twice as well. Terminal
-// jobs keep this test pure (no processAlive / proc dependency), so it runs on every
-// platform.
+// RestoreAndCollect must read each job's meta.json exactly once, the IO win it
+// exists for: the two scans it replaces loaded every job's meta twice (once per
+// scan). The single loadJob result is shared by the GC and restore decisions. Each
+// decision still reads the exit_code sentinel itself; for these two job categories
+// (an expired job GC removes, and a recent job restore inspects) that is one read
+// each, which this also asserts. Terminal jobs keep the test pure (no processAlive
+// / proc dependency), so it runs on every platform.
 func TestRestoreAndCollectScansEachJobOnce(t *testing.T) {
 	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
 	// An expired terminal job (GC removes it) and a recent terminal job (kept).

--- a/main.go
+++ b/main.go
@@ -66,17 +66,17 @@ func serve() error {
 		}
 	})
 	mgr := manager.New(cfg)
-	if removed, err := mgr.GarbageCollect(); err != nil {
-		log.Printf("startup GC: %v", err)
-	} else if len(removed) > 0 {
-		log.Printf("startup GC removed %d expired job(s)", len(removed))
+	// Run startup garbage collection and concurrency-gate restoration in one
+	// job-store scan (RestoreAndCollect), instead of two back-to-back scans that
+	// each opened every meta.json and exit_code. It fails closed: serving with an
+	// unrestored gate could bypass the cap and re-expose the agy session-lock hang
+	// the gate prevents, so a scan failure refuses to start rather than logging on.
+	removed, err := mgr.RestoreAndCollect()
+	if err != nil {
+		return fmt.Errorf("startup recovery: %w", err)
 	}
-	// Re-occupy the concurrency gate for jobs whose detached supervisor outlived a
-	// previous manager, so a new run is serialized against them and the cap holds.
-	// Fail closed: serving with an unrestored gate could bypass the cap and
-	// re-expose the agy session-lock hang the gate prevents.
-	if err := mgr.RestoreGate(); err != nil {
-		return fmt.Errorf("restore concurrency gate: %w", err)
+	if len(removed) > 0 {
+		log.Printf("startup GC removed %d expired job(s)", len(removed))
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
## Summary

The last of the bigger #36 logic items: startup ran two full job-store scans back to back (`GarbageCollect` then `RestoreGate`), each opening every job's `meta.json` and `exit_code` sentinel a second time. This fuses them into a single `RestoreAndCollect` pass that scans the jobs directory once and makes both the keep/remove and the gate-restore decision per job.

The two decisions are mutually exclusive per job (GC only removes terminal or dead jobs; restore only re-occupies the gate for live ones), so one pass produces the same outcome as the two sequential scans it replaces.

## Changes

- Extract the GC loop body into `gcEvaluate` and the restore loop body into `restoreEvaluate`. `GarbageCollect` (still used by periodic GC) and `RestoreGate` now call them, so those paths are behavior-identical and the existing tests cover the shared logic.
- Add `loadJob` (one meta read) and `terminalChecker` (a memoized `exit_code` read). The memo lets the fused pass read each `exit_code` once while both decisions share it. It preserves `GarbageCollect`'s property that recent jobs trigger no `exit_code` read at all, and `gcEvaluate`'s deliberate fresh re-read for the sentinel-written-between-checks race bypasses the memo so the race guard still works.
- `RestoreAndCollect` fails closed like `RestoreGate`: a scan failure now refuses startup, where previously GC's scan error was only logged. The gate cannot be safely restored without a scan, so failing closed is the safe default.
- `main.go`'s startup path calls `RestoreAndCollect` instead of the two methods.

## Test plan

- New `restore_test.go` (pure, runs on all platforms): a `countingStore` asserts the fused pass reads each job's meta once and `exit_code` at most once (the IO win it exists for), plus the TTL-disabled and fail-closed cases.
- New `TestRestoreAndCollectCollectsExpiredAndRestoresLive` (Linux): proves the fused pass collects an expired finished job while re-occupying the gate for a live (expired-but-alive) job in one call.
- Existing `gc_test.go` / `restore_linux_test.go` are the behavior-preservation oracle for `GarbageCollect` / `RestoreGate`, both unchanged and green.
- `go test -race ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues, fresh cache), `gofmt -l` clean, `go build -tags ruleguard ./rules/`, and darwin/windows cross-compiles all pass.

Refs #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Startup recovery now combines gate restoration and expired-job cleanup into one pass, reducing startup overhead and re-occupying concurrency gates for restored live jobs to prevent conflicting starts.
  * Removed expired jobs are reported at startup (count logged when non-empty).

* **Bug Fix**
  * Startup now fails immediately on critical job-store scan errors instead of continuing, ensuring recovery integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->