### PR TITLE
refactor: set the "agy-mcp: " log prefix once in main (#36)

### DIFF
--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -88,7 +88,7 @@ func (g *gate) release(key string) {
 		// release, or a release on a key that was never acquired). The clamp keeps
 		// inFlight from going negative and silently raising the cap; log it so the
 		// regression surfaces instead of hiding.
-		log.Printf("agy-mcp: gate release underflow for key %q (released more than acquired)", key)
+		log.Printf("gate release underflow for key %q (released more than acquired)", key)
 	}
 	if key != "" {
 		delete(g.keys, key)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -166,7 +166,7 @@ func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
 func (m *Manager) persistCapturedID(jobID, captured string) string {
 	final, err := m.store.SetConversationID(jobID, captured)
 	if err != nil {
-		log.Printf("agy-mcp: persist captured conversation id for job %s: %v", jobID, err)
+		log.Printf("persist captured conversation id for job %s: %v", jobID, err)
 		return captured
 	}
 	return final
@@ -343,7 +343,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		// (notably after a reboot) this job reads as not-alive, so it cannot be
 		// restored across a manager restart and a recycled PID is never mistaken for
 		// it. Surface the unreadable boot_id since it degrades cross-boot liveness.
-		log.Printf("agy-mcp: job %s: kernel boot id unreadable; cross-boot liveness degraded for this job", id)
+		log.Printf("job %s: kernel boot id unreadable; cross-boot liveness degraded for this job", id)
 	}
 	// Whenever the run has no resolved conversation id (a fresh run, or a
 	// continue_latest that found no prior conversation), agy will create a new
@@ -357,7 +357,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 			// No trustworthy pre-run snapshot: a post-run diff could attribute
 			// a pre-existing conversation to this run. Report no id instead.
 			meta.CaptureDisabled = true
-			log.Printf("agy-mcp: job %s: conversation cache unreadable; id capture disabled for this run", id)
+			log.Printf("job %s: conversation cache unreadable; id capture disabled for this run", id)
 		}
 	}
 	dir, err := m.store.Create(meta)
@@ -522,13 +522,13 @@ func (m *Manager) gcEvaluate(l loadedJob, cutoff time.Time) bool {
 			// may be a job still mid-Create, so it is kept.
 			if m.orphanExpired(l.id, cutoff) {
 				if rerr := m.store.Remove(l.id); rerr != nil {
-					log.Printf("agy-mcp: GC: remove orphan job dir %s: %v", l.id, rerr)
+					log.Printf("GC: remove orphan job dir %s: %v", l.id, rerr)
 					return false
 				}
 				m.untrackCapture(l.id)
 				return true
 			}
-			log.Printf("agy-mcp: GC: orphan job dir %s (no meta.json) kept until older than the TTL", l.id)
+			log.Printf("GC: orphan job dir %s (no meta.json) kept until older than the TTL", l.id)
 			return false
 		}
 		// meta.json exists but could not be read or parsed: a transient error
@@ -536,7 +536,7 @@ func (m *Manager) gcEvaluate(l loadedJob, cutoff time.Time) bool {
 		// be reaped by dir mtime: a valid long-running job's dir mtime is old
 		// (writing to out/err does not bump the directory mtime), so reaping here
 		// could delete a live job. Log and keep; a later sweep retries the Load.
-		log.Printf("agy-mcp: GC: job %s meta unreadable (not reaping, may be transient): %v", l.id, l.metaErr)
+		log.Printf("GC: job %s meta unreadable (not reaping, may be transient): %v", l.id, l.metaErr)
 		return false
 	}
 	if !l.meta.StartedAt.Before(cutoff) {
@@ -568,7 +568,7 @@ func (m *Manager) gcEvaluate(l loadedJob, cutoff time.Time) bool {
 		return false
 	}
 	if err := m.store.Remove(l.id); err != nil {
-		log.Printf("agy-mcp: GC: remove expired job %s: %v", l.id, err)
+		log.Printf("GC: remove expired job %s: %v", l.id, err)
 		return false
 	}
 	m.untrackCapture(l.id)
@@ -630,9 +630,9 @@ func (m *Manager) runPeriodicGC(ctx context.Context, interval time.Duration) {
 			return
 		case <-t.C:
 			if removed, err := m.GarbageCollect(); err != nil {
-				log.Printf("agy-mcp: periodic GC: %v", err)
+				log.Printf("periodic GC: %v", err)
 			} else if len(removed) > 0 {
-				log.Printf("agy-mcp: periodic GC removed %d expired job(s)", len(removed))
+				log.Printf("periodic GC removed %d expired job(s)", len(removed))
 			}
 		}
 	}
@@ -660,7 +660,7 @@ func reqFromMeta(meta jobstore.Meta) StartRequest {
 		// under this rare path (a legacy relative cwd plus an os.Getwd failure) the
 		// restored key may not match a new same-directory run's normalized key, the
 		// one inconsistency that can still split serialization for that job.
-		log.Printf("agy-mcp: normalize cwd %q for restored job %s: %v; using raw cwd for gate key", cwd, meta.ID, err)
+		log.Printf("normalize cwd %q for restored job %s: %v; using raw cwd for gate key", cwd, meta.ID, err)
 	}
 	return StartRequest{ConversationID: meta.ConversationID, Cwd: cwd}
 }
@@ -699,7 +699,7 @@ func (m *Manager) restoreEvaluate(l loadedJob) {
 		// skipping silently: if such a job's supervisor is somehow still alive its
 		// gate is not held, the one gap in this method's fail-closed contract.
 		// GarbageCollect reaps the dir once it is older than the TTL.
-		log.Printf("agy-mcp: restore gate: skipping job %s with unreadable meta: %v", l.id, l.metaErr)
+		log.Printf("restore gate: skipping job %s with unreadable meta: %v", l.id, l.metaErr)
 		return
 	}
 	if _, terminal := m.store.ExitCode(l.id); terminal {

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -20,7 +20,7 @@ type Session struct {
 func agyCachePath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		log.Printf("agy-mcp: cannot resolve home dir for agy conversation cache; session listing and conversation-id capture disabled: %v", err)
+		log.Printf("cannot resolve home dir for agy conversation cache; session listing and conversation-id capture disabled: %v", err)
 		return ""
 	}
 	return filepath.Join(home, ".gemini", "antigravity-cli", "cache", "last_conversations.json")

--- a/internal/mcptools/serve.go
+++ b/internal/mcptools/serve.go
@@ -95,7 +95,7 @@ func ServeHTTP(ctx context.Context, mgr *manager.Manager, addr, token string) er
 		// shutdown error (e.g. in-flight responses outlasting the 5s drain) is worth
 		// surfacing rather than silently dropping.
 		if err := srv.Shutdown(shutCtx); err != nil {
-			log.Printf("agy-mcp: http shutdown: %v", err)
+			log.Printf("http shutdown: %v", err)
 		}
 	}()
 	err := srv.ListenAndServe()

--- a/main.go
+++ b/main.go
@@ -23,6 +23,12 @@ func main() {
 	// stdout is reserved for the JSON-RPC stream in stdio mode. Force the
 	// standard logger to stderr so a stray log line cannot corrupt the protocol.
 	log.SetOutput(os.Stderr)
+	// One source of the "agy-mcp: " log prefix, set here before either the serve or
+	// the run-job (supervisor) path runs, so every log line is tagged consistently
+	// and individual messages no longer hardcode the prefix. This does not affect
+	// errors.New strings (e.g. proc.ErrUnsupported) or the fmt.Fprintf stderr writes
+	// below, which are surfaced to callers rather than logged.
+	log.SetPrefix("agy-mcp: ")
 
 	if len(os.Args) >= 2 && os.Args[1] == "run-job" {
 		if len(os.Args) != 3 {
@@ -95,14 +101,14 @@ func serve() error {
 		if cfg.HTTPToken != "" {
 			authNote = "bearer-token auth enabled"
 		}
-		log.Printf("agy-mcp serving Streamable HTTP on %s (%s)", *httpAddr, authNote)
+		log.Printf("serving Streamable HTTP on %s (%s)", *httpAddr, authNote)
 		if err := mcptools.ServeHTTP(ctx, mgr, *httpAddr, cfg.HTTPToken); err != nil {
 			return fmt.Errorf("http serve: %w", err)
 		}
 		return nil
 	}
 
-	log.Print("agy-mcp serving over stdio")
+	log.Print("serving over stdio")
 	if err := mcptools.ServeStdio(ctx, mgr); err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("stdio serve: %w", err)
 	}


### PR DESCRIPTION
## Summary

Last of the #36 logging item. Every `manager`/`mcptools` log message hardcoded the `agy-mcp: ` prefix, while `main`'s own logs used `agy-mcp ` or no prefix at all, so the tag was both repetitive and inconsistent. Set it once with `log.SetPrefix("agy-mcp: ")` in `main()` and strip the literal from every `log.*` message.

## Changes

- Add `log.SetPrefix("agy-mcp: ")` in `main()` right after `log.SetOutput(os.Stderr)`, before the `run-job` (supervisor subprocess) and `serve()` paths split, so both the supervisor and the server inherit the prefix.
- Strip the hardcoded `agy-mcp: ` prefix from the 14 `log.*` messages in `manager`, `concurrency`, `sessions`, and `mcptools/serve`, and the `agy-mcp ` form from `main`'s two "serving" messages.
- Left untouched (these bypass the `log` package and are surfaced to callers, so `SetPrefix` does not affect them): `proc.ErrUnsupported`'s `errors.New` string and `main`'s `fmt.Fprintf(os.Stderr, ...)` usage/fatal writes.

## Test plan

- Verified at runtime: startup now logs `agy-mcp: <ts> serving over stdio` with a single prefix; the HTTP loopback error (surfaced via `fmt.Fprintf`, not logged) correctly has none.
- Grepped that no remaining `log.*` message begins with `agy-mcp` (no double-prefix), and that no test asserts on the `agy-mcp:` log literal.
- `go test -race ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l` clean, `go build -tags ruleguard ./rules/`, darwin + windows cross-compiles all pass.

Refs #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized application log message formatting by centralizing the log prefix handling. Log output remains consistent; no functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->