### PR TITLE
refactor(manager): dedup conversation-cache reads and capture-persist (#36)

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -3,7 +3,6 @@
 package manager
 
 import (
-	"cmp"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -59,11 +58,20 @@ type Manager struct {
 
 // New constructs a Manager.
 func New(c config.Config) *Manager {
+	// Prefer an explicitly configured cache path; only fall back to the default
+	// under HOME when none was given. Resolving the fallback here, rather than with
+	// cmp.Or (which evaluates both args), keeps agyCachePath's home-dir lookup and
+	// its failure log from running when an explicit ConversationCacheFile is set, so
+	// that explicit path is never shadowed by a misleading "disabled" log.
+	cacheFile := c.ConversationCacheFile
+	if cacheFile == "" {
+		cacheFile = agyCachePath()
+	}
 	return &Manager{
 		cfg:                  c,
 		store:                jobstore.New(c.StateDir),
 		gate:                 newGate(c.MaxConcurrency),
-		cacheFile:            cmp.Or(c.ConversationCacheFile, agyCachePath()),
+		cacheFile:            cacheFile,
 		captureBudget:        2 * time.Second,
 		capturePoll:          100 * time.Millisecond,
 		restoredPollInterval: 2 * time.Second,
@@ -104,12 +112,7 @@ func (m *Manager) captureFreshConversationID(meta *jobstore.Meta) {
 	deadline := time.Now().Add(m.captureBudget)
 	for {
 		if id, ok := captureNewUUID(m.cacheFile, meta.Cwd, meta.CwdUUIDBefore); ok {
-			final, err := m.store.SetConversationID(meta.ID, id)
-			if err != nil {
-				log.Printf("agy-mcp: persist captured conversation id for job %s: %v", meta.ID, err)
-				final = id
-			}
-			meta.ConversationID = final
+			meta.ConversationID = m.persistCapturedID(meta.ID, id)
 			return
 		}
 		if !time.Now().Before(deadline) {
@@ -152,10 +155,19 @@ func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
 		m.settleCapture(meta.ID)
 		return ""
 	}
-	final, err := m.store.SetConversationID(meta.ID, id)
+	return m.persistCapturedID(meta.ID, id)
+}
+
+// persistCapturedID stores a captured conversation id to the job's meta and
+// returns the effective id to report. On a persist failure it logs and falls
+// back to the captured id (best-effort: report what was captured even if it
+// could not be saved). Shared by the eager (captureFreshConversationID) and lazy
+// (lazyCaptureConversationID) capture paths.
+func (m *Manager) persistCapturedID(jobID, captured string) string {
+	final, err := m.store.SetConversationID(jobID, captured)
 	if err != nil {
-		log.Printf("agy-mcp: persist captured conversation id for job %s: %v", meta.ID, err)
-		return id // best-effort: report what we captured even if the persist failed
+		log.Printf("agy-mcp: persist captured conversation id for job %s: %v", jobID, err)
+		return captured
 	}
 	return final
 }

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -1,9 +1,7 @@
 package manager
 
 import (
-	"encoding/json"
-	"errors"
-	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -15,10 +13,14 @@ type Session struct {
 	ConversationID string `json:"conversation_id"`
 }
 
-// agyCachePath returns the path to last_conversations.json, honoring HOME.
+// agyCachePath returns the path to last_conversations.json, honoring HOME. An
+// empty return (the home dir is unresolvable) degrades every consumer to "no
+// sessions" and disables conversation-id capture, so log it rather than failing
+// silently; the cause is almost always a missing HOME in a restricted environment.
 func agyCachePath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
+		log.Printf("agy-mcp: cannot resolve home dir for agy conversation cache; session listing and conversation-id capture disabled: %v", err)
 		return ""
 	}
 	return filepath.Join(home, ".gemini", "antigravity-cli", "cache", "last_conversations.json")
@@ -32,15 +34,11 @@ func (m *Manager) ListSessions(dir string) ([]Session, error) {
 }
 
 func readSessions(cacheFile, filterDir string) ([]Session, error) {
-	b, err := os.ReadFile(cacheFile)
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil, nil
-	}
+	// loadCache is the single reader for last_conversations.json: it treats a
+	// missing file as an empty cache and reports a torn or corrupt read as an
+	// error, so this no longer duplicates the read+unmarshal (issue #36).
+	raw, err := loadCache(cacheFile)
 	if err != nil {
-		return nil, err
-	}
-	var raw map[string]string
-	if err := json.Unmarshal(b, &raw); err != nil {
 		return nil, err
 	}
 	cleanFilter := ""

--- a/internal/manager/sessions_test.go
+++ b/internal/manager/sessions_test.go
@@ -21,6 +21,19 @@ func TestListSessionsFromCache(t *testing.T) {
 	}
 }
 
+// A missing cache file is a normal empty cache (fresh agy install, no
+// conversations yet), so readSessions must return no sessions and no error. This
+// locks in the behavior now that readSessions delegates the read to loadCache.
+func TestListSessionsMissingCacheIsEmpty(t *testing.T) {
+	sessions, err := readSessions(filepath.Join(t.TempDir(), "does-not-exist.json"), "")
+	if err != nil {
+		t.Fatalf("a missing cache must not error: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("a missing cache must yield no sessions, got %d", len(sessions))
+	}
+}
+
 func TestListSessionsFilteredByDir(t *testing.T) {
 	cache := t.TempDir()
 	data := `{"/home/u/proj":"uuid-1","/home/u/other":"uuid-2"}`

--- a/internal/manager/sessions_test.go
+++ b/internal/manager/sessions_test.go
@@ -34,6 +34,20 @@ func TestListSessionsMissingCacheIsEmpty(t *testing.T) {
 	}
 }
 
+// A malformed cache (a torn or corrupt write) must surface as an error, not be
+// mistaken for an empty cache: agy rewrites last_conversations.json in place, so a
+// concurrent read can be torn. This covers the error side of the loadCache
+// contract that readSessions now relies on.
+func TestListSessionsMalformedCacheErrors(t *testing.T) {
+	cache := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cache, []byte("{ not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readSessions(cache, ""); err == nil {
+		t.Fatal("a malformed cache must return an error, not an empty session list")
+	}
+}
+
 func TestListSessionsFilteredByDir(t *testing.T) {
 	cache := t.TempDir()
 	data := `{"/home/u/proj":"uuid-1","/home/u/other":"uuid-2"}`


### PR DESCRIPTION
## Summary

Three low-risk cleanups from #36, all in the conversation-cache plumbing. No behavior change (beyond making one silent failure visible).

## Changes

- **`readSessions` reuses `loadCache`.** It duplicated `loadCache`'s `os.ReadFile` + `json.Unmarshal` of `last_conversations.json`. It now delegates to `loadCache`, the single reader that treats a missing file as an empty cache and reports a torn/corrupt read as a wrapped error. A missing cache still yields no sessions and no error (locked in by a new test); the only caller (the `list_sessions` MCP handler) bubbles the error without inspecting its type or text.
- **Extract `persistCapturedID`.** `captureFreshConversationID` and `lazyCaptureConversationID` shared an identical "`SetConversationID`, log on failure, fall back to the captured id" block. Both now call the helper, an exact equivalent for each path.
- **`agyCachePath` no longer degrades silently.** It returned `""` when `UserHomeDir` fails and every consumer fell back to "no sessions" with no signal. It now logs the cause. `New()` resolves the fallback lazily (an explicit `if`, not `cmp.Or`, which evaluated both args) so the home-dir lookup and its failure log only run when no explicit `ConversationCacheFile` was given. This avoids a misleading "disabled" log when an explicit path is set in a `HOME`-less environment (caught in peer review).

## Test plan

- New `TestListSessionsMissingCacheIsEmpty` locks in that a missing cache returns no sessions + no error now that the read goes through `loadCache`.
- `go test -race ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l` clean, `go build -tags ruleguard ./rules/`, darwin + windows cross-compiles all pass.

Refs #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history storage reliability with automatic fallback when persistence fails
  * Enhanced logging when the configuration/home directory cannot be resolved

* **Refactor**
  * Consolidated conversation persistence logic to remove duplication
  * Centralized cache loading for consistent handling of missing or corrupted cache files

* **Tests**
  * Added tests for missing cache treated as empty and for malformed cache error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->