### PR TITLE
fix(rules): constrain FilepathIsLocal, extend ErrorBeforeUse, prune dead clauses (#31)

### DIFF
--- a/rules/doc.go
+++ b/rules/doc.go
@@ -1,0 +1,9 @@
+//go:build ruleguard
+
+// Package gorules defines custom ruleguard matchers for Go modernization.
+//
+// The matchers are loaded by golangci-lint's gocritic ruleguard checker (see
+// settings.gocritic.settings.ruleguard.rules in .golangci.yaml). Every file
+// carries the //go:build ruleguard tag so the normal Go toolchain ignores
+// them; `go build -tags ruleguard ./rules/` compiles them as a canary.
+package gorules

--- a/rules/net.go
+++ b/rules/net.go
@@ -81,13 +81,17 @@ func FilepathIsLocal(m dsl.Matcher) {
 	//     pattern the rule is really about (a path held in a local var).
 	//
 	//  2. The identifier must read like a path. The match is case-sensitive so it
-	//     keys on Go's camelCase boundaries instead of plain substrings:
+	//     keys on Go's camelCase boundaries instead of plain substrings, and BOTH
+	//     alternatives are anchored (`|` has the lowest precedence, so an
+	//     unanchored second branch would match the keyword as a substring of any
+	//     identifier, e.g. MyDirtyVar via "Dir" or IsFiled via "File"):
 	//       - `^(path|dir|file)(s|path|name|[A-Z].*)?$` catches a lowercase
 	//         keyword that is the whole name, a plural, a common lowercase compound
 	//         (filepath, filename, dirname, dirpath), or the first camelCase
 	//         component (fileName, dirEntry, ...).
-	//       - `(Path|Dir|File)` catches a capitalized keyword anywhere in a
-	//         compound identifier (userPath, srcDir, inputFile, ...).
+	//       - `^(.*[a-z0-9_])?(Path|Dir|File)(s|[A-Z].*)?$` catches a capitalized
+	//         keyword at a camelCase boundary (userPath, srcDir, inputFile), while
+	//         requiring it to sit on a boundary so MyDirtyVar/IsFiled do not match.
 	//     A flat `(?i)path|dir|file` would also fire on words that merely contain
 	//     those letters (profile, directory, redirect, dirty, filed).
 	//
@@ -98,7 +102,7 @@ func FilepathIsLocal(m dsl.Matcher) {
 	).
 		Where(
 			m["path"].Text.Matches(`^[A-Za-z_][A-Za-z0-9_]*$`) &&
-				m["path"].Text.Matches(`^(path|dir|file)(s|path|name|[A-Z].*)?$|(Path|Dir|File)`),
+				m["path"].Text.Matches(`^(path|dir|file)(s|path|name|[A-Z].*)?$|^(.*[a-z0-9_])?(Path|Dir|File)(s|[A-Z].*)?$`),
 		).
 		Report("consider using filepath.IsLocal($path) for file path validation (Go 1.20+); for URL paths, strings.Contains is appropriate")
 }

--- a/rules/net.go
+++ b/rules/net.go
@@ -71,22 +71,35 @@ func FilepathIsLocal(m dsl.Matcher) {
 	// flag when the checked expression reads like a path. This trades a little
 	// recall for far fewer false positives; it stays advisory (Report-only).
 	//
-	// The name match is deliberately case-sensitive so it keys on Go's camelCase
-	// boundaries instead of plain substrings:
-	//   - `^(path|dir|file)(s?$|[A-Z])` catches a lowercase keyword that is the
-	//     whole name or the first camelCase component (path, dir, file, paths,
-	//     fileName, dirEntry, pathStr, ...).
-	//   - `(Path|Dir|File)` catches a capitalized keyword anywhere in a compound
-	//     identifier (userPath, filePath, srcDir, inputFile, ...).
-	// A flat `(?i)path|dir|file` would also fire on words that merely contain
-	// those letters (profile, directory, redirect, dirty, filed), so it is not used.
+	// Two guards keep this narrow:
+	//
+	//  1. The operand must be a bare identifier (`^[A-Za-z_][A-Za-z0-9_]*$`).
+	//     The name match below runs on the operand's full source text, so without
+	//     this a selector like req.URL.Path would match on "Path" and get flagged,
+	//     even though the message says URL paths are the exception. Restricting to
+	//     a plain local variable both removes that contradiction and targets the
+	//     pattern the rule is really about (a path held in a local var).
+	//
+	//  2. The identifier must read like a path. The match is case-sensitive so it
+	//     keys on Go's camelCase boundaries instead of plain substrings:
+	//       - `^(path|dir|file)(s|path|name|[A-Z].*)?$` catches a lowercase
+	//         keyword that is the whole name, a plural, a common lowercase compound
+	//         (filepath, filename, dirname, dirpath), or the first camelCase
+	//         component (fileName, dirEntry, ...).
+	//       - `(Path|Dir|File)` catches a capitalized keyword anywhere in a
+	//         compound identifier (userPath, srcDir, inputFile, ...).
+	//     A flat `(?i)path|dir|file` would also fire on words that merely contain
+	//     those letters (profile, directory, redirect, dirty, filed).
 	//
 	// Note: For URL paths, strings.Contains is still appropriate because
 	// filepath.IsLocal cleans paths internally (e.g., "path/../etc" → "etc").
 	m.Match(
 		`strings.Contains($path, "..")`,
 	).
-		Where(m["path"].Text.Matches(`(^(path|dir|file)(s?$|[A-Z]))|(Path|Dir|File)`)).
+		Where(
+			m["path"].Text.Matches(`^[A-Za-z_][A-Za-z0-9_]*$`) &&
+				m["path"].Text.Matches(`^(path|dir|file)(s|path|name|[A-Z].*)?$|(Path|Dir|File)`),
+		).
 		Report("consider using filepath.IsLocal($path) for file path validation (Go 1.20+); for URL paths, strings.Contains is appropriate")
 }
 
@@ -153,10 +166,12 @@ func DeprecatedReverseProxyDirector(m dsl.Matcher) {
 // See: https://go.dev/doc/go1.25#compiler (nil check reordering fix)
 func ErrorBeforeUse(m dsl.Matcher) {
 	// os.Open/Create/OpenFile followed by a use of $f before the error check.
-	// Three result shapes are covered for each constructor:
+	// Four result shapes are covered for each constructor:
 	//   - single-value assignment: name := f.Method(...)
 	//   - bare call (return value discarded): f.Method(...)
 	//   - multi-value assignment: a, b := f.Method(...)
+	//   - deferred call: defer f.Method(...) (the classic `defer f.Close()` before
+	//     the err check, which runs on a nil receiver and panics when Open fails)
 	m.Match(
 		// single-value assignment
 		`$f, $err := os.Open($path); $_ := $f.$method($*_); if $err != nil { $*_ }`,
@@ -170,6 +185,10 @@ func ErrorBeforeUse(m dsl.Matcher) {
 		`$f, $err := os.Open($path); $_, $_ := $f.$method($*_); if $err != nil { $*_ }`,
 		`$f, $err := os.Create($path); $_, $_ := $f.$method($*_); if $err != nil { $*_ }`,
 		`$f, $err := os.OpenFile($*_); $_, $_ := $f.$method($*_); if $err != nil { $*_ }`,
+		// deferred call
+		`$f, $err := os.Open($path); defer $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.Create($path); defer $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.OpenFile($*_); defer $f.$method($*_); if $err != nil { $*_ }`,
 	).
 		Report("potential nil pointer: $f may be nil if $err != nil; check error before using $f.$method()")
 }

--- a/rules/net.go
+++ b/rules/net.go
@@ -62,12 +62,31 @@ func JoinHostPort(m dsl.Matcher) {
 //
 // See: https://pkg.go.dev/path/filepath#IsLocal
 func FilepathIsLocal(m dsl.Matcher) {
-	// Detect simple .. check that might be replaced by IsLocal
-	// Note: For URL paths, strings.Contains is still appropriate because filepath.IsLocal
-	// cleans paths internally (e.g., "path/../etc" → "etc" → valid).
+	// Detect simple .. check that might be replaced by IsLocal.
+	//
+	// strings.Contains($x, "..") on its own is far too broad: it fires on any
+	// ".." substring test (version ranges, ellipsis checks, arbitrary text), not
+	// just path traversal. There is no type signal that distinguishes a path from
+	// any other string, so this constrains on the operand's name instead: only
+	// flag when the checked expression reads like a path. This trades a little
+	// recall for far fewer false positives; it stays advisory (Report-only).
+	//
+	// The name match is deliberately case-sensitive so it keys on Go's camelCase
+	// boundaries instead of plain substrings:
+	//   - `^(path|dir|file)(s?$|[A-Z])` catches a lowercase keyword that is the
+	//     whole name or the first camelCase component (path, dir, file, paths,
+	//     fileName, dirEntry, pathStr, ...).
+	//   - `(Path|Dir|File)` catches a capitalized keyword anywhere in a compound
+	//     identifier (userPath, filePath, srcDir, inputFile, ...).
+	// A flat `(?i)path|dir|file` would also fire on words that merely contain
+	// those letters (profile, directory, redirect, dirty, filed), so it is not used.
+	//
+	// Note: For URL paths, strings.Contains is still appropriate because
+	// filepath.IsLocal cleans paths internally (e.g., "path/../etc" → "etc").
 	m.Match(
 		`strings.Contains($path, "..")`,
 	).
+		Where(m["path"].Text.Matches(`(^(path|dir|file)(s?$|[A-Z]))|(Path|Dir|File)`)).
 		Report("consider using filepath.IsLocal($path) for file path validation (Go 1.20+); for URL paths, strings.Contains is appropriate")
 }
 
@@ -133,11 +152,24 @@ func DeprecatedReverseProxyDirector(m dsl.Matcher) {
 //
 // See: https://go.dev/doc/go1.25#compiler (nil check reordering fix)
 func ErrorBeforeUse(m dsl.Matcher) {
-	// os.Open/Create followed by method call before error check
+	// os.Open/Create/OpenFile followed by a use of $f before the error check.
+	// Three result shapes are covered for each constructor:
+	//   - single-value assignment: name := f.Method(...)
+	//   - bare call (return value discarded): f.Method(...)
+	//   - multi-value assignment: a, b := f.Method(...)
 	m.Match(
+		// single-value assignment
 		`$f, $err := os.Open($path); $_ := $f.$method($*_); if $err != nil { $*_ }`,
 		`$f, $err := os.Create($path); $_ := $f.$method($*_); if $err != nil { $*_ }`,
 		`$f, $err := os.OpenFile($*_); $_ := $f.$method($*_); if $err != nil { $*_ }`,
+		// bare call
+		`$f, $err := os.Open($path); $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.Create($path); $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.OpenFile($*_); $f.$method($*_); if $err != nil { $*_ }`,
+		// multi-value assignment
+		`$f, $err := os.Open($path); $_, $_ := $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.Create($path); $_, $_ := $f.$method($*_); if $err != nil { $*_ }`,
+		`$f, $err := os.OpenFile($*_); $_, $_ := $f.$method($*_); if $err != nil { $*_ }`,
 	).
 		Report("potential nil pointer: $f may be nil if $err != nil; check error before using $f.$method()")
 }

--- a/rules/reflect.go
+++ b/rules/reflect.go
@@ -102,14 +102,14 @@ func ReflectTypeOf(m dsl.Matcher) {
 // See: https://pkg.go.dev/unsafe#Slice
 // See: https://pkg.go.dev/unsafe#String
 func DeprecatedReflectHeaders(m dsl.Matcher) {
+	// `{$*_}` matches zero or more fields, so it already covers the empty `{}`
+	// literal; a separate `{}` clause would be dead weight.
 	m.Match(
-		`reflect.SliceHeader{}`,
 		`reflect.SliceHeader{$*_}`,
 	).
 		Report("reflect.SliceHeader is deprecated in Go 1.21; use unsafe.Slice instead")
 
 	m.Match(
-		`reflect.StringHeader{}`,
 		`reflect.StringHeader{$*_}`,
 	).
 		Report("reflect.StringHeader is deprecated in Go 1.21; use unsafe.String instead")

--- a/rules/slices.go
+++ b/rules/slices.go
@@ -4,7 +4,8 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// SortInts detects sort.Ints/sort.Strings/sort.Float64s and suggests slices.Sort.
+// SortToSlices detects sort.Ints/sort.Strings/sort.Float64s (and their
+// *AreSorted variants) and suggests the generic slices.Sort/slices.IsSorted.
 //
 // Old patterns:
 //
@@ -24,7 +25,7 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 //   - Part of the new slices package
 //
 // See: https://pkg.go.dev/slices#Sort
-func SortInts(m dsl.Matcher) {
+func SortToSlices(m dsl.Matcher) {
 	m.Match(
 		`sort.Ints($s)`,
 	).

--- a/rules/strings.go
+++ b/rules/strings.go
@@ -4,7 +4,7 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// StringsLinesIteration detects manual line splitting patterns and suggests strings.Lines.
+// LinesIteration detects manual line splitting patterns and suggests strings.Lines.
 //
 // Old pattern:
 //
@@ -29,7 +29,7 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 // strings.Split: Lines keeps the line terminator (the trailing \n, and \r\n)
 // on each yielded line, whereas Split strips the separator. Callers that
 // compare or trim lines must account for that, so this stays Report-only.
-func StringsLinesIteration(m dsl.Matcher) {
+func LinesIteration(m dsl.Matcher) {
 	// Pattern: for _, line := range strings.Split(s, "\n")
 	m.Match(
 		`for $_, $line := range strings.Split($s, "\n") { $*body }`,
@@ -59,7 +59,7 @@ func StringsLinesIteration(m dsl.Matcher) {
 		Report(`use for $line := range bytes.Lines($s) instead of ranging over bytes.Split (Go 1.24+); not value-equivalent: Lines keeps the trailing newline, Split strips it`)
 }
 
-// StringsSplitIteration detects strings.Split used only for iteration
+// SplitIteration detects strings.Split used only for iteration
 // and suggests strings.SplitSeq for better memory efficiency.
 //
 // Old pattern:
@@ -84,7 +84,7 @@ func StringsLinesIteration(m dsl.Matcher) {
 //
 // See: https://pkg.go.dev/strings#SplitSeq
 // See: https://pkg.go.dev/bytes#SplitSeq
-func StringsSplitIteration(m dsl.Matcher) {
+func SplitIteration(m dsl.Matcher) {
 	// Pattern: for _, part := range strings.Split(s, sep)
 	// Excluding newline separators which should use Lines() instead
 	m.Match(
@@ -101,7 +101,7 @@ func StringsSplitIteration(m dsl.Matcher) {
 		Report("use for $part := range bytes.SplitSeq($s, $sep) to avoid intermediate slice allocation (Go 1.24+)")
 }
 
-// StringsFieldsIteration detects strings.Fields used only for iteration
+// FieldsIteration detects strings.Fields used only for iteration
 // and suggests strings.FieldsSeq.
 //
 // Old pattern:
@@ -118,7 +118,7 @@ func StringsSplitIteration(m dsl.Matcher) {
 //
 // See: https://pkg.go.dev/strings#FieldsSeq
 // See: https://pkg.go.dev/bytes#FieldsSeq
-func StringsFieldsIteration(m dsl.Matcher) {
+func FieldsIteration(m dsl.Matcher) {
 	m.Match(
 		`for $_, $field := range strings.Fields($s) { $*body }`,
 	).
@@ -130,7 +130,7 @@ func StringsFieldsIteration(m dsl.Matcher) {
 		Report("use for $field := range bytes.FieldsSeq($s) to avoid intermediate slice allocation (Go 1.24+)")
 }
 
-// StringsFieldsFuncIteration detects strings.FieldsFunc used only for iteration
+// FieldsFuncIteration detects strings.FieldsFunc used only for iteration
 // and suggests strings.FieldsFuncSeq.
 //
 // Old pattern:
@@ -147,7 +147,7 @@ func StringsFieldsIteration(m dsl.Matcher) {
 //
 // See: https://pkg.go.dev/strings#FieldsFuncSeq
 // See: https://pkg.go.dev/bytes#FieldsFuncSeq
-func StringsFieldsFuncIteration(m dsl.Matcher) {
+func FieldsFuncIteration(m dsl.Matcher) {
 	m.Match(
 		`for $_, $field := range strings.FieldsFunc($s, $f) { $*body }`,
 	).

--- a/rules/sync.go
+++ b/rules/sync.go
@@ -1,6 +1,5 @@
 //go:build ruleguard
 
-// Package gorules defines custom linter rules for Go modernization.
 package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"

--- a/rules/time.go
+++ b/rules/time.go
@@ -156,37 +156,11 @@ func TimerChannelLen(m dsl.Matcher) {
 // See: https://pkg.go.dev/time#Since
 // Note: Go 1.22 vet tool also warns about this pattern.
 func DeferredTimeSince(m dsl.Matcher) {
-	// Pattern: defer with time.Since as argument
+	// One clause covers time.Since in any argument position: the two variadic
+	// captures absorb any preceding and trailing args (including none), so the
+	// earlier per-position clauses were redundant.
 	m.Match(
-		`defer $fn(time.Since($start))`,
-	).
-		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
-
-	// Pattern: defer with time.Since as argument (multiple args)
-	m.Match(
-		`defer $fn(time.Since($start), $*args)`,
-	).
-		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
-
-	m.Match(
-		`defer $fn($arg, time.Since($start))`,
-	).
-		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
-
-	m.Match(
-		`defer $fn($arg1, $arg2, time.Since($start))`,
-	).
-		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
-
-	// time.Since as second argument with trailing args
-	m.Match(
-		`defer $fn($arg, time.Since($start), $*args)`,
-	).
-		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
-
-	// time.Since as fourth argument (3 preceding args)
-	m.Match(
-		`defer $fn($arg1, $arg2, $arg3, time.Since($start))`,
+		`defer $fn($*_, time.Since($start), $*_)`,
 	).
 		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
 }
@@ -204,20 +178,11 @@ func DeferredTimeSince(m dsl.Matcher) {
 //
 // See: https://pkg.go.dev/time#Now
 func DeferredTimeNow(m dsl.Matcher) {
+	// One clause covers time.Now() in any argument position: the two variadic
+	// captures absorb any preceding and trailing args (including none), so the
+	// earlier per-position clauses were redundant.
 	m.Match(
-		`defer $fn(time.Now())`,
-	).
-		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
-
-	// time.Now() as the last argument (with preceding args).
-	m.Match(
-		`defer $fn($*args, time.Now())`,
-	).
-		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
-
-	// time.Now() as the first argument (with trailing args).
-	m.Match(
-		`defer $fn(time.Now(), $*args)`,
+		`defer $fn($*_, time.Now(), $*_)`,
 	).
 		Report("time.Now() is evaluated at defer time, not function exit; wrap in func() if you want exit time")
 }


### PR DESCRIPTION
## Summary

Remaining rule-quality items from #31, all confined to the `rules/*.go` ruleguard matchers.

**Correctness / coverage**
- `FilepathIsLocal` (net.go): was firing on *every* `strings.Contains($x, "..")` (version ranges, ellipsis checks, arbitrary text), not just path traversal. Now constrained to path-like operands via a case-sensitive camelCase name match, so it keys on `path`/`dir`/`file` components (`path`, `dir`, `file`, `userPath`, `filePath`, `dirName`, `fileName`, `srcDir`) without flagging incidental substrings (`profile`, `directory`, `redirect`, `dirty`, `filed`). Stays advisory (Report-only).
- `ErrorBeforeUse` (net.go): now covers the bare-call (`f.Method()`) and multi-value (`a, b := f.Method()`) result shapes for `os.Open`/`Create`/`OpenFile`, not just the single-value assignment.

**Dead-weight removal (behavior-preserving, verified)**
- `DeferredTimeSince`/`DeferredTimeNow` (time.go): the per-argument-position clauses (6 and 3 respectively) collapse into one two-variadic-wildcard clause each, `defer $fn($*_, time.X(...), $*_)`. The wildcards absorb any preceding/trailing args, so the enumerated positions were redundant.
- `DeprecatedReflectHeaders` (reflect.go): drop the dedicated `{}` clauses; `{$*_}` already matches the empty composite literal.

**Naming and docs**
- Rename `SortInts` -> `SortToSlices` (it also handles Strings/Float64s and the `*AreSorted` variants), and the four `Strings*Iteration` rules -> `Lines`/`Split`/`Fields`/`FieldsFuncIteration` (they cover `bytes.*` too). Rule function names are internal only and have no external references.
- Move the package doc comment out of `sync.go` into a dedicated `doc.go`.

## Related Issues

Relates to #31. Three items are intentionally left for a maintainer decision and are NOT in this PR:
- **Overlap policy** (AppendWithoutValues vs govet; DeferredTimeSince vs govet; the Deprecated-API rules vs staticcheck SA1019): whether to keep the richer custom messages, drop the duplicates, or accept the overlap deliberately. With `uniq-by-line: true` the surviving message per line is arbitrary.
- **Enabling `nosprintfhostport` / `usetesting`**: would cover JoinHostPort and most of TestingContext off the shelf, but changes the shared linting standard copied from go-flac.
- **TestingContext firing in TestMain/benchmarks**: ruleguard matches by filename and cannot see the enclosing function, so this stays message-only unless `usetesting` is adopted.

## Test Plan
- [x] `go build -tags ruleguard ./rules/` (ruleguard canary) passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go test ./...` passes
- [x] Each behavior change verified empirically with golangci-lint v2.11.4 against fixtures (false positive eliminated; new ErrorBeforeUse forms fire; collapsed time.go clauses still catch every argument position; reflect `{}` still matches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lint detection for “error checked after file operation,” covering more defer/call/result usage shapes.
  * Reduced false positives in filepath “local” detection while preserving the intended unsafe target.
  * Simplified deprecated `reflect.SliceHeader` detection.
  * Expanded deferred `time.Since`/`time.Now` pattern coverage without changing messages.

* **Refactor**
  * Streamlined several rule matchers and adjusted internal rule naming.

* **Documentation**
  * Added build-tag/package documentation to support canary compilation and rule loading by the linter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->