### PR TITLE
fix(manager): serialize same-key jobs across processes with an advisory flock

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,16 @@ same directory is refused (`agy_run` returns a conflict error rather than queuin
 them in separate directories or retry once the first finishes. Runs in different directories,
 and runs continuing distinct conversations, still run concurrently up to the configured cap.
 The gate that enforces this is rebuilt at startup from jobs whose supervisor outlived a server
-restart, so the cap and serialization hold across restarts.
+restart, so serialization holds across restarts.
+
+This serialization holds across separate `agy-mcp` processes too, which matters in stdio mode,
+where each MCP client session spawns its own process sharing one `AGY_MCP_STATE_DIR`. A per-key
+advisory lock (`flock` on a file under `<state-dir>/locks/`) serializes same-`cwd`/same-conversation
+runs across processes, so two sibling sessions cannot start a conflicting run concurrently. The
+global concurrency cap, by contrast, is enforced per process: with N client sessions each capped
+at the configured limit, up to N times that many distinct, non-conflicting runs can be in flight.
+The lock files are tiny and left in place by design (unlinking a `flock` file races), so the
+`locks/` directory keeps one empty file per distinct directory or conversation ever locked.
 
 ## HTTP mode
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ at the configured limit, up to N times that many distinct, non-conflicting runs 
 The lock files are tiny and left in place by design (unlinking a `flock` file races), so the
 `locks/` directory keeps one empty file per distinct directory or conversation ever locked.
 
+Two caveats. `AGY_MCP_STATE_DIR` must live on a local filesystem that supports `flock` (not NFS,
+where `flock` may be a no-op or fail); a run is refused rather than started if the lock cannot be
+taken, so cross-process exclusion can never silently lapse. And across a server restart there is a
+brief window, while the manager process is down, before it re-takes the locks for jobs whose
+supervisor outlived it; a sibling process that starts the same-`cwd` run during that window is not
+blocked. The in-process gate is always restored at startup, so this gap is limited to the restart
+window itself.
+
 ## HTTP mode
 
 ```bash

--- a/internal/manager/admit.go
+++ b/internal/manager/admit.go
@@ -1,0 +1,68 @@
+package manager
+
+import "log"
+
+// admit reserves both the in-process gate slot and the cross-process advisory lock
+// for key, so the run is serialized against same-key runs in this process (via the
+// gate) and in sibling processes that share the state dir (via the lock). It returns
+// the gate's own outcome on an in-process refusal, acquireKeyBusy when a sibling
+// process holds the key, and a non-nil error when the cross-process lock could not
+// be established at all, which the caller must treat as fail-closed (refuse the run
+// rather than proceed without exclusion). On every refusal and on error the
+// in-process reservation is rolled back, so the caller releases nothing. The
+// returned outcome is meaningful only when err is nil.
+func (m *Manager) admit(key string) (acquireOutcome, error) {
+	outcome := m.gate.tryAcquire(key)
+	if outcome != acquireOK {
+		return outcome, nil
+	}
+	// An empty key skips per-key serialization (there is nothing to serialize on),
+	// so there is no cross-process lock to take; the global cap already counted it.
+	if key == "" {
+		return acquireOK, nil
+	}
+	locked, err := m.xlock.tryLock(key)
+	if err != nil {
+		m.gate.release(key) // reserved the slot but the run cannot safely proceed
+		return acquireOK, err
+	}
+	if !locked {
+		m.gate.release(key) // a sibling process holds the key
+		return acquireKeyBusy, nil
+	}
+	return acquireOK, nil
+}
+
+// releaseKey releases both the in-process gate slot/key and the cross-process lock
+// for key. It pairs with admit and forceAdmit. The cross-process unlock is a no-op
+// for a key this process does not hold (a restored job whose lock a sibling held),
+// so it is always safe on the run's completion path.
+func (m *Manager) releaseKey(key string) {
+	m.gate.release(key)
+	if key != "" {
+		m.xlock.unlock(key)
+	}
+}
+
+// forceAdmit tracks an already-running restored job (whose detached supervisor
+// outlived a manager restart) in the in-process gate, then best-effort re-takes the
+// cross-process lock so siblings are blocked again. Unlike admit it never refuses:
+// the job is running and must be counted regardless of the cap. The cross-process
+// lock is best effort because a sibling may have grabbed the key during the
+// manager-down gap; when that happens the job is still tracked in-process and the
+// lapse is logged. It returns false (without taking the lock) only when this process
+// already tracks the key, so the caller starts exactly one watcher per key.
+func (m *Manager) forceAdmit(key string) bool {
+	if !m.gate.forceAcquire(key) {
+		return false
+	}
+	if key == "" {
+		return true
+	}
+	if locked, err := m.xlock.tryLock(key); err != nil {
+		log.Printf("restore: cross-process lock for key %q failed: %v; job tracked in-process only", key, err)
+	} else if !locked {
+		log.Printf("restore: cross-process lock for key %q held by another process; job tracked in-process only", key)
+	}
+	return true
+}

--- a/internal/manager/admit_linux_test.go
+++ b/internal/manager/admit_linux_test.go
@@ -1,0 +1,126 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+)
+
+// twoManagers returns two managers that share one state dir, modeling two sibling
+// agy-mcp processes in stdio mode (each process has its own in-memory gate, but
+// they share AGY_MCP_STATE_DIR and so must serialize through the on-disk locks).
+func twoManagers(t *testing.T) (*Manager, *Manager) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.Config{StateDir: dir, MaxConcurrency: 4}
+	return New(cfg), New(cfg)
+}
+
+// TestAdmitExcludesAcrossManagers: a fresh-run key admitted by one manager must be
+// refused to a sibling manager sharing the state dir, then admittable once released.
+// This is the cross-process serialization the in-process gate alone cannot provide.
+func TestAdmitExcludesAcrossManagers(t *testing.T) {
+	m1, m2 := twoManagers(t)
+
+	if outcome, err := m1.admit("cwd:/w"); err != nil || outcome != acquireOK {
+		t.Fatalf("m1.admit = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+	// m2's own gate is free, so only the cross-process lock can refuse it.
+	if outcome, err := m2.admit("cwd:/w"); err != nil || outcome != acquireKeyBusy {
+		t.Fatalf("m2.admit while m1 holds = (%v, %v), want (acquireKeyBusy, nil)", outcome, err)
+	}
+	// A distinct key is independent.
+	if outcome, err := m2.admit("cwd:/other"); err != nil || outcome != acquireOK {
+		t.Fatalf("m2.admit distinct key = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+
+	m1.releaseKey("cwd:/w")
+	if outcome, err := m2.admit("cwd:/w"); err != nil || outcome != acquireOK {
+		t.Fatalf("m2.admit after m1.releaseKey = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+}
+
+// TestAdmitInProcessRefusalsStillApply: admit must preserve the in-process gate's
+// own outcomes (same-key busy, at-cap) and not let the cross-process layer mask
+// them, so the precise StartJob error is unchanged.
+func TestAdmitInProcessRefusalsStillApply(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 1})
+
+	if outcome, err := m.admit("conv:a"); err != nil || outcome != acquireOK {
+		t.Fatalf("first admit = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+	// Same key, same process: the in-process gate reports key-busy.
+	if outcome, err := m.admit("conv:a"); err != nil || outcome != acquireKeyBusy {
+		t.Fatalf("same-key admit = (%v, %v), want (acquireKeyBusy, nil)", outcome, err)
+	}
+	// Distinct key at the cap of 1: the in-process gate reports at-cap.
+	if outcome, err := m.admit("conv:b"); err != nil || outcome != acquireAtCap {
+		t.Fatalf("at-cap admit = (%v, %v), want (acquireAtCap, nil)", outcome, err)
+	}
+}
+
+// TestAdmitFailsClosedOnLockError: when the cross-process lock cannot be
+// established (the locks dir is uncreatable because the state dir is a regular
+// file), admit returns an error and rolls back the in-process reservation, so the
+// key is not left held. StartJob turns the error into a refusal.
+func TestAdmitFailsClosedOnLockError(t *testing.T) {
+	base := t.TempDir()
+	fileAsStateDir := filepath.Join(base, "file")
+	if err := os.WriteFile(fileAsStateDir, []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	m := New(config.Config{StateDir: fileAsStateDir, MaxConcurrency: 4})
+
+	if _, err := m.admit("cwd:/w"); err == nil {
+		t.Fatal("admit must fail closed when the cross-process lock cannot be created")
+	}
+	// The in-process reservation was rolled back: the gate slot/key is free, so a
+	// later admit (once the lock dir is fixed) is not wrongly blocked in-process.
+	if m.gate.keys["cwd:/w"] {
+		t.Fatal("admit must roll back the in-process key on a lock error")
+	}
+}
+
+// TestForceAdmitTakesCrossProcessLock: a restored job (whose detached supervisor
+// outlived a manager restart) must re-take the cross-process lock so a sibling is
+// blocked, and releaseKey must drop it.
+func TestForceAdmitTakesCrossProcessLock(t *testing.T) {
+	m1, m2 := twoManagers(t)
+
+	if !m1.forceAdmit("cwd:/w") {
+		t.Fatal("forceAdmit should track a restored job")
+	}
+	if outcome, err := m2.admit("cwd:/w"); err != nil || outcome != acquireKeyBusy {
+		t.Fatalf("m2.admit while m1 force-holds = (%v, %v), want (acquireKeyBusy, nil)", outcome, err)
+	}
+	m1.releaseKey("cwd:/w")
+	if outcome, err := m2.admit("cwd:/w"); err != nil || outcome != acquireOK {
+		t.Fatalf("m2.admit after m1.releaseKey = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+}
+
+// TestForceAdmitTracksDespiteSiblingLock: when a sibling already holds the
+// cross-process lock (it grabbed the key during the manager-down restart gap),
+// forceAdmit must still track the restored job in-process (it is genuinely
+// running), and the later releaseKey must not release the sibling's lock.
+func TestForceAdmitTracksDespiteSiblingLock(t *testing.T) {
+	m1, m2 := twoManagers(t)
+
+	// m2 (the sibling) grabbed the key during the gap.
+	if outcome, err := m2.admit("cwd:/w"); err != nil || outcome != acquireOK {
+		t.Fatalf("m2.admit = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+	// m1 restores a still-running job for the same key: tracked in-process even
+	// though it could not take the (sibling-held) cross-process lock.
+	if !m1.forceAdmit("cwd:/w") {
+		t.Fatal("forceAdmit must track a restored job even when a sibling holds the lock")
+	}
+	// m1 never held the lock, so its release must not free the sibling's lock.
+	m1.releaseKey("cwd:/w")
+	m3 := New(config.Config{StateDir: m2.cfg.StateDir, MaxConcurrency: 4})
+	if outcome, err := m3.admit("cwd:/w"); err != nil || outcome != acquireKeyBusy {
+		t.Fatalf("m3.admit while m2 still holds = (%v, %v), want (acquireKeyBusy, nil)", outcome, err)
+	}
+}

--- a/internal/manager/admit_linux_test.go
+++ b/internal/manager/admit_linux_test.go
@@ -11,7 +11,7 @@ import (
 // twoManagers returns two managers that share one state dir, modeling two sibling
 // agy-mcp processes in stdio mode (each process has its own in-memory gate, but
 // they share AGY_MCP_STATE_DIR and so must serialize through the on-disk locks).
-func twoManagers(t *testing.T) (*Manager, *Manager) {
+func twoManagers(t *testing.T) (m1, m2 *Manager) {
 	t.Helper()
 	dir := t.TempDir()
 	cfg := config.Config{StateDir: dir, MaxConcurrency: 4}
@@ -40,6 +40,29 @@ func TestAdmitExcludesAcrossManagers(t *testing.T) {
 	if outcome, err := m2.admit("cwd:/w"); err != nil || outcome != acquireOK {
 		t.Fatalf("m2.admit after m1.releaseKey = (%v, %v), want (acquireOK, nil)", outcome, err)
 	}
+}
+
+// TestAdmitEmptyKeyNotSerialized: an empty key has nothing to serialize on, so
+// admit must skip the cross-process lock entirely and never block a sibling. This
+// pins the key == "" short-circuit in admit/releaseKey that StartJob relies on for
+// the defensive no-cwd path.
+func TestAdmitEmptyKeyNotSerialized(t *testing.T) {
+	m1, m2 := twoManagers(t)
+
+	if outcome, err := m1.admit(""); err != nil || outcome != acquireOK {
+		t.Fatalf("m1.admit(\"\") = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+	// A sibling admitting an empty key is not blocked: empty keys do not serialize.
+	if outcome, err := m2.admit(""); err != nil || outcome != acquireOK {
+		t.Fatalf("m2.admit(\"\") while m1 holds an empty key = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+	// No cross-process lock fd was taken for the empty key in either process.
+	if len(m1.xlock.fds) != 0 || len(m2.xlock.fds) != 0 {
+		t.Fatalf("empty key must take no cross-process lock; fds = %d, %d", len(m1.xlock.fds), len(m2.xlock.fds))
+	}
+	// releaseKey on an empty key is a no-op on the lock side and must not panic.
+	m1.releaseKey("")
+	m2.releaseKey("")
 }
 
 // TestAdmitInProcessRefusalsStillApply: admit must preserve the in-process gate's

--- a/internal/manager/admit_linux_test.go
+++ b/internal/manager/admit_linux_test.go
@@ -104,6 +104,11 @@ func TestAdmitFailsClosedOnLockError(t *testing.T) {
 	if m.gate.keys["cwd:/w"] {
 		t.Fatal("admit must roll back the in-process key on a lock error")
 	}
+	// Rollback must also release the slot, not just the key: a leaked in-flight slot
+	// would silently lower the effective cap while the key map looks clean.
+	if m.gate.inFlight != 0 {
+		t.Fatalf("admit must roll back the in-flight count on a lock error; got %d", m.gate.inFlight)
+	}
 }
 
 // TestForceAdmitTakesCrossProcessLock: a restored job (whose detached supervisor

--- a/internal/manager/concurrency.go
+++ b/internal/manager/concurrency.go
@@ -6,8 +6,12 @@ import (
 )
 
 // gate enforces a global concurrency cap and per-key (conversation/cwd)
-// serialization so concurrent agy sessions cannot trigger the known
-// session-lock hang.
+// serialization so concurrent agy sessions cannot trigger the known session-lock
+// hang. It is in-process only; crossLock (keylock.go) extends the same per-key
+// serialization across sibling agy-mcp processes that share one state dir. The
+// Manager pairs them in admit/releaseKey/forceAdmit (admit.go). The global cap
+// stays per-process: in stdio mode each client session runs its own process and
+// enforces the cap independently.
 type gate struct {
 	mu       sync.Mutex
 	max      int

--- a/internal/manager/keylock.go
+++ b/internal/manager/keylock.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"crypto/sha256"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -82,5 +83,12 @@ func (c *crossLock) unlock(key string) {
 		return
 	}
 	delete(c.fds, key)
-	_ = f.Close()
+	// Closing the fd drops the flock. A close error should never happen for a lock
+	// file, but if it does the kernel may not have released the lock yet while this
+	// process has already forgotten the fd; log it so the regression surfaces rather
+	// than silently leaving the key un-releasable until process exit (which does free
+	// the lock).
+	if err := f.Close(); err != nil {
+		log.Printf("crosslock: close lock file for key %q: %v", key, err)
+	}
 }

--- a/internal/manager/keylock.go
+++ b/internal/manager/keylock.go
@@ -1,0 +1,86 @@
+package manager
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// crossLock provides per-key cross-process advisory locking via flock(2), so the
+// gate's per-key serialization holds across separate agy-mcp processes that share
+// one AGY_MCP_STATE_DIR. That sharing is the default in stdio mode, where every MCP
+// client session spawns its own agy-mcp process: the in-process gate (concurrency.go)
+// stops same-key concurrency within one process, and this stops it across processes,
+// closing the agy session-lock hang and the conversation-cache misattribution the
+// gate alone cannot prevent on a shared state dir.
+//
+// A lock is held by the manager process for the whole run: acquired alongside the
+// gate slot and released when the job ends. The held fd is kept open and stored
+// here; closing it drops the flock. Lock files are never unlinked, because removing
+// a flock file races (one process unlinks while another recreates, and both then
+// hold locks on different inodes for the same path), so the empty files are left in
+// place. They accumulate one per distinct conversation/cwd ever locked, each zero
+// bytes.
+type crossLock struct {
+	dir string
+	mu  sync.Mutex
+	fds map[string]*os.File // key -> open lock file; one entry per key this process holds
+}
+
+func newCrossLock(stateDir string) *crossLock {
+	return &crossLock{dir: filepath.Join(stateDir, "locks"), fds: map[string]*os.File{}}
+}
+
+// lockPath maps a gate key to its lock file. The key (a conversation id or an
+// absolute cwd) is hashed so an arbitrary path can neither escape the locks dir nor
+// collide with another key, and so sibling processes derive the same path for the
+// same key.
+func (c *crossLock) lockPath(key string) string {
+	return filepath.Join(c.dir, fmt.Sprintf("%x.lock", sha256.Sum256([]byte(key))))
+}
+
+// tryLock takes the cross-process lock for key without blocking. It returns
+// (true, nil) when the lock is acquired (the fd is retained until unlock),
+// (false, nil) when another process already holds it, and (false, err) on any other
+// failure, which the caller must treat as fail-closed: refuse the run rather than
+// proceed without cross-process exclusion. The gate never admits the same key twice
+// in one process, so tryLock is never called for a key this instance already holds
+// (which would leak the prior fd).
+func (c *crossLock) tryLock(key string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := os.MkdirAll(c.dir, 0o700); err != nil {
+		return false, fmt.Errorf("create locks dir: %w", err)
+	}
+	f, err := os.OpenFile(c.lockPath(key), os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return false, fmt.Errorf("open lock file: %w", err)
+	}
+	locked, err := flockExclusiveNB(f.Fd())
+	if err != nil {
+		_ = f.Close()
+		return false, fmt.Errorf("flock: %w", err)
+	}
+	if !locked {
+		_ = f.Close() // held by another process; drop our fd so it is not leaked
+		return false, nil
+	}
+	c.fds[key] = f
+	return true, nil
+}
+
+// unlock releases a key this instance holds by closing its fd, which drops the
+// flock. It is a no-op for a key not held here, so a caller that did not acquire
+// (because a sibling held it) can still call unlock unconditionally on release.
+func (c *crossLock) unlock(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	f, ok := c.fds[key]
+	if !ok {
+		return
+	}
+	delete(c.fds, key)
+	_ = f.Close()
+}

--- a/internal/manager/keylock.go
+++ b/internal/manager/keylock.go
@@ -47,11 +47,16 @@ func (c *crossLock) lockPath(key string) string {
 // (false, nil) when another process already holds it, and (false, err) on any other
 // failure, which the caller must treat as fail-closed: refuse the run rather than
 // proceed without cross-process exclusion. The gate never admits the same key twice
-// in one process, so tryLock is never called for a key this instance already holds
-// (which would leak the prior fd).
+// in one process, so tryLock is not expected to be called for a key this instance
+// already holds; the duplicate guard below enforces that invariant locally (rather
+// than silently overwriting and leaking the prior fd) should a future caller bypass
+// the gate.
 func (c *crossLock) tryLock(key string) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if _, held := c.fds[key]; held {
+		return false, fmt.Errorf("crosslock: key %q already held by this process", key)
+	}
 	if err := os.MkdirAll(c.dir, 0o700); err != nil {
 		return false, fmt.Errorf("create locks dir: %w", err)
 	}

--- a/internal/manager/keylock_linux.go
+++ b/internal/manager/keylock_linux.go
@@ -1,0 +1,22 @@
+package manager
+
+import (
+	"errors"
+	"syscall"
+)
+
+// flockExclusiveNB takes a non-blocking exclusive flock on fd. It returns
+// (true, nil) on success, (false, nil) when another open file description already
+// holds the lock (EWOULDBLOCK), and (false, err) on any other error. The flock is
+// associated with the open file description, so it is released when fd is closed.
+func flockExclusiveNB(fd uintptr) (bool, error) {
+	err := syscall.Flock(int(fd), syscall.LOCK_EX|syscall.LOCK_NB)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, syscall.EWOULDBLOCK):
+		return false, nil
+	default:
+		return false, err
+	}
+}

--- a/internal/manager/keylock_linux_test.go
+++ b/internal/manager/keylock_linux_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -61,6 +62,31 @@ func TestCrossLockUnlockUnheldKeyIsNoop(t *testing.T) {
 	b.unlock("conv:x")
 	if ok, _ := b.tryLock("conv:x"); ok {
 		t.Fatal("b must still be refused conv:x: a's hold survives b's no-op unlock")
+	}
+}
+
+// TestCrossLockHashesArbitraryKeys: a gate key is an absolute cwd or a conversation
+// id, so it can contain path separators and "..". Hashing the key into the filename
+// must keep the lock file inside the locks dir (no path escape) and still serialize
+// siblings, for both traversal-laden and very long keys.
+func TestCrossLockHashesArbitraryKeys(t *testing.T) {
+	dir := t.TempDir()
+	a := newCrossLock(dir)
+	b := newCrossLock(dir)
+
+	for _, key := range []string{
+		"cwd:/a/b/../../etc/passwd",
+		"cwd:" + strings.Repeat("/deep", 300),
+	} {
+		if got := filepath.Dir(a.lockPath(key)); got != a.dir {
+			t.Fatalf("lockPath(%q) escaped the locks dir: got dir %q, want %q", key, got, a.dir)
+		}
+		if ok, err := a.tryLock(key); err != nil || !ok {
+			t.Fatalf("a.tryLock(%q) = (%v, %v), want (true, nil)", key, ok, err)
+		}
+		if ok, err := b.tryLock(key); err != nil || ok {
+			t.Fatalf("b.tryLock(%q) must be refused while a holds it; got (%v, %v)", key, ok, err)
+		}
 	}
 }
 

--- a/internal/manager/keylock_linux_test.go
+++ b/internal/manager/keylock_linux_test.go
@@ -65,6 +65,25 @@ func TestCrossLockUnlockUnheldKeyIsNoop(t *testing.T) {
 	}
 }
 
+// TestCrossLockTryLockRejectsDuplicateHeldKey: locking a key this instance already
+// holds is a contract violation (the gate prevents it in production). The guard must
+// fail fast rather than overwrite and leak the prior fd, and the original hold must
+// survive intact.
+func TestCrossLockTryLockRejectsDuplicateHeldKey(t *testing.T) {
+	c := newCrossLock(t.TempDir())
+	if ok, err := c.tryLock("conv:x"); err != nil || !ok {
+		t.Fatalf("first tryLock = (%v, %v), want (true, nil)", ok, err)
+	}
+	if ok, err := c.tryLock("conv:x"); ok || err == nil {
+		t.Fatalf("duplicate tryLock = (%v, %v), want (false, error)", ok, err)
+	}
+	// The original hold is intact: unlock then re-lock succeeds.
+	c.unlock("conv:x")
+	if ok, err := c.tryLock("conv:x"); err != nil || !ok {
+		t.Fatalf("tryLock after unlock = (%v, %v), want (true, nil)", ok, err)
+	}
+}
+
 // TestCrossLockHashesArbitraryKeys: a gate key is an absolute cwd or a conversation
 // id, so it can contain path separators and "..". Hashing the key into the filename
 // must keep the lock file inside the locks dir (no path escape) and still serialize

--- a/internal/manager/keylock_linux_test.go
+++ b/internal/manager/keylock_linux_test.go
@@ -1,0 +1,81 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCrossLockExcludesAcrossInstances: two crossLock instances rooted at the
+// same state dir model two sibling agy-mcp processes that share AGY_MCP_STATE_DIR.
+// The second must be refused the key the first holds (the cross-process exclusion
+// the in-process gate alone cannot provide), and must succeed once it is released.
+func TestCrossLockExcludesAcrossInstances(t *testing.T) {
+	dir := t.TempDir()
+	a := newCrossLock(dir)
+	b := newCrossLock(dir)
+
+	ok, err := a.tryLock("cwd:/w")
+	if err != nil {
+		t.Fatalf("a.tryLock: unexpected error %v", err)
+	}
+	if !ok {
+		t.Fatal("a.tryLock should acquire a free key")
+	}
+
+	// A different instance (a sibling process) must not acquire the held key.
+	ok, err = b.tryLock("cwd:/w")
+	if err != nil {
+		t.Fatalf("b.tryLock: unexpected error %v", err)
+	}
+	if ok {
+		t.Fatal("b.tryLock must be refused while a holds the key")
+	}
+
+	// A distinct key is independent and still acquirable by the sibling.
+	if ok, err := b.tryLock("cwd:/other"); err != nil || !ok {
+		t.Fatalf("b.tryLock on a distinct key = (%v, %v), want (true, nil)", ok, err)
+	}
+
+	a.unlock("cwd:/w")
+
+	// Released: the sibling can now take it.
+	if ok, err := b.tryLock("cwd:/w"); err != nil || !ok {
+		t.Fatalf("b.tryLock after a.unlock = (%v, %v), want (true, nil)", ok, err)
+	}
+}
+
+// TestCrossLockUnlockUnheldKeyIsNoop: unlocking a key this instance never held
+// must not panic or disturb another holder. forceAdmit relies on this when a
+// restored job's lock could not be re-acquired (a sibling holds it), so the later
+// release must tolerate "no fd stored for this key".
+func TestCrossLockUnlockUnheldKeyIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	a := newCrossLock(dir)
+	b := newCrossLock(dir)
+
+	if ok, _ := a.tryLock("conv:x"); !ok {
+		t.Fatal("a should acquire conv:x")
+	}
+	// b never held conv:x; unlocking it must be a harmless no-op (not release a's).
+	b.unlock("conv:x")
+	if ok, _ := b.tryLock("conv:x"); ok {
+		t.Fatal("b must still be refused conv:x: a's hold survives b's no-op unlock")
+	}
+}
+
+// TestCrossLockFailsClosedOnUncreatableDir: when the locks directory cannot be
+// created (its parent is a regular file), tryLock returns an error so the caller
+// fails closed rather than running unprotected.
+func TestCrossLockFailsClosedOnUncreatableDir(t *testing.T) {
+	base := t.TempDir()
+	// A regular file where the state dir is expected: MkdirAll(base/file/locks) fails.
+	fileAsStateDir := filepath.Join(base, "file")
+	if err := os.WriteFile(fileAsStateDir, []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	c := newCrossLock(fileAsStateDir)
+	if ok, err := c.tryLock("cwd:/w"); err == nil || ok {
+		t.Fatalf("tryLock on an uncreatable locks dir = (%v, %v), want (false, error)", ok, err)
+	}
+}

--- a/internal/manager/keylock_other.go
+++ b/internal/manager/keylock_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package manager
+
+import "github.com/tphakala/agy-mcp/internal/proc"
+
+// flockExclusiveNB is unavailable off Linux. StartJob refuses to spawn on
+// unsupported platforms (proc.Supported) before any admission, and restore never
+// finds a live job there (processAlive is a stub), so this is never reached for a
+// real run; it exists only so the package compiles on macOS and Windows.
+func flockExclusiveNB(_ uintptr) (bool, error) { return false, proc.ErrUnsupported }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -24,9 +24,10 @@ import (
 // Manager coordinates jobs backed by an on-disk store.
 type Manager struct {
 	cfg       config.Config
-	store     jobStore // *jobstore.Store in production; an interface so tests can inject failures
-	gate      *gate    // serializes conflicting jobs and caps total concurrency
-	cacheFile string   // agy conversation cache (last_conversations.json); injectable for tests
+	store     jobStore   // *jobstore.Store in production; an interface so tests can inject failures
+	gate      *gate      // serializes conflicting jobs and caps total concurrency within this process
+	xlock     *crossLock // serializes same-key jobs across sibling processes sharing the state dir
+	cacheFile string     // agy conversation cache (last_conversations.json); injectable for tests
 
 	// pendingCaptures holds the job ids of fresh runs whose conversation-id
 	// capture is armed but not yet settled (the post-exit capture attempt has
@@ -71,6 +72,7 @@ func New(c config.Config) *Manager {
 		cfg:                  c,
 		store:                jobstore.New(c.StateDir),
 		gate:                 newGate(c.MaxConcurrency),
+		xlock:                newCrossLock(c.StateDir),
 		cacheFile:            cacheFile,
 		captureBudget:        2 * time.Second,
 		capturePoll:          100 * time.Millisecond,
@@ -310,9 +312,16 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}
 
 	key := keyFor(req)
-	switch outcome := m.gate.tryAcquire(key); outcome {
+	outcome, err := m.admit(key)
+	if err != nil {
+		// The cross-process lock could not be established (e.g. the locks dir is
+		// unwritable). Fail closed: starting without it could let a sibling process
+		// run a conflicting same-key job and re-expose the session-lock hang.
+		return Job{}, fmt.Errorf("acquire cross-process lock for this conversation or directory: %w", err)
+	}
+	switch outcome {
 	case acquireOK:
-		// Slot reserved; proceed to spawn below.
+		// Slot and cross-process lock reserved; proceed to spawn below.
 	case acquireKeyBusy:
 		return Job{}, fmt.Errorf("a conflicting agy job for this conversation or directory is already running")
 	case acquireAtCap:
@@ -363,7 +372,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	dir, err := m.store.Create(meta)
 	if err != nil {
 		m.pendingCaptures.Delete(id)
-		m.gate.release(key)
+		m.releaseKey(key)
 		return Job{}, fmt.Errorf("create job store entry: %w", err)
 	}
 
@@ -380,7 +389,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		// orphan; remove it now rather than leaving it for a later GarbageCollect.
 		_ = m.store.Remove(id)
 		m.pendingCaptures.Delete(id)
-		m.gate.release(key)
+		m.releaseKey(key)
 		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
 	}
 	// Record the supervisor PID (for liveness and cancel) and its start time (so a
@@ -403,7 +412,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 			_ = cmd.Wait()
 			_ = m.store.Remove(id)
 			m.pendingCaptures.Delete(id)
-			m.gate.release(key)
+			m.releaseKey(key)
 		}()
 		return Job{}, fmt.Errorf("record supervisor pid: %w", err)
 	}
@@ -423,7 +432,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		// Settle the capture (success or give-up) before releasing the key, so
 		// CapturePending=false means the reported status is final.
 		m.pendingCaptures.Delete(id)
-		m.gate.release(key)
+		m.releaseKey(key)
 	}()
 
 	return Job{ID: id, ConversationID: req.ConversationID, State: StateRunning}, nil
@@ -708,13 +717,14 @@ func (m *Manager) restoreEvaluate(l loadedJob) {
 	if !m.processAlive(l.meta) {
 		return // supervisor gone; GarbageCollect will reap it
 	}
-	// forceAcquire counts the job and holds its key unconditionally: a restored
-	// job is already running, so it must be tracked even past the cap (otherwise a
-	// new same-key run could start once a slot frees and run concurrently with it,
-	// the bypass this method prevents). A false return means another restored job
-	// already holds this key, so it is already watched.
+	// forceAdmit counts the job and holds its key unconditionally: a restored job is
+	// already running, so it must be tracked even past the cap (otherwise a new
+	// same-key run could start once a slot frees and run concurrently with it, the
+	// bypass this method prevents). It also best-effort re-takes the cross-process
+	// lock so sibling processes are blocked again across the restart. A false return
+	// means another restored job already holds this key, so it is already watched.
 	key := keyFor(reqFromMeta(l.meta))
-	if m.gate.forceAcquire(key) {
+	if m.forceAdmit(key) {
 		if l.meta.ConversationID == "" && !l.meta.CaptureDisabled {
 			// Mirror StartJob: arm the capture so pollers can tell this
 			// restored fresh run's id is still being settled.
@@ -756,7 +766,7 @@ func (m *Manager) watchRestored(meta jobstore.Meta, key string) {
 			m.captureFreshConversationID(&meta)
 		}
 		m.pendingCaptures.Delete(meta.ID)
-		m.gate.release(key)
+		m.releaseKey(key)
 	}()
 }
 


### PR DESCRIPTION
## Summary

The concurrency gate lived only in process memory and was reconciled against disk only once at startup (`RestoreGate`). In stdio mode every MCP client session spawns its own `agy-mcp` process, and all of them share one `AGY_MCP_STATE_DIR` and agy's `last_conversations.json`. A job started by a sibling process was therefore invisible to another process's in-memory gate, so:

- two sessions could run same-`cwd` fresh jobs concurrently, which is exactly the agy session-lock hang the gate exists to prevent;
- both runs snapshot/diff the same shared conversation-cache entry (keyed by `cwd`), so captured conversation ids could be misattributed;
- the global cap multiplied per process.

This adds a **per-key cross-process advisory lock** (`flock` on a file under `<state-dir>/locks/<sha256(key)>.lock`), held by the manager for the run's duration and paired with the in-process gate in a small `admit`/`releaseKey`/`forceAdmit` layer:

- `crossLock` (`keylock.go`, with the `flock` syscall split into `keylock_linux.go` / `keylock_other.go`) owns the lock files. fds are kept open for the held key and closed on release; lock files are never unlinked (unlinking a `flock` file races), so they accumulate as zero-byte files, one per distinct `cwd`/conversation.
- The `gate` (`concurrency.go`) is unchanged in behavior; it stays a pure in-memory admission controller. The cross-process layer wraps it.
- The `cwd` key is held across the **whole capture window** (pre-run snapshot through the post-exit capture+persist), so sibling processes can neither start a conflicting run nor race the shared cache diff.
- Acquisition **fails closed**: if the lock cannot be established the run is refused rather than run unprotected.
- Restore re-takes the lock best-effort for jobs whose detached supervisor outlived a manager restart.

### Scope / design notes for review

- **The global cap stays per-process by design.** A true cross-process cap needs a shared counting semaphore; the per-key lock already fixes the actual correctness bugs (the hang and the cache misattribution). The README now documents the per-process cap explicitly.
- **`SetConversationID` needs no cross-process lock.** Job ids are globally unique, so two processes never write the same `meta.json`; only the shared `cwd` cache needed cross-process protection, which the `cwd` flock provides.
- **Manager-held, not supervisor-held.** The manager must diff the cache *after* the supervisor exits, so the lock has to outlive the supervisor; holding it in the manager keeps the capture window protected. The trade-off is a narrow window during a manager restart (documented in the README) where a sibling could race the same key before the new manager re-takes the lock.
- **`flock` requires a local filesystem.** On NFS (where `flock` may be a no-op or fail) a run fails closed rather than running unprotected; the README notes the state dir should be local.

## Related Issues

Fixes #25

## Test Plan

- [x] `go build ./...`, `GOOS=darwin go build ./...`, `GOOS=windows go build ./...` (non-Linux stub compiles)
- [x] `go vet ./...` clean, `golangci-lint run ./...` clean (v2.11.4)
- [x] `go test ./... -race` green
- [x] New unit tests model two sibling processes via two `crossLock`/`Manager` instances sharing one state dir: cross-process exclusion, fail-closed on an uncreatable locks dir, the restore best-effort path with a sibling-held lock, the empty-key short-circuit, and path-safety hashing of traversal/long keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance on how run serialization and concurrency work across restarts and across separate manager processes in stdio mode, including advisory lock behavior, required filesystem support, and restart timing caveats.

* **New Features**
  * Added per-key cross-process admission control to prevent conflicting runs with the same key across concurrent manager instances (while keeping the existing per-process concurrency cap).

* **Tests**
  * Added Linux cross-process and failure-mode test coverage for admission, empty-key behavior, lock release correctness, and fail-closed behavior when locking can’t be initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->