### PR TITLE
test: fractional fake-agy sleeps and bounded testutil subprocess runs

### DIFF
--- a/internal/manager/job_linux_test.go
+++ b/internal/manager/job_linux_test.go
@@ -190,7 +190,7 @@ func TestStartJobSerializesEquivalentCwdSpellings(t *testing.T) {
 	dir := t.TempDir()
 	// A sleeping fake agy keeps the first supervisor alive, so its gate key stays
 	// held while the second run is attempted.
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", SleepSecs: 30})
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Sleep: 30 * time.Second})
 	c := config.Config{
 		AgyPath:        "/usr/bin/agy",
 		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy}),

--- a/internal/mcptools/run_sync_linux_test.go
+++ b/internal/mcptools/run_sync_linux_test.go
@@ -159,7 +159,7 @@ func TestAgyRunSyncOverrunReturnsJobID(t *testing.T) {
 	// The sleep must comfortably outlast the 100ms wait cap even on a stalled
 	// CI runner, or the job finishes before the cap and the running assertion
 	// flakes.
-	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "LATE OK", Exit: 0, SleepSecs: 5})
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "LATE OK", Exit: 0, Sleep: 2 * time.Second})
 	cs := connect(t, mgr, nil)
 
 	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
@@ -188,7 +188,7 @@ func TestAgyRunSyncOverrunReturnsJobID(t *testing.T) {
 func TestAgyRunSyncSendsProgress(t *testing.T) {
 	// One second spans several 250ms poll ticks, so at least one progress
 	// notification fires while the job runs.
-	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "SLOW OK", Exit: 0, SleepSecs: 1})
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "SLOW OK", Exit: 0, Sleep: 1 * time.Second})
 
 	var mu sync.Mutex
 	var tokens []any
@@ -238,7 +238,7 @@ func TestAgyRunSyncSendsProgress(t *testing.T) {
 }
 
 func TestAgyRunSyncClientCancelKeepsJobAlive(t *testing.T) {
-	mgr, stateDir := newTestManager(t, testutil.FakeAgy{Stdout: "LATE OK", Exit: 0, SleepSecs: 5})
+	mgr, stateDir := newTestManager(t, testutil.FakeAgy{Stdout: "LATE OK", Exit: 0, Sleep: 2 * time.Second})
 	cs := connect(t, mgr, nil)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -102,7 +102,7 @@ func TestSupervisorRecordsNonZeroExit(t *testing.T) {
 func TestSupervisorHardTimeoutKillsAgy(t *testing.T) {
 	dir := t.TempDir()
 	// A fake agy that would sleep far longer than the hard timeout.
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "should not finish", SleepSecs: 30})
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "should not finish", Sleep: 30 * time.Second})
 	writeMeta(t, dir, jobstore.Meta{
 		ID: "j", AgyPath: agy, Args: []string{"-p", "x"},
 		StartedAt: time.Now(), Timeout: 500 * time.Millisecond,

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -6,14 +6,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // FakeAgy configures a stand-in agy binary for tests.
 type FakeAgy struct {
-	Stdout    string // printed to stdout, then process exits
-	Stderr    string // printed to stderr
-	Exit      int    // exit code
-	SleepSecs int    // seconds to sleep before printing (simulate a long run)
+	Stdout string        // printed to stdout, then process exits
+	Stderr string        // printed to stderr
+	Exit   int           // exit code
+	Sleep  time.Duration // delay before printing (simulate a long run); bash sleep honors fractions
 	// IgnoreSIGTERM makes the script trap and ignore SIGTERM and loop forever, so
 	// only SIGKILL can stop it. Used to exercise the supervisor's SIGKILL
 	// escalation after killGrace. Mutually exclusive with Stdout/Stderr/Exit
@@ -51,11 +52,11 @@ func WriteFakeAgy(t *testing.T, cfg FakeAgy) string {
 		t.Fatalf("write fake agy stderr: %v", err)
 	}
 	script := fmt.Sprintf(`#!/usr/bin/env bash
-sleep %d
+sleep %.3f
 cat %q
 cat %q 1>&2
 exit %d
-`, cfg.SleepSecs, outPath, errPath, cfg.Exit)
+`, cfg.Sleep.Seconds(), outPath, errPath, cfg.Exit)
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake agy: %v", err)
 	}

--- a/internal/testutil/fakeagy_test.go
+++ b/internal/testutil/fakeagy_test.go
@@ -1,27 +1,46 @@
 package testutil
 
 import (
-	"errors"
-	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFakeAgyEmitsStdoutAndExit(t *testing.T) {
 	path := WriteFakeAgy(t, FakeAgy{Stdout: "hello world", Exit: 0})
-	out, err := exec.Command(path, "-p", "ignored").Output()
-	if err != nil {
-		t.Fatalf("run: %v", err)
+	res := runScript(t, 10*time.Second, path, "-p", "ignored")
+	if res.ExitCode != 0 {
+		t.Fatalf("exit = %d, want 0; stderr: %q", res.ExitCode, res.Stderr)
 	}
-	if got := strings.TrimSpace(string(out)); got != "hello world" {
+	if got := strings.TrimSpace(res.Stdout); got != "hello world" {
 		t.Fatalf("stdout = %q, want %q", got, "hello world")
 	}
 }
 
 func TestFakeAgyNonZeroExit(t *testing.T) {
 	path := WriteFakeAgy(t, FakeAgy{Stderr: "boom", Exit: 3})
-	err := exec.Command(path).Run()
-	if ee, ok := errors.AsType[*exec.ExitError](err); !ok || ee.ExitCode() != 3 {
-		t.Fatalf("exit = %v, want code 3", err)
+	res := runScript(t, 10*time.Second, path)
+	if res.ExitCode != 3 {
+		t.Fatalf("exit = %d, want 3; stderr: %q", res.ExitCode, res.Stderr)
+	}
+	if got := strings.TrimSpace(res.Stderr); got != "boom" {
+		t.Fatalf("stderr = %q, want %q", got, "boom")
+	}
+}
+
+// TestFakeAgyAppliesFractionalSleep: a sub-second Sleep must be honored as a real
+// fractional delay (bash sleep accepts fractions), proving the field is a duration
+// rather than whole seconds. Lower bound only, since a sleep is never shorter than
+// requested; the generous slack keeps it robust on slow CI.
+func TestFakeAgyAppliesFractionalSleep(t *testing.T) {
+	path := WriteFakeAgy(t, FakeAgy{Stdout: "ok", Sleep: 150 * time.Millisecond})
+	start := time.Now()
+	res := runScript(t, 10*time.Second, path)
+	elapsed := time.Since(start)
+	if res.ExitCode != 0 {
+		t.Fatalf("exit = %d, want 0; stderr: %q", res.ExitCode, res.Stderr)
+	}
+	if elapsed < 120*time.Millisecond {
+		t.Fatalf("elapsed %s, want >= ~150ms; fractional sleep not applied", elapsed)
 	}
 }

--- a/internal/testutil/fakesupervisor_linux_test.go
+++ b/internal/testutil/fakesupervisor_linux_test.go
@@ -2,18 +2,19 @@ package testutil
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // runSupervisor executes the fake supervisor the way the manager does
-// (`<exe> run-job <jobdir>`) and returns the job dir.
+// (`<exe> run-job <jobdir>`) and returns the job dir. It runs under a hard timeout
+// so a hung script fails the test with diagnostics instead of stalling the suite.
 func runSupervisor(t *testing.T, sup string) string {
 	t.Helper()
 	dir := t.TempDir()
-	if err := exec.Command(sup, "run-job", dir).Run(); err != nil {
-		t.Fatalf("run fake supervisor: %v", err)
+	if res := runScript(t, 10*time.Second, sup, "run-job", dir); res.ExitCode != 0 {
+		t.Fatalf("fake supervisor exited %d; stderr: %q", res.ExitCode, res.Stderr)
 	}
 	return dir
 }

--- a/internal/testutil/runscript_test.go
+++ b/internal/testutil/runscript_test.go
@@ -1,0 +1,49 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// runScriptResult captures the outcome of running a generated test script.
+type runScriptResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// runScript runs a generated test script (a WriteFakeAgy / WriteFakeSupervisor
+// output) under a hard timeout, capturing stdout and stderr separately. A timeout
+// fails the test immediately with the captured stderr, so a hung script surfaces
+// diagnostics instead of stalling the whole suite. A non-zero exit is returned in
+// ExitCode (not a test failure) so callers can assert on it; any other spawn error
+// fails the test with stderr included.
+func runScript(t *testing.T, timeout time.Duration, path string, args ...string) runScriptResult {
+	t.Helper()
+	// Derive from t.Context() so the subprocess is bounded by both the timeout and
+	// the test's lifetime: if the test ends first, the run is cancelled too.
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("script %s timed out after %s; stderr:\n%s", path, timeout, stderr.String())
+	}
+	res := runScriptResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if err == nil {
+		return res
+	}
+	if ee, ok := errors.AsType[*exec.ExitError](err); ok {
+		res.ExitCode = ee.ExitCode()
+		return res
+	}
+	t.Fatalf("run script %s: %v; stderr:\n%s", path, err, stderr.String())
+	return runScriptResult{}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -87,7 +87,7 @@ func TestRunJobCancelViaSignal(t *testing.T) {
 	}
 	// A fake agy that sleeps far longer than the test; with no timeout in meta,
 	// only an external cancel signal can stop it.
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", SleepSecs: 60})
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Sleep: 60 * time.Second})
 	jobDir := t.TempDir()
 	meta := jobstore.Meta{ID: filepath.Base(jobDir), AgyPath: agy, Args: []string{"-p", "x"}}
 	b, _ := jsonMarshalForTest(meta)


### PR DESCRIPTION
## Summary

Two of the remaining test-hygiene items from #34.

**Fractional fake-agy sleeps.** `FakeAgy.SleepSecs` (whole-second `int`) becomes `Sleep time.Duration`, emitted as a fractional bash `sleep %.3f` via `.Seconds()`, exactly the pattern `FakeSupervisor.CacheDelay` already uses. This lets timing tests use sub-second waits instead of burning whole seconds:

- The two `agy_run_sync` overrun/cancel tests drop from `SleepSecs: 5` to `Sleep: 2 * time.Second`. Their wait cap is `100ms`, so the job must still be running when the wait returns; 2s keeps a 20x margin (verified non-flaky under `-race -count=5`), and the follow-up `waitForDone(..., 15s)` gives the job room to finish.
- The progress test keeps `1 * time.Second` because it must span several 250ms progress-poll ticks.
- Tests that are killed early by cancel or the hard timeout (the 60s/30s sleeps) keep their long durations as pure retypes; they never wait the full sleep, so they do not slow the suite.

**Bounded testutil subprocess self-tests.** A new `runScript` helper runs generated fake-agy / fake-supervisor scripts via `exec.CommandContext` with a hard timeout (derived from `t.Context()`, so the run is also bounded by the test's lifetime) and captures stdout/stderr separately. A timeout fails the test with the captured stderr, so a hung or crashing generated script surfaces diagnostics instead of stalling the whole suite. The fake-agy/fake-supervisor self-tests now go through it, and `TestFakeAgyNonZeroExit` additionally asserts the captured stderr.

## Related Issues

Relates to #34 (the `FakeAgy.SleepSecs -> time.Duration` and testutil subprocess timeout/stderr items). The remaining `waitFor` helper + parameterized manager-builder consolidation is intentionally left for its own focused pass.

## Test Plan

- [x] `go test ./... -race` green; timing tests pass under `-race -count=5`
- [x] `go vet ./...` clean, `golangci-lint run ./...` clean (incl. the repo's ruleguard `TestingContext` rule, which is why the helper uses `t.Context()`)
- [x] `GOOS=darwin` / `GOOS=windows go build ./...` (the platform-neutral self-tests run on the macOS CI job; BSD `sleep` accepts fractional seconds)
- [x] New `TestFakeAgyAppliesFractionalSleep` pins the fractional-sleep behavior (lower-bound timing assertion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to support precise timing configuration with standard duration types and improved subprocess timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->