### PR TITLE
Port async job supervision to Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build and test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -29,16 +29,18 @@ jobs:
         with:
           go-version-file: go.mod
       # build + vet on every OS proves the package compiles cross-platform (macOS gets
-      # the unsupported-platform stubs). Tests run job supervision, which is Linux only,
-      # so they (and the Windows cross-compile check) run on the ubuntu job.
+      # the unsupported-platform stubs). Job supervision is implemented on Linux and
+      # Windows, so both run the test suite; macOS only builds and vets the stubs.
       - run: go build ./...
       - run: go vet ./...
       - name: Test (race)
         if: matrix.os == 'ubuntu-latest'
         run: go test ./... -race
-      - name: Windows cross-compile
-        if: matrix.os == 'ubuntu-latest'
-        run: GOOS=windows go build ./...
+      # No -race on Windows: the race detector needs a cgo C toolchain that the
+      # windows-latest runner does not provide on PATH.
+      - name: Test (Windows)
+        if: matrix.os == 'windows-latest'
+        run: go test ./...
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Two transports run the same core:
 
 - The `agy` binary on `PATH` (or configured explicitly via `AGY_MCP_AGY_PATH`). agy 1.0.9 or newer is recommended (see the continuation note below).
 - Go 1.26+ to build.
-- The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) relies on process groups, `/proc`, and the kernel boot id, so it runs on Linux only; on macOS and Windows those tools return a clear "job supervision is only supported on Linux" error, while stdio/HTTP serving, `list_models`, and `list_sessions` work everywhere.
+- The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) is implemented on **Linux** (process groups, `/proc`, the kernel boot id) and **Windows** (Job Objects, `OpenProcess` + process creation time, `LockFileEx`). On **macOS** those async tools return a clear "job supervision is only supported on Linux and Windows" error, while stdio/HTTP serving, `list_models`, and `list_sessions` work everywhere.
+
+  Windows behaves the same as Linux with two documented differences:
+  - **Cancel and hard timeout are hard kills.** Linux sends agy `SIGTERM` and waits a 10s grace before `SIGKILL`; Windows has no equivalent signal for a detached process, so `TerminateJobObject` ends the whole process tree immediately with no flush window.
+  - **Cancel is delivered via a sentinel file, not a signal.** The manager writes a `cancel` file into the job directory and the supervisor polls for it (a few hundred ms), since Windows cannot signal an arbitrary process. Liveness uses the process creation time (an absolute wall-clock value) to defend against PID recycling, which subsumes the Linux boot-id check across reboots.
 
 > Note: every job spawns a fresh `agy` process, which on startup launches whatever MCP servers are configured in agy's own `mcp_config.json`. Peer-review and automation runs usually do not need those servers, and a slow or hanging one adds latency to every job. agy 1.0.7+ bounds this with a per-server launch `timeout` (set `-1` to disable it). If startup is slow, give the unneeded servers a `timeout` in agy's `mcp_config.json`, or point agy at a trimmed config.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
+	golang.org/x/sys v0.41.0
 )
 
 require (
@@ -13,5 +14,4 @@ require (
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 )

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package config
 
 import (

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -27,7 +27,7 @@ type Meta struct {
 	Prompt         string    `json:"prompt"`
 	StartedAt      time.Time `json:"started_at"`
 	PID            int       `json:"pid"`
-	StartTimeTicks uint64    `json:"start_time_ticks,omitempty"` // supervisor /proc start time; 0 = unknown
+	StartTimeTicks uint64    `json:"start_time_ticks,omitempty"` // supervisor start time (Linux /proc ticks, Windows FILETIME); 0 = unknown
 	BootID         string    `json:"boot_id"`
 	CwdUUIDBefore  string    `json:"cwd_uuid_before,omitempty"`
 	// CaptureDisabled marks a fresh run whose pre-run cache snapshot could not
@@ -57,6 +57,7 @@ const (
 	OutFile      = "out"       // captured agy stdout
 	ErrFile      = "err"       // captured agy stderr
 	ExitCodeFile = "exit_code" // completion sentinel
+	CancelFile   = "cancel"    // manager -> supervisor cancel request sentinel
 )
 
 // MetaPath, OutPath, ErrPath, and ExitCodePath join a job directory with the
@@ -67,6 +68,12 @@ func MetaPath(dir string) string     { return filepath.Join(dir, MetaFile) }
 func OutPath(dir string) string      { return filepath.Join(dir, OutFile) }
 func ErrPath(dir string) string      { return filepath.Join(dir, ErrFile) }
 func ExitCodePath(dir string) string { return filepath.Join(dir, ExitCodeFile) }
+
+// CancelPath is the manager -> supervisor cancel sentinel in a job directory.
+// On Windows the manager creates this file to request cancellation and the
+// supervisor polls for it (Windows has no POSIX signal to deliver to an
+// arbitrary process); on Linux cancel is delivered as SIGTERM instead.
+func CancelPath(dir string) string { return filepath.Join(dir, CancelFile) }
 
 // LoadDir reads and parses meta.json directly from a job directory. The
 // supervisor knows only the job dir (not the store root or the id), so this

--- a/internal/manager/cancel.go
+++ b/internal/manager/cancel.go
@@ -2,29 +2,31 @@ package manager
 
 import (
 	"fmt"
-	"syscall"
-
-	"github.com/tphakala/agy-mcp/internal/proc"
 )
 
 // Cancel asks the job's supervisor to terminate its agy child. The supervisor
-// forwards SIGTERM to agy and writes the exit-code sentinel, so the job ends in
-// a definite "cancelled" state. If the supervisor is no longer alive (already
-// exited, or a stale PID from a previous boot), Cancel is a no-op success and
-// Status reports the terminal state from disk.
+// then terminates agy and writes the exit-code sentinel, so the job ends in a
+// definite "cancelled" state. If the supervisor is no longer alive (already
+// exited, or a stale PID), Cancel is a no-op success and Status reports the
+// terminal state from disk.
+//
+// How the request reaches the supervisor is platform-specific (requestCancel):
+// Linux forwards SIGTERM to the supervisor PID; Windows writes a cancel sentinel
+// file the supervisor polls for, since Windows has no POSIX signal to deliver to
+// an arbitrary process.
 func (m *Manager) Cancel(id string) error {
 	meta, err := m.store.Load(id)
 	if err != nil {
 		return fmt.Errorf("load job %s to cancel: %w", id, err)
 	}
-	// Confirm the recorded PID is still our supervisor (boot id plus /proc comm)
-	// before signaling, so a recycled PID is never sent SIGTERM. proc.Signal treats
-	// an already-exited pid (ESRCH) as success.
+	// Confirm the recorded PID is still our supervisor before acting, so a recycled
+	// PID is never cancelled. requestCancel tolerates a supervisor that exits
+	// between this check and the request.
 	if !m.processAlive(meta) {
 		return nil
 	}
-	if err := proc.Signal(meta.PID, syscall.SIGTERM); err != nil {
-		return fmt.Errorf("signal supervisor: %w", err)
+	if err := m.requestCancel(meta); err != nil {
+		return fmt.Errorf("request supervisor cancel: %w", err)
 	}
 	return nil
 }

--- a/internal/manager/cancel_linux.go
+++ b/internal/manager/cancel_linux.go
@@ -1,0 +1,15 @@
+package manager
+
+import (
+	"syscall"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/proc"
+)
+
+// requestCancel forwards SIGTERM to the supervisor, which its signal handler turns
+// into a graceful cancel of agy (SIGTERM, then SIGKILL after a grace window).
+// proc.Signal treats an already-exited PID (ESRCH) as success.
+func (m *Manager) requestCancel(meta jobstore.Meta) error {
+	return proc.Signal(meta.PID, syscall.SIGTERM)
+}

--- a/internal/manager/cancel_other.go
+++ b/internal/manager/cancel_other.go
@@ -1,0 +1,11 @@
+//go:build !linux && !windows
+
+package manager
+
+import "github.com/tphakala/agy-mcp/internal/jobstore"
+
+// requestCancel is never reached on unsupported platforms: proc.Supported is
+// false there, so no job is ever started and processAlive always reports false,
+// making Cancel return before it calls this. The stub exists so the package
+// compiles.
+func (m *Manager) requestCancel(_ jobstore.Meta) error { return nil }

--- a/internal/manager/cancel_windows.go
+++ b/internal/manager/cancel_windows.go
@@ -17,9 +17,22 @@ func (m *Manager) requestCancel(meta jobstore.Meta) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(jobstore.CancelPath(dir), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	// Create the sentinel atomically (temp file + rename), matching the rest of the
+	// job-dir contract (meta.json, exit_code). The supervisor only checks the file's
+	// existence, so an empty file is already a valid signal; the rename additionally
+	// keeps any future content-reading consumer from ever seeing a half-written file.
+	tmp, err := os.CreateTemp(dir, "cancel-*.tmp")
 	if err != nil {
 		return err
 	}
-	return f.Close()
+	tmpName := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, jobstore.CancelPath(dir)); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
 }

--- a/internal/manager/cancel_windows.go
+++ b/internal/manager/cancel_windows.go
@@ -1,0 +1,25 @@
+package manager
+
+import (
+	"os"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// requestCancel writes the cancel sentinel file the supervisor polls for. Windows
+// has no POSIX signal to deliver to an arbitrary process, so the manager and
+// supervisor communicate the cancel through the shared on-disk job dir instead.
+// The supervisor only checks for the file's existence, so no content or atomic
+// write is needed; the file persists until the job dir is removed, so a cancel
+// requested before the supervisor starts polling is never lost.
+func (m *Manager) requestCancel(meta jobstore.Meta) error {
+	dir, err := m.store.Dir(meta.ID)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(jobstore.CancelPath(dir), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/internal/manager/cancel_windows_test.go
+++ b/internal/manager/cancel_windows_test.go
@@ -1,0 +1,53 @@
+package manager
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// TestCancelWritesSentinelWhenAlive: on Windows the manager requests a cancel by
+// writing the sentinel file the supervisor polls for, so Cancel of a live job
+// must create it.
+func TestCancelWritesSentinelWhenAlive(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4})
+	cmd := startSleeper(t) // stands in for a live supervisor
+	ticks, ok := readStartTimeTicks(cmd.Process.Pid)
+	if !ok {
+		t.Fatal("could not read creation time for the live process")
+	}
+	dir, err := m.store.Create(jobstore.Meta{
+		ID: "j", PID: cmd.Process.Pid, StartTimeTicks: ticks, BootID: readBootID(), StartedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Cancel("j"); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if _, err := os.Stat(jobstore.CancelPath(dir)); err != nil {
+		t.Fatalf("cancel sentinel not written: %v", err)
+	}
+}
+
+// TestCancelDeadSupervisorNoOp: when the recorded supervisor is no longer alive,
+// Cancel is a no-op success and must not write a sentinel (there is nothing to
+// cancel; Status reports the terminal state from disk).
+func TestCancelDeadSupervisorNoOp(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4})
+	dir, err := m.store.Create(jobstore.Meta{
+		ID: "j", PID: 999999, StartTimeTicks: 12345, BootID: readBootID(), StartedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Cancel("j"); err != nil {
+		t.Fatalf("Cancel of a dead supervisor must be a no-op success, got %v", err)
+	}
+	if _, err := os.Stat(jobstore.CancelPath(dir)); err == nil {
+		t.Fatal("Cancel must not write a sentinel for a dead supervisor")
+	}
+}

--- a/internal/manager/keylock_other.go
+++ b/internal/manager/keylock_other.go
@@ -1,11 +1,12 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package manager
 
 import "github.com/tphakala/agy-mcp/internal/proc"
 
-// flockExclusiveNB is unavailable off Linux. StartJob refuses to spawn on
-// unsupported platforms (proc.Supported) before any admission, and restore never
-// finds a live job there (processAlive is a stub), so this is never reached for a
-// real run; it exists only so the package compiles on macOS and Windows.
+// flockExclusiveNB has no implementation on platforms without supervision (e.g.
+// macOS); Linux uses flock and Windows uses LockFileEx (keylock_windows.go).
+// StartJob refuses to spawn on unsupported platforms (proc.Supported) before any
+// admission, and restore never finds a live job there (processAlive is a stub),
+// so this is never reached for a real run; it exists only so the package compiles.
 func flockExclusiveNB(_ uintptr) (bool, error) { return false, proc.ErrUnsupported }

--- a/internal/manager/keylock_windows.go
+++ b/internal/manager/keylock_windows.go
@@ -1,0 +1,34 @@
+package manager
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// flockExclusiveNB takes a non-blocking exclusive lock on the file handle behind
+// fd via LockFileEx, the Windows analog of the Linux flock. It returns (true, nil)
+// on success, (false, nil) when another handle already holds the lock
+// (ERROR_LOCK_VIOLATION, the LOCKFILE_FAIL_IMMEDIATELY result), and (false, err)
+// on any other error. The lock covers a fixed one-byte range so every process
+// contends on the same bytes, and Windows releases it when the handle is closed,
+// matching the Linux "closing the fd drops the lock" model crossLock relies on.
+func flockExclusiveNB(fd uintptr) (bool, error) {
+	var overlapped windows.Overlapped // offset 0
+	err := windows.LockFileEx(
+		windows.Handle(fd),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, // reserved
+		1, // bytesLow: lock one byte
+		0, // bytesHigh
+		&overlapped,
+	)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, windows.ERROR_LOCK_VIOLATION):
+		return false, nil
+	default:
+		return false, err
+	}
+}

--- a/internal/manager/keylock_windows_test.go
+++ b/internal/manager/keylock_windows_test.go
@@ -1,0 +1,69 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFlockExclusiveNBContention: a second handle to the same file cannot take the
+// exclusive lock while the first holds it, and can once the first handle closes
+// (the release-on-close behavior crossLock relies on).
+func TestFlockExclusiveNBContention(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "k.lock")
+	f1, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Guard against a fatal between here and the explicit Close below: an open
+	// handle would block t.TempDir's RemoveAll on Windows. A double close is benign.
+	t.Cleanup(func() { _ = f1.Close() })
+	ok, err := flockExclusiveNB(f1.Fd())
+	if err != nil || !ok {
+		t.Fatalf("first lock: ok=%v err=%v, want true,nil", ok, err)
+	}
+
+	f2, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f2.Close() }()
+	ok, err = flockExclusiveNB(f2.Fd())
+	if err != nil || ok {
+		t.Fatalf("contended lock: ok=%v err=%v, want false,nil", ok, err)
+	}
+
+	// Closing the first handle releases the lock, so the second can now take it.
+	if err := f1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ok, err = flockExclusiveNB(f2.Fd())
+	if err != nil || !ok {
+		t.Fatalf("lock after release: ok=%v err=%v, want true,nil", ok, err)
+	}
+}
+
+// TestCrossLockSerializesAcrossInstances: two crossLock instances sharing a state
+// dir (standing in for two agy-mcp processes) cannot both hold the same key, and
+// the key frees once the holder unlocks.
+func TestCrossLockSerializesAcrossInstances(t *testing.T) {
+	dir := t.TempDir()
+	a := newCrossLock(dir)
+	b := newCrossLock(dir)
+	const key = "conv-123"
+
+	got, err := a.tryLock(key)
+	if err != nil || !got {
+		t.Fatalf("a.tryLock: got=%v err=%v, want true,nil", got, err)
+	}
+	got, err = b.tryLock(key)
+	if err != nil || got {
+		t.Fatalf("b.tryLock while a holds it: got=%v err=%v, want false,nil", got, err)
+	}
+	a.unlock(key)
+	got, err = b.tryLock(key)
+	if err != nil || !got {
+		t.Fatalf("b.tryLock after a released: got=%v err=%v, want true,nil", got, err)
+	}
+	b.unlock(key)
+}

--- a/internal/manager/liveness_other.go
+++ b/internal/manager/liveness_other.go
@@ -1,12 +1,13 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package manager
 
 import "github.com/tphakala/agy-mcp/internal/jobstore"
 
-// Non-Linux liveness stubs. Real liveness reads the kernel boot id and /proc, which only
-// exist on Linux. StartJob refuses to spawn on unsupported platforms, so these are never
-// reached for a live job; they exist so the package compiles on macOS and Windows.
+// Liveness stubs for platforms with no supervision implementation (e.g. macOS).
+// Linux reads the kernel boot id and /proc; Windows queries the process via
+// Win32 (liveness_windows.go). StartJob refuses to spawn on unsupported platforms,
+// so these are never reached for a live job; they exist so the package compiles.
 
 func readBootID() string { return "" }
 

--- a/internal/manager/liveness_windows.go
+++ b/internal/manager/liveness_windows.go
@@ -1,0 +1,109 @@
+package manager
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"golang.org/x/sys/windows"
+)
+
+// readBootID has no kernel-boot-id analog on Windows, and none is needed:
+// readStartTimeTicks returns an absolute wall-clock creation time that already
+// differs for a PID recycled after a reboot, so boot pinning is subsumed. It
+// returns a fixed non-empty sentinel (rather than "") so StartJob's "boot id
+// unreadable; cross-boot liveness degraded" warning, which is meaningful only for
+// the Linux boot-relative start time, stays dormant here.
+func readBootID() string { return "windows" }
+
+// readStartTimeTicks returns pid's creation time as a uint64 FILETIME (100ns
+// ticks since 1601-01-01 UTC). Being absolute wall-clock, it uniquely pins a
+// process across reboots, so a recycled PID never matches the original's ticks.
+// ok is false on any failure, so a transient error is never mistaken for a
+// recycled PID: callers only act on a successful read.
+func readStartTimeTicks(pid int) (uint64, bool) {
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return 0, false
+	}
+	defer func() { _ = windows.CloseHandle(h) }()
+	return creationTicks(h)
+}
+
+// creationTicks reads the process creation time from an open handle as a packed
+// uint64 FILETIME.
+func creationTicks(h windows.Handle) (uint64, bool) {
+	var creation, exit, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(h, &creation, &exit, &kernel, &user); err != nil {
+		return 0, false
+	}
+	return uint64(creation.HighDateTime)<<32 | uint64(creation.LowDateTime), true
+}
+
+// processAlive reports whether the job's recorded supervisor PID is still that
+// same live supervisor process. It opens the PID, rejects it when the recorded
+// creation time no longer matches (PID recycled to a different process), confirms
+// the process has not exited, and, only when no creation time was recorded, falls
+// back to matching the image name against the supervisor executable.
+func (m *Manager) processAlive(meta jobstore.Meta) bool {
+	if meta.PID <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.SYNCHRONIZE, false, uint32(meta.PID))
+	if err != nil {
+		return false // no such PID (or inaccessible): not our live supervisor
+	}
+	defer func() { _ = windows.CloseHandle(h) }()
+
+	// A recorded creation time that no longer matches proves the PID was recycled to
+	// a different process. When it matches (or a transient read fails) fall through
+	// to the still-running check; a definite mismatch is authoritative.
+	if meta.StartTimeTicks != 0 {
+		if cur, ok := creationTicks(h); ok && cur != meta.StartTimeTicks {
+			return false
+		}
+	}
+	// WaitForSingleObject signals (WAIT_OBJECT_0) once the process has exited;
+	// WAIT_TIMEOUT means it is still running.
+	event, err := windows.WaitForSingleObject(h, 0)
+	if err != nil || event != uint32(windows.WAIT_TIMEOUT) {
+		return false
+	}
+	// Without a recorded creation time (older meta, or a transient stat failure)
+	// confirm identity by image name, mirroring the Linux comm fallback.
+	if meta.StartTimeTicks == 0 {
+		return sameImage(h, m.cfg.SupervisorExe)
+	}
+	return true
+}
+
+// sameImage reports whether the process behind h has the same executable
+// basename as exe, the Windows analog of the Linux /proc/<pid>/comm check.
+func sameImage(h windows.Handle, exe string) bool {
+	name, ok := imageName(h)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(filepath.Base(name), filepath.Base(exe))
+}
+
+// imageName returns the full image path of an open process handle. It starts with
+// a MAX_PATH buffer and grows to the long-path maximum if the image path exceeds
+// it, so a supervisor installed under a >260-character path is not misread as dead
+// on the name-based liveness fallback. ok is false on any other query failure, so a
+// transient error never reads as a matching name.
+func imageName(h windows.Handle) (string, bool) {
+	for _, n := range [...]uint32{windows.MAX_PATH, 32768} { // 32768 = long-path max + 1
+		buf := make([]uint16, n)
+		size := n
+		err := windows.QueryFullProcessImageName(h, 0, &buf[0], &size)
+		if err == nil {
+			return windows.UTF16ToString(buf[:size]), true
+		}
+		if !errors.Is(err, windows.ERROR_INSUFFICIENT_BUFFER) {
+			return "", false
+		}
+	}
+	return "", false
+}

--- a/internal/manager/liveness_windows_test.go
+++ b/internal/manager/liveness_windows_test.go
@@ -1,0 +1,96 @@
+package manager
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// startSleeper spawns a long-running process a liveness test can inspect and then
+// kill. ping to the loopback is available on every Windows host.
+func startSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("ping", "-n", "60", "127.0.0.1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleeper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd
+}
+
+func TestReadStartTimeTicksNonZero(t *testing.T) {
+	cmd := startSleeper(t)
+	ticks, ok := readStartTimeTicks(cmd.Process.Pid)
+	if !ok || ticks == 0 {
+		t.Fatalf("readStartTimeTicks = (%d, %v), want a non-zero creation time", ticks, ok)
+	}
+}
+
+func TestProcessAliveLiveThenDead(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir()})
+	cmd := startSleeper(t)
+	ticks, ok := readStartTimeTicks(cmd.Process.Pid)
+	if !ok {
+		t.Fatal("could not read creation time for the live process")
+	}
+	meta := jobstore.Meta{ID: "j", PID: cmd.Process.Pid, StartTimeTicks: ticks, BootID: readBootID()}
+	if !m.processAlive(meta) {
+		t.Fatal("processAlive must be true for a running process with a matching creation time")
+	}
+	// Kill it and confirm liveness flips to false.
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	deadline := time.Now().Add(5 * time.Second)
+	for m.processAlive(meta) && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if m.processAlive(meta) {
+		t.Fatal("processAlive must be false once the process has exited")
+	}
+}
+
+func TestProcessAliveRejectsCreationTimeMismatch(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir()})
+	cmd := startSleeper(t)
+	ticks, ok := readStartTimeTicks(cmd.Process.Pid)
+	if !ok {
+		t.Fatal("could not read creation time")
+	}
+	// Same live PID but a creation time that does not match: this models a PID
+	// recycled to a different process, which must never read as our supervisor.
+	meta := jobstore.Meta{ID: "j", PID: cmd.Process.Pid, StartTimeTicks: ticks + 1, BootID: readBootID()}
+	if m.processAlive(meta) {
+		t.Fatal("processAlive must reject a matching PID with a mismatched creation time")
+	}
+}
+
+func TestProcessAliveRejectsNonPositivePID(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir()})
+	if m.processAlive(jobstore.Meta{ID: "j", PID: 0}) {
+		t.Fatal("processAlive must be false for a non-positive PID")
+	}
+}
+
+// TestProcessAliveImageNameFallback: with no recorded creation time (an older meta
+// or a transient read failure) liveness falls back to matching the image name
+// against the configured supervisor executable.
+func TestProcessAliveImageNameFallback(t *testing.T) {
+	cmd := startSleeper(t) // image name is ping.exe
+
+	match := New(config.Config{StateDir: t.TempDir(), SupervisorExe: "ping.exe"})
+	meta := jobstore.Meta{ID: "j", PID: cmd.Process.Pid, StartTimeTicks: 0, BootID: readBootID()}
+	if !match.processAlive(meta) {
+		t.Fatal("processAlive must match a live process by image name when no ticks are recorded")
+	}
+
+	mismatch := New(config.Config{StateDir: t.TempDir(), SupervisorExe: "not-ping.exe"})
+	if mismatch.processAlive(meta) {
+		t.Fatal("processAlive must reject a process whose image name differs from the supervisor exe")
+	}
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -269,10 +269,10 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	if req.ContinueLatest && req.ConversationID != "" {
 		return Job{}, fmt.Errorf("conversation_id and continue_latest are mutually exclusive: pass one or the other")
 	}
-	// Job supervision needs process groups and /proc, which only exist on Linux. On
-	// other platforms refuse before doing any work, so the failure is a clear error
-	// rather than a half-spawned job. stdio/HTTP serve, list_models, and list_sessions
-	// still work everywhere.
+	// Job supervision is implemented on Linux (process groups, /proc) and Windows
+	// (Job Objects, OpenProcess). On other platforms refuse before doing any work, so
+	// the failure is a clear error rather than a half-spawned job. stdio/HTTP serve,
+	// list_models, and list_sessions still work everywhere.
 	if !proc.Supported {
 		return Job{}, proc.ErrUnsupported
 	}
@@ -387,19 +387,36 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 
 	cmd := exec.Command(m.cfg.SupervisorExe, "run-job", dir)
 	cmd.Env = os.Environ()
-	proc.SetGroup(cmd)
 	// Detach stdio: supervisor must not inherit the manager's stdout (the
 	// JSON-RPC stream in stdio mode).
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	if err := cmd.Start(); err != nil {
+	// StartDetached puts the supervisor in its own group/job and starts it detached
+	// so it survives the manager's death (init adoption on Linux; a non-kill-on-close
+	// Job Object on Windows).
+	if err := proc.StartDetached(cmd); err != nil {
 		// No supervisor was spawned, so the just-created job dir is a never-started
 		// orphan; remove it now rather than leaving it for a later GarbageCollect.
 		_ = m.store.Remove(id)
 		m.pendingCaptures.Delete(id)
 		m.releaseKey(key)
 		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
+	}
+	// Capture a handle to the supervisor's process tree so the record-pid failure
+	// path below can terminate it (and any agy it already spawned) as a unit.
+	// killOnClose=false: closing the handle on manager exit must NOT kill the tree,
+	// so the detached supervisor still outlives the manager.
+	grp, err := proc.Track(cmd, false)
+	if err != nil {
+		// Started but untrackable (Track only fails before Start, which succeeded).
+		// Fail closed: kill the supervisor, reap it in the background, and clean up.
+		_ = cmd.Process.Kill()
+		go func() { _ = cmd.Wait() }()
+		_ = m.store.Remove(id)
+		m.pendingCaptures.Delete(id)
+		m.releaseKey(key)
+		return Job{}, fmt.Errorf("track supervisor: %w", err)
 	}
 	// Record the supervisor PID (for liveness and cancel) and its start time (so a
 	// later process that recycles the same PID within this boot is not mistaken for
@@ -416,9 +433,10 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		// remove the dir and release the gate. Releasing only after the agy process
 		// group is gone keeps a conflicting same-key run from starting while the
 		// dying agy still holds its session lock.
-		_ = proc.TerminateGroup(cmd.Process.Pid, syscall.SIGTERM)
+		_ = grp.Terminate(syscall.SIGTERM)
 		go func() {
 			_ = cmd.Wait()
+			_ = grp.Close()
 			_ = m.store.Remove(id)
 			m.pendingCaptures.Delete(id)
 			m.releaseKey(key)
@@ -432,6 +450,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// the manager dies first, init adopts and reaps it.
 	go func() {
 		_ = cmd.Wait()
+		_ = grp.Close()
 		// For a successful fresh run, capture the conversation id agy created
 		// while the gate key is still held, then release. Gating on exit 0 avoids
 		// waiting out the capture budget for a run that created no conversation.

--- a/internal/manager/models_test.go
+++ b/internal/manager/models_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -11,6 +12,9 @@ import (
 // TestListModelsIncludesStderrOnError: when `agy models` fails, the error must
 // carry agy's stderr (e.g. an auth prompt) rather than a bare "exit status 1".
 func TestListModelsIncludesStderrOnError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific: WriteFakeAgy emits a bash script that is not executable on Windows; ListModels error-surfacing is covered on Linux")
+	}
 	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stderr: "agy: not logged in", Exit: 1})
 	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
 

--- a/internal/manager/models_test.go
+++ b/internal/manager/models_test.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 
@@ -12,9 +11,7 @@ import (
 // TestListModelsIncludesStderrOnError: when `agy models` fails, the error must
 // carry agy's stderr (e.g. an auth prompt) rather than a bare "exit status 1".
 func TestListModelsIncludesStderrOnError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-specific: WriteFakeAgy emits a bash script that is not executable on Windows; ListModels error-surfacing is covered on Linux")
-	}
+	skipIfWindows(t, "Unix-specific: WriteFakeAgy emits a bash script that is not executable on Windows; ListModels error-surfacing is covered on Linux")
 	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stderr: "agy: not logged in", Exit: 1})
 	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
 

--- a/internal/manager/platform_test.go
+++ b/internal/manager/platform_test.go
@@ -1,0 +1,18 @@
+package manager
+
+import (
+	"runtime"
+	"testing"
+)
+
+// skipIfWindows skips a test that encodes a Unix-specific assumption (filesystem
+// permission semantics, symlinks, forward-slash path formats, or a shell-script
+// fake) when the suite runs on Windows. The ported job-supervision paths have
+// their own dedicated _windows_test.go coverage; these skips only cover the
+// pre-existing Unix-shaped tests.
+func skipIfWindows(t *testing.T, reason string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip(reason)
+	}
+}

--- a/internal/manager/restore_test.go
+++ b/internal/manager/restore_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -104,6 +105,9 @@ func TestRestoreAndCollectSkipsRemovalWhenTTLDisabled(t *testing.T) {
 // serving with an unrestored gate (a stricter contract than GarbageCollect's, whose
 // scan failure was only logged).
 func TestRestoreAndCollectFailsClosedOnScanError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific: os.ReadDir on a regular file does not error on Windows, so the file-as-dir scan-failure technique does not apply; the fail-closed contract is covered on Linux")
+	}
 	state := t.TempDir()
 	// Make the jobs path a file so the directory scan errors (distinct from the
 	// benign "directory does not exist yet" case, which is not an error).

--- a/internal/manager/restore_test.go
+++ b/internal/manager/restore_test.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -105,9 +104,7 @@ func TestRestoreAndCollectSkipsRemovalWhenTTLDisabled(t *testing.T) {
 // serving with an unrestored gate (a stricter contract than GarbageCollect's, whose
 // scan failure was only logged).
 func TestRestoreAndCollectFailsClosedOnScanError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-specific: os.ReadDir on a regular file does not error on Windows, so the file-as-dir scan-failure technique does not apply; the fail-closed contract is covered on Linux")
-	}
+	skipIfWindows(t, "Unix-specific: os.ReadDir on a regular file does not error on Windows, so the file-as-dir scan-failure technique does not apply; the fail-closed contract is covered on Linux")
 	state := t.TempDir()
 	// Make the jobs path a file so the directory scan errors (distinct from the
 	// benign "directory does not exist yet" case, which is not an error).

--- a/internal/manager/sessions_test.go
+++ b/internal/manager/sessions_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
+
+// wantUUID1 is the conversation id the session-filter tests expect to survive
+// their directory filter.
+const wantUUID1 = "uuid-1"
 
 func TestListSessionsFromCache(t *testing.T) {
 	cache := t.TempDir()
@@ -51,9 +54,7 @@ func TestListSessionsMalformedCacheErrors(t *testing.T) {
 }
 
 func TestListSessionsFilteredByDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-specific: hardcoded /home/u paths do not survive Windows path canonicalization; cross-platform filtering is covered by TestListSessionsFilterMatchesRealDir")
-	}
+	skipIfWindows(t, "Unix-specific: hardcoded /home/u paths do not survive Windows path canonicalization; cross-platform filtering is covered by TestListSessionsFilterMatchesRealDir")
 	cache := t.TempDir()
 	data := `{"/home/u/proj":"uuid-1","/home/u/other":"uuid-2"}`
 	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), []byte(data), 0o644); err != nil {
@@ -63,7 +64,7 @@ func TestListSessionsFilteredByDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
+	if len(sessions) != 1 || sessions[0].ConversationID != wantUUID1 {
 		t.Fatalf("got %+v", sessions)
 	}
 }
@@ -75,9 +76,7 @@ func TestListSessionsFilteredByDir(t *testing.T) {
 // a symlinked alias would never match. The filter must canonicalize the same way
 // StartJob canonicalizes a run's cwd (issue #24).
 func TestListSessionsFilterCanonicalizesSymlink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-specific: uses os.Symlink (privileged on Windows) and a raw path in JSON")
-	}
+	skipIfWindows(t, "Unix-specific: uses os.Symlink (privileged on Windows) and a raw path in JSON")
 	realDir := t.TempDir()
 	resolved, err := filepath.EvalSymlinks(realDir)
 	if err != nil {
@@ -99,7 +98,7 @@ func TestListSessionsFilterCanonicalizesSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
+	if len(sessions) != 1 || sessions[0].ConversationID != wantUUID1 {
 		t.Fatalf("symlinked filter did not match resolved cache key: got %+v", sessions)
 	}
 }
@@ -116,7 +115,7 @@ func TestListSessionsFilterMatchesRealDir(t *testing.T) {
 	}
 	other := filepath.Join(dir, "other") // a distinct path that must be filtered out
 	cache := filepath.Join(t.TempDir(), "last_conversations.json")
-	data, err := json.Marshal(map[string]string{norm: "uuid-1", other: "uuid-2"})
+	data, err := json.Marshal(map[string]string{norm: wantUUID1, other: "uuid-2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +126,7 @@ func TestListSessionsFilterMatchesRealDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
+	if len(sessions) != 1 || sessions[0].ConversationID != wantUUID1 {
 		t.Fatalf("directory filter did not match the real-dir cache key: got %+v", sessions)
 	}
 }

--- a/internal/manager/sessions_test.go
+++ b/internal/manager/sessions_test.go
@@ -1,8 +1,10 @@
 package manager
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -49,6 +51,9 @@ func TestListSessionsMalformedCacheErrors(t *testing.T) {
 }
 
 func TestListSessionsFilteredByDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific: hardcoded /home/u paths do not survive Windows path canonicalization; cross-platform filtering is covered by TestListSessionsFilterMatchesRealDir")
+	}
 	cache := t.TempDir()
 	data := `{"/home/u/proj":"uuid-1","/home/u/other":"uuid-2"}`
 	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), []byte(data), 0o644); err != nil {
@@ -70,6 +75,9 @@ func TestListSessionsFilteredByDir(t *testing.T) {
 // a symlinked alias would never match. The filter must canonicalize the same way
 // StartJob canonicalizes a run's cwd (issue #24).
 func TestListSessionsFilterCanonicalizesSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-specific: uses os.Symlink (privileged on Windows) and a raw path in JSON")
+	}
 	realDir := t.TempDir()
 	resolved, err := filepath.EvalSymlinks(realDir)
 	if err != nil {
@@ -93,5 +101,33 @@ func TestListSessionsFilterCanonicalizesSymlink(t *testing.T) {
 	}
 	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
 		t.Fatalf("symlinked filter did not match resolved cache key: got %+v", sessions)
+	}
+}
+
+// TestListSessionsFilterMatchesRealDir exercises the directory filter with a real,
+// platform-native path key, so the filter path is covered on every OS (the
+// hardcoded-Unix-path filter tests are skipped off Linux). Using json.Marshal for
+// the cache keeps a Windows path (with backslashes) valid in the JSON.
+func TestListSessionsFilterMatchesRealDir(t *testing.T) {
+	dir := t.TempDir()
+	norm, err := normalizeCwd(dir)
+	if err != nil {
+		t.Fatalf("normalizeCwd: %v", err)
+	}
+	other := filepath.Join(dir, "other") // a distinct path that must be filtered out
+	cache := filepath.Join(t.TempDir(), "last_conversations.json")
+	data, err := json.Marshal(map[string]string{norm: "uuid-1", other: "uuid-2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cache, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := readSessions(cache, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].ConversationID != "uuid-1" {
+		t.Fatalf("directory filter did not match the real-dir cache key: got %+v", sessions)
 	}
 }

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -1,14 +1,15 @@
-// Package proc holds the process-group primitives shared by the manager (which
-// spawns and signals the supervisor) and the supervisor (which spawns and
-// signals agy). They are meaningful only on Linux; other platforms get the
-// no-op/error stubs in proc_other.go so both callers build everywhere and
-// refuse early via Supported.
+// Package proc holds the process-tree primitives shared by the manager (which
+// spawns the supervisor) and the supervisor (which spawns agy). They are
+// implemented on Linux (process groups) in proc_linux.go and on Windows (Job
+// Objects) in proc_windows.go; other platforms get the no-op/error stubs in
+// proc_other.go so both callers build everywhere and refuse early via Supported.
 package proc
 
 import "errors"
 
-// ErrUnsupported is returned by the off-Linux stubs and by callers that refuse
-// before spawning. It is a non-nil sentinel on every platform, including Linux
-// where it is never returned, so an errors.Is/== comparison against it is
-// always safe: a nil error from a successful call must never match it.
-var ErrUnsupported = errors.New("agy-mcp: process supervision is only supported on Linux")
+// ErrUnsupported is returned by the stubs on platforms without a supervision
+// implementation and by callers that refuse before spawning. It is a non-nil
+// sentinel on every platform, including Linux and Windows where it is never
+// returned, so an errors.Is/== comparison against it is always safe: a nil error
+// from a successful call must never match it.
+var ErrUnsupported = errors.New("agy-mcp: process supervision is only supported on Linux and Windows")

--- a/internal/proc/proc_linux.go
+++ b/internal/proc/proc_linux.go
@@ -10,31 +10,65 @@ import (
 // check it and refuse before spawning on platforms where the stubs apply.
 const Supported = true
 
-// SetGroup puts the spawned process in its own process group, so the whole
-// group (the child and its descendants) can be signaled together. It sets only
-// Setpgid, preserving any other SysProcAttr fields a caller configured first.
-func SetGroup(cmd *exec.Cmd) {
+// ConfigureGroup puts the spawned process in its own process group, so the whole
+// group (the child and its descendants) can be terminated together via a Group
+// captured by Track. The supervisor uses it for agy. It sets only Setpgid,
+// preserving any other SysProcAttr fields a caller configured first.
+func ConfigureGroup(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.Setpgid = true
 }
 
-// TerminateGroup sends sig to the entire process group led by pid. A
-// non-positive pid is rejected: syscall.Kill(-pid, ...) with pid <= 0 would
-// target the caller's own process group. Callers always pass a live
-// cmd.Process.Pid (> 0); this guards a future caller or a corrupted meta.
-func TerminateGroup(pid int, sig syscall.Signal) error {
-	if pid <= 0 {
+// StartDetached configures cmd so the child leads its own process group and
+// starts it, so the child (the detached supervisor) can be tracked as a group
+// and survives the parent's death via init adoption. On Linux this is
+// ConfigureGroup plus Start; the Windows build additionally sets the detach and
+// job-breakaway creation flags that let the supervisor outlive the manager.
+func StartDetached(cmd *exec.Cmd) error {
+	ConfigureGroup(cmd)
+	return cmd.Start()
+}
+
+// Group is a handle to a spawned process tree that can be terminated as a unit.
+// On Linux it is identified by the leader pid (kill -pgid); the Windows build
+// wraps a Job Object handle.
+type Group struct {
+	pid int
+}
+
+// Track captures a handle to the process group led by an already-started cmd, so
+// the group can later be terminated together. cmd.Start must have succeeded.
+// killOnClose is a Windows Job Object option (tear the tree down with the handle);
+// it has no effect on Linux, where a crashing tracker orphans its process group
+// rather than killing it, so the parameter is accepted for a common signature and
+// ignored.
+func Track(cmd *exec.Cmd, _ bool) (*Group, error) {
+	if cmd.Process == nil {
+		return nil, errors.New("proc: Track before Start")
+	}
+	return &Group{pid: cmd.Process.Pid}, nil
+}
+
+// Terminate sends sig to the entire process group. A non-positive leader pid is
+// rejected: syscall.Kill(-pid, ...) with pid <= 0 would target the caller's own
+// process group. Callers always pass a live pid captured at Start; this guards a
+// future caller or a corrupted Group.
+func (g *Group) Terminate(sig syscall.Signal) error {
+	if g == nil || g.pid <= 0 {
 		return syscall.EINVAL
 	}
-	return syscall.Kill(-pid, sig)
+	return syscall.Kill(-g.pid, sig)
 }
+
+// Close releases the handle. On Linux there is nothing to release.
+func (g *Group) Close() error { return nil }
 
 // Signal sends sig to a single pid (not its group). A pid that has already
 // exited (ESRCH) is treated as success: there is nothing left to signal. A
 // non-positive pid is rejected so it never signals the caller's own process
-// group.
+// group. The manager's Linux cancel uses it to forward SIGTERM to the supervisor.
 func Signal(pid int, sig syscall.Signal) error {
 	if pid <= 0 {
 		return syscall.EINVAL

--- a/internal/proc/proc_linux_test.go
+++ b/internal/proc/proc_linux_test.go
@@ -9,25 +9,25 @@ import (
 	"testing"
 )
 
-func TestSetGroupRequestsNewProcessGroup(t *testing.T) {
+func TestConfigureGroupRequestsNewProcessGroup(t *testing.T) {
 	cmd := exec.Command("true")
-	SetGroup(cmd)
+	ConfigureGroup(cmd)
 	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
-		t.Fatal("SetGroup must request a new process group (Setpgid)")
+		t.Fatal("ConfigureGroup must request a new process group (Setpgid)")
 	}
 }
 
-// TestSetGroupPreservesExistingAttrs: SetGroup must set only Setpgid, leaving
-// any SysProcAttr fields a caller configured first intact.
-func TestSetGroupPreservesExistingAttrs(t *testing.T) {
+// TestConfigureGroupPreservesExistingAttrs: ConfigureGroup must set only Setpgid,
+// leaving any SysProcAttr fields a caller configured first intact.
+func TestConfigureGroupPreservesExistingAttrs(t *testing.T) {
 	cmd := exec.Command("true")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	SetGroup(cmd)
+	ConfigureGroup(cmd)
 	if !cmd.SysProcAttr.Setpgid {
-		t.Error("SetGroup must set Setpgid")
+		t.Error("ConfigureGroup must set Setpgid")
 	}
 	if !cmd.SysProcAttr.Setsid {
-		t.Error("SetGroup must preserve a pre-existing SysProcAttr field (Setsid)")
+		t.Error("ConfigureGroup must preserve a pre-existing SysProcAttr field (Setsid)")
 	}
 }
 
@@ -41,12 +41,14 @@ func TestErrUnsupportedIsNonNil(t *testing.T) {
 }
 
 // TestNonPositivePidRejected: syscall.Kill(-pid, ...) with pid <= 0 targets the
-// caller's own process group, so signaling a non-positive pid would terminate
-// the manager/supervisor itself. Both helpers must reject it.
+// caller's own process group, so terminating a group led by a non-positive pid
+// would kill the manager/supervisor itself. Group.Terminate and Signal must
+// reject it.
 func TestNonPositivePidRejected(t *testing.T) {
 	for _, pid := range []int{0, -1, -1000} {
-		if err := TerminateGroup(pid, syscall.SIGTERM); !errors.Is(err, syscall.EINVAL) {
-			t.Errorf("TerminateGroup(%d) = %v, want EINVAL", pid, err)
+		g := &Group{pid: pid}
+		if err := g.Terminate(syscall.SIGTERM); !errors.Is(err, syscall.EINVAL) {
+			t.Errorf("Group{pid:%d}.Terminate = %v, want EINVAL", pid, err)
 		}
 		if err := Signal(pid, syscall.SIGTERM); !errors.Is(err, syscall.EINVAL) {
 			t.Errorf("Signal(%d) = %v, want EINVAL", pid, err)
@@ -67,5 +69,36 @@ func TestSignalToleratesAlreadyExited(t *testing.T) {
 	_ = cmd.Wait() // reap, so pid is gone and a later Kill sees ESRCH
 	if err := Signal(pid, syscall.SIGTERM); err != nil {
 		t.Fatalf("Signal on an exited pid = %v, want nil (ESRCH tolerated)", err)
+	}
+}
+
+// TestTrackRequiresStart: Track before Start has no pid to capture and must error
+// rather than return a Group that would later terminate pid 0 (the caller's group).
+func TestTrackRequiresStart(t *testing.T) {
+	if _, err := Track(exec.Command("true"), false); err == nil {
+		t.Fatal("Track before Start must return an error")
+	}
+}
+
+// TestTrackTerminateKillsGroup: a Group captured after Start terminates the whole
+// process group. The child sleeps; Terminate(SIGKILL) must end it.
+func TestTrackTerminateKillsGroup(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	ConfigureGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	g, err := Track(cmd, false)
+	if err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	if err := g.Terminate(syscall.SIGKILL); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("expected the killed process to exit non-nil")
+	}
+	if err := g.Close(); err != nil {
+		t.Errorf("Close: %v", err)
 	}
 }

--- a/internal/proc/proc_other.go
+++ b/internal/proc/proc_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package proc
 
@@ -7,15 +7,23 @@ import (
 	"syscall"
 )
 
-// Non-Linux stubs so the manager and supervisor packages build on macOS and
-// Windows. Both callers check Supported and refuse before spawning, so these
-// are never reached at runtime.
+// Non-Linux, non-Windows stubs so the manager and supervisor packages build on
+// platforms (e.g. macOS) without a supervision implementation. Both callers
+// check Supported and refuse before spawning, so these are never reached at
+// runtime.
 
-// Supported is false off Linux: supervision relies on process groups and /proc.
+// Supported is false here: supervision relies on process groups / job objects.
 const Supported = false
 
-func SetGroup(_ *exec.Cmd) {}
+func ConfigureGroup(_ *exec.Cmd) {}
 
-func TerminateGroup(_ int, _ syscall.Signal) error { return ErrUnsupported }
+func StartDetached(_ *exec.Cmd) error { return ErrUnsupported }
 
-func Signal(_ int, _ syscall.Signal) error { return ErrUnsupported }
+// Group has no state on unsupported platforms; Track never returns one.
+type Group struct{}
+
+func Track(_ *exec.Cmd, _ bool) (*Group, error) { return nil, ErrUnsupported }
+
+func (g *Group) Terminate(_ syscall.Signal) error { return ErrUnsupported }
+
+func (g *Group) Close() error { return nil }

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -165,7 +165,11 @@ func canBreakaway() bool {
 	var inJob int32
 	r1, _, _ := procIsProcessInJob.Call(uintptr(windows.CurrentProcess()), 0, uintptr(unsafe.Pointer(&inJob)))
 	if r1 == 0 {
-		return true // IsProcessInJob failed; if not in a job the flag is harmless
+		// IsProcessInJob itself failed (r1 == 0 is the API failure return, not the
+		// in-a-job result). Fail closed: if we are in a job that forbids breakaway,
+		// setting the flag would make CreateProcess fail and the spawn would fail
+		// entirely, which is worse than a supervisor that stays in the parent job.
+		return false
 	}
 	if inJob == 0 {
 		return true // not in any job: CREATE_BREAKAWAY_FROM_JOB is ignored

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -1,0 +1,182 @@
+package proc
+
+import (
+	"errors"
+	"log"
+	"os/exec"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Supported reports whether process supervision runs on this OS. On Windows the
+// process tree is killed via a Job Object rather than a process-group signal.
+const Supported = true
+
+func ensureSysProcAttr(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+}
+
+// ConfigureGroup marks the spawned process as the root of a new process group so
+// it is isolated from the parent's console control events. The supervisor uses it
+// for agy; the process tree is actually terminated via the Job Object captured by
+// Track. It ORs the flag into any CreationFlags a caller set first.
+func ConfigureGroup(cmd *exec.Cmd) {
+	ensureSysProcAttr(cmd)
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP
+}
+
+// StartDetached configures cmd so the spawned supervisor is detached from the
+// manager and starts it. DETACHED_PROCESS drops the console (the manager's stdio
+// is the JSON-RPC stream), and, when the manager sits in a job that permits it,
+// CREATE_BREAKAWAY_FROM_JOB frees the supervisor from that job so it outlives the
+// manager. The breakaway flag would make CreateProcess fail if the parent job
+// forbids it, so it is added only after confirming the job allows breakaway.
+func StartDetached(cmd *exec.Cmd) error {
+	ensureSysProcAttr(cmd)
+	flags := uint32(windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP)
+	if canBreakaway() {
+		flags |= windows.CREATE_BREAKAWAY_FROM_JOB
+	}
+	cmd.SysProcAttr.CreationFlags |= flags
+	return cmd.Start()
+}
+
+// Group is a handle to a spawned process tree that can be terminated as a unit.
+// On Windows it is a Job Object; if the job could not be created or the process
+// could not be assigned to it, job is 0 and Terminate falls back to terminating
+// the single leader process by pid.
+type Group struct {
+	job windows.Handle
+	pid int
+}
+
+// Track puts the already-started process into a fresh Job Object so its whole
+// tree can later be terminated together. cmd.Start must have succeeded. Job
+// creation or assignment failures are non-fatal: Track logs and returns a
+// pid-only Group whose Terminate degrades to single-process termination, so a
+// job-object hiccup never leaves the caller unable to stop the job at all.
+//
+// killOnClose sets JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so the tracked tree is
+// terminated when the last handle (this Group's, closed by Close) goes away. The
+// supervisor passes true so agy and its descendants die if the supervisor itself
+// dies unexpectedly (a crash or a force-kill), rather than orphaning MCP-server
+// grandchildren; this is stricter than Linux, where a crashing supervisor's agy
+// is merely reparented. The manager passes false: the supervisor must outlive the
+// manager's exit, so closing the manager's handle must NOT kill it.
+//
+// The process is assigned right after Start, so a grandchild spawned by the
+// child in the microseconds before assignment could escape the job. For the agy
+// child (which spends its startup initializing before spawning anything) this
+// window is not a practical concern.
+func Track(cmd *exec.Cmd, killOnClose bool) (*Group, error) {
+	if cmd.Process == nil {
+		return nil, errors.New("proc: Track before Start")
+	}
+	pid := cmd.Process.Pid
+	g := &Group{pid: pid}
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		log.Printf("proc: CreateJobObject for pid %d failed, using single-process termination: %v", pid, err)
+		return g, nil
+	}
+	// Allow a grandchild to break away if it needs to. KILL_ON_JOB_CLOSE is added
+	// only when the caller wants the tree torn down with the handle (see above).
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_BREAKAWAY_OK
+	if killOnClose {
+		info.BasicLimitInformation.LimitFlags |= windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	}
+	if _, err := windows.SetInformationJobObject(job, windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info))); err != nil {
+		// Non-fatal: TerminateJobObject still kills the members without the flag.
+		log.Printf("proc: SetInformationJobObject for pid %d: %v", pid, err)
+	}
+
+	// AssignProcessToJobObject needs PROCESS_SET_QUOTA and PROCESS_TERMINATE.
+	ph, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		log.Printf("proc: OpenProcess for job assignment (pid %d) failed, using single-process termination: %v", pid, err)
+		_ = windows.CloseHandle(job)
+		return g, nil
+	}
+	defer func() { _ = windows.CloseHandle(ph) }()
+	if err := windows.AssignProcessToJobObject(job, ph); err != nil {
+		log.Printf("proc: AssignProcessToJobObject (pid %d) failed, using single-process termination: %v", pid, err)
+		_ = windows.CloseHandle(job)
+		return g, nil
+	}
+	g.job = job
+	return g, nil
+}
+
+// Terminate kills the whole job (the tracked process and every descendant still
+// in the job) in one call. sig is ignored: TerminateJobObject is a hard kill,
+// so Windows has no SIGTERM grace window (the supervisor calls Terminate twice,
+// SIGTERM then SIGKILL; the first already killed everything, so the second is a
+// harmless no-op on an empty job). Without a job it terminates the leader pid.
+func (g *Group) Terminate(_ syscall.Signal) error {
+	if g == nil {
+		return syscall.EINVAL
+	}
+	if g.job != 0 {
+		return windows.TerminateJobObject(g.job, 1)
+	}
+	if g.pid <= 0 {
+		return syscall.EINVAL
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(g.pid))
+	if err != nil {
+		// A non-existent PID (already exited) reports ERROR_INVALID_PARAMETER; treat
+		// that as success, mirroring the Linux ESRCH tolerance. Any other failure
+		// (e.g. access denied) is a real problem and must surface.
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return nil
+		}
+		return err
+	}
+	defer func() { _ = windows.CloseHandle(h) }()
+	return windows.TerminateProcess(h, 1)
+}
+
+// Close releases the Job Object handle. Because the job has no kill-on-close
+// limit, closing it does not terminate the tracked process, so the supervisor
+// survives the manager exit that triggers this Close.
+func (g *Group) Close() error {
+	if g == nil || g.job == 0 {
+		return nil
+	}
+	return windows.CloseHandle(g.job)
+}
+
+var procIsProcessInJob = windows.NewLazySystemDLL("kernel32.dll").NewProc("IsProcessInJob")
+
+// canBreakaway reports whether it is safe to pass CREATE_BREAKAWAY_FROM_JOB when
+// spawning the supervisor: true when this process is in no job (the flag is then
+// ignored) or in a job that explicitly permits breakaway, and false when it is in
+// a job that forbids it (where the flag would make CreateProcess fail). It fails
+// safe toward not setting the flag when the job cannot be inspected. x/sys/windows
+// does not wrap IsProcessInJob, so that one call is made through a lazy proc.
+func canBreakaway() bool {
+	var inJob int32
+	r1, _, _ := procIsProcessInJob.Call(uintptr(windows.CurrentProcess()), 0, uintptr(unsafe.Pointer(&inJob)))
+	if r1 == 0 {
+		return true // IsProcessInJob failed; if not in a job the flag is harmless
+	}
+	if inJob == 0 {
+		return true // not in any job: CREATE_BREAKAWAY_FROM_JOB is ignored
+	}
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	var ret uint32
+	if err := windows.QueryInformationJobObject(0, windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)), uint32(unsafe.Sizeof(info)), &ret); err != nil {
+		return false // in a job we cannot inspect: do not risk a failed spawn
+	}
+	// SILENT_BREAKAWAY_OK makes children leave the job automatically without the
+	// flag, so only BREAKAWAY_OK requires (and permits) setting it.
+	return info.BasicLimitInformation.LimitFlags&windows.JOB_OBJECT_LIMIT_BREAKAWAY_OK != 0
+}

--- a/internal/proc/proc_windows_test.go
+++ b/internal/proc/proc_windows_test.go
@@ -1,0 +1,154 @@
+package proc
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// startSleeper spawns a process that runs for ~60s so a test can terminate it.
+// ping to the loopback with a high count is a dependency-free long-running
+// process available on every Windows host.
+func startSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("ping", "-n", "60", "127.0.0.1")
+	ConfigureGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleeper: %v", err)
+	}
+	// Reap the process even if the test fatals before terminating it, so a failed
+	// assertion never leaves a 60s ping running.
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd
+}
+
+func TestConfigureGroupSetsNewProcessGroup(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit")
+	ConfigureGroup(cmd)
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Fatal("ConfigureGroup must set CREATE_NEW_PROCESS_GROUP")
+	}
+}
+
+func TestConfigureGroupPreservesExistingFlags(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+	ConfigureGroup(cmd)
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("ConfigureGroup must preserve a pre-existing CreationFlag")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Error("ConfigureGroup must add CREATE_NEW_PROCESS_GROUP")
+	}
+}
+
+// TestStartDetachedRunsAndSetsFlags: StartDetached must actually start the process
+// and mark it detached (no inherited console).
+func TestStartDetachedRunsAndSetsFlags(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit")
+	if err := StartDetached(cmd); err != nil {
+		t.Fatalf("StartDetached: %v", err)
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.DETACHED_PROCESS == 0 {
+		t.Error("StartDetached must set DETACHED_PROCESS")
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Errorf("Wait: %v", err)
+	}
+}
+
+// TestTrackTerminateKillsProcess: a Group captured after Start terminates the
+// tracked process. Without the kill the sleeper would run ~60s; cmd.Wait must
+// return promptly once the Job Object is terminated.
+func TestTrackTerminateKillsProcess(t *testing.T) {
+	cmd := startSleeper(t)
+	g, err := Track(cmd, true)
+	if err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	if g.job == 0 {
+		t.Fatal("Track should have created a Job Object for the tracked process")
+	}
+	if err := g.Terminate(syscall.SIGKILL); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done: // killed; Wait returned
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("Terminate did not kill the tracked process")
+	}
+	if err := g.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+// TestCloseKillsWhenKillOnClose: with killOnClose=true, closing the Group's last
+// Job Object handle terminates the tracked tree. This is the guarantee that agy
+// (and its descendants) die if the supervisor process itself dies unexpectedly.
+func TestCloseKillsWhenKillOnClose(t *testing.T) {
+	cmd := startSleeper(t)
+	g, err := Track(cmd, true)
+	if err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	if g.job == 0 {
+		t.Skip("no Job Object was created; kill-on-close does not apply")
+	}
+	if err := g.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("closing the kill-on-close job did not terminate the process")
+	}
+}
+
+// TestTerminateFallbackWithoutJob: when Track could not create a Job Object, the
+// Group keeps only the pid and Terminate degrades to killing that single process.
+// Constructing a job-less Group directly exercises that fallback.
+func TestTerminateFallbackWithoutJob(t *testing.T) {
+	cmd := startSleeper(t)            // startSleeper's cleanup reaps the process
+	g := &Group{pid: cmd.Process.Pid} // job == 0: force the single-process fallback
+	if err := g.Terminate(syscall.SIGKILL); err != nil {
+		t.Fatalf("fallback Terminate: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("fallback Terminate did not kill the process")
+	}
+}
+
+// TestTerminateRejectsUnusable: a nil group, or a job-less group with a
+// non-positive pid, has nothing valid to terminate and must not act.
+func TestTerminateRejectsUnusable(t *testing.T) {
+	var g *Group
+	if err := g.Terminate(syscall.SIGKILL); !errors.Is(err, syscall.EINVAL) {
+		t.Errorf("nil Group.Terminate = %v, want EINVAL", err)
+	}
+	g = &Group{pid: 0}
+	if err := g.Terminate(syscall.SIGKILL); !errors.Is(err, syscall.EINVAL) {
+		t.Errorf("Group{pid:0}.Terminate = %v, want EINVAL", err)
+	}
+}
+
+func TestTrackRequiresStart(t *testing.T) {
+	if _, err := Track(exec.Command("cmd.exe"), true); err == nil {
+		t.Fatal("Track before Start must return an error")
+	}
+}

--- a/internal/supervisor/signal_other.go
+++ b/internal/supervisor/signal_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package supervisor
 
@@ -8,6 +8,7 @@ import (
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
-// signalExitCode stub so the package builds off Linux. Run refuses early there
-// (proc.Supported is false), so this is never reached at runtime.
+// signalExitCode stub so the package builds on platforms without a supervision
+// implementation (e.g. macOS). Run refuses early there (proc.Supported is false),
+// so this is never reached at runtime.
 func signalExitCode(_ *exec.ExitError) int { return jobstore.ExitSIGTERM }

--- a/internal/supervisor/signal_windows.go
+++ b/internal/supervisor/signal_windows.go
@@ -1,0 +1,14 @@
+package supervisor
+
+import "os/exec"
+
+// signalExitCode classifies an agy exit the supervisor did not itself cause. On
+// Windows it is effectively unreachable: supervisor.go calls it only when
+// exec.ExitError.ExitCode() is negative, and a Windows exit status is an unsigned
+// 32-bit value that ExitCode() widens into a non-negative int on the 64-bit target
+// (the only way it goes negative is a 0xFFFFFFFF exit on 32-bit Windows). It exists
+// for build symmetry with signal_linux.go and returns a generic failure code, never
+// a cancel/timeout sentinel: a timeout or cancel is already applied by
+// resolveExitCode's overrides before this is consulted, so reaching here means a
+// genuine abnormal exit that must be reported as a failure, not a clean cancel.
+func signalExitCode(_ *exec.ExitError) int { return 1 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"os/signal"
 	"syscall"
 	"time"
 
@@ -80,10 +79,10 @@ func Run(jobDir string) error {
 // race-free.
 func run(jobDir string, grace time.Duration) error {
 	if !proc.Supported {
-		// Job supervision needs process groups, signal forwarding, and /proc, which
-		// only exist on Linux. The non-Linux proc.TerminateGroup stub cannot kill agy,
-		// so the timeout would "fire" without terminating anything and Run would block
-		// in cmd.Wait forever. Refuse here, matching StartJob's guard on the manager side.
+		// Job supervision is implemented on Linux (process groups) and Windows (Job
+		// Objects). On other platforms the proc stubs cannot terminate agy, so the hard
+		// timeout would "fire" without killing anything and Run would block in cmd.Wait
+		// forever. Refuse here, matching StartJob's guard on the manager side.
 		return proc.ErrUnsupported
 	}
 	m, err := jobstore.LoadDir(jobDir)
@@ -91,17 +90,16 @@ func run(jobDir string, grace time.Duration) error {
 		return err
 	}
 
-	// Install the SIGTERM handler first, before opening the job files and starting
-	// agy. A SIGTERM (the manager's cancel) landing during this startup window would
-	// otherwise kill the supervisor with its default disposition, leaving agy with
-	// nobody to forward the signal to, the timeout unenforced, and no sentinel
-	// written. The channel is buffered, so a signal that arrives before the
-	// forwarding goroutine reads it is held, not lost. Installing it before the job
-	// files are created also makes their existence a sound readiness barrier for
-	// tests: once out/err exist, the handler is already in place.
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM)
-	defer signal.Stop(sig)
+	// Arm cancel detection first, before opening the job files and starting agy. A
+	// cancel (SIGTERM on Linux, a sentinel file on Windows) arriving during this
+	// startup window would otherwise be missed, leaving agy with nobody to
+	// terminate it, the timeout unenforced, and no sentinel written. waitForCancel
+	// holds an early cancel (a buffered signal, or a file that persists), so it is
+	// not lost. Arming it before the job files are created also makes their
+	// existence a sound readiness barrier for tests: once out/err exist, cancel is
+	// already armed.
+	cancel, stopCancel := waitForCancel(jobDir)
+	defer stopCancel()
 
 	// 0600: out/err capture full agy output, which often embeds source code, so
 	// they must not be readable by other users on a multi-user host. os.Create would
@@ -128,13 +126,29 @@ func run(jobDir string, grace time.Duration) error {
 	cmd.Stdin = devnull
 	cmd.Stdout = outF
 	cmd.Stderr = errF
-	// Put agy in its own process group so we can signal it and its children.
-	proc.SetGroup(cmd)
+	// Put agy in its own process group / job so the whole tree can be terminated
+	// together on cancel or timeout.
+	proc.ConfigureGroup(cmd)
 
 	if err := cmd.Start(); err != nil {
 		_ = jobstore.WriteExitCodeDir(jobDir, jobstore.ExitSpawnFail)
 		return err
 	}
+	// Capture a handle to agy's process tree so cancel/timeout can terminate it and
+	// its descendants as a unit (kill -pgid on Linux, a Job Object on Windows).
+	// killOnClose=true: if the supervisor itself dies unexpectedly, the Job Object
+	// closing tears down agy and its descendants too (on Windows), rather than
+	// leaking them; on Linux the flag is a no-op (a crashing supervisor orphans agy).
+	grp, err := proc.Track(cmd, true)
+	if err != nil {
+		// Track only fails before Start, which already succeeded above; treat an
+		// unexpected failure as fatal, killing agy so it cannot outlive the sentinel.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = jobstore.WriteExitCodeDir(jobDir, jobstore.ExitSpawnFail)
+		return err
+	}
+	defer func() { _ = grp.Close() }()
 
 	// Terminate the agy process group on either an external SIGTERM (cancel from
 	// the manager) or the hard timeout, escalating to SIGKILL after a grace
@@ -151,21 +165,23 @@ func run(jobDir string, grace time.Duration) error {
 		select {
 		case <-done:
 			return
-		case <-sig:
+		case <-cancel:
 			close(cancelled) // cancel requested by the manager
 		case <-t.C:
 			close(timedOut)
 		}
-		_ = proc.TerminateGroup(cmd.Process.Pid, syscall.SIGTERM)
+		_ = grp.Terminate(syscall.SIGTERM)
 		select {
 		case <-done:
 		case <-time.After(grace):
 			// Do not signal a process group that may have already been reaped
-			// (and whose pgid could be recycled) once Wait has returned.
+			// (and whose pgid could be recycled) once Wait has returned. On Windows
+			// the first Terminate already hard-killed the job, so this escalation is
+			// a no-op there.
 			select {
 			case <-done:
 			default:
-				_ = proc.TerminateGroup(cmd.Process.Pid, syscall.SIGKILL)
+				_ = grp.Terminate(syscall.SIGKILL)
 			}
 		}
 	}()

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package supervisor
 
 import (

--- a/internal/supervisor/supervisor_windows_test.go
+++ b/internal/supervisor/supervisor_windows_test.go
@@ -1,0 +1,140 @@
+package supervisor
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// comspec is the cmd.exe interpreter used to drive the fake agy commands. The
+// supervisor execs agy directly and Windows CreateProcess cannot run a .bat, so
+// the fake agy is a cmd.exe command line rather than a script file.
+func comspec() string {
+	if c := os.Getenv("COMSPEC"); c != "" {
+		return c
+	}
+	return "cmd.exe"
+}
+
+// writeMetaWin writes meta.json into a job dir for a fake-agy command. agyCmd is
+// the cmd.exe command line the supervisor runs (e.g. "echo hi & exit 0").
+func writeMetaWin(t *testing.T, dir, agyCmd string, timeout time.Duration) {
+	t.Helper()
+	m := jobstore.Meta{
+		ID:        "j",
+		AgyPath:   comspec(),
+		Args:      []string{"/c", agyCmd},
+		Cwd:       dir,
+		StartedAt: time.Now(),
+		Timeout:   timeout,
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobstore.MetaPath(dir), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readExit(t *testing.T, dir string) int {
+	t.Helper()
+	b, err := os.ReadFile(jobstore.ExitCodePath(dir))
+	if err != nil {
+		t.Fatalf("read exit_code: %v", err)
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		t.Fatalf("parse exit_code %q: %v", b, err)
+	}
+	return code
+}
+
+// TestRunCapturesOutputAndExit: a fake agy that prints to stdout and stderr and
+// exits non-zero must have its output captured and its exit code recorded.
+func TestRunCapturesOutputAndExit(t *testing.T) {
+	dir := t.TempDir()
+	writeMetaWin(t, dir, "echo review text& echo warn 1>&2& exit 3", time.Minute)
+	if err := Run(dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out, err := os.ReadFile(jobstore.OutPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "review text") {
+		t.Errorf("out = %q, want it to contain %q", out, "review text")
+	}
+	errBytes, err := os.ReadFile(jobstore.ErrPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(errBytes), "warn") {
+		t.Errorf("err = %q, want it to contain %q", errBytes, "warn")
+	}
+	if code := readExit(t, dir); code != 3 {
+		t.Errorf("exit_code = %d, want 3", code)
+	}
+}
+
+// TestRunHardTimeoutTerminatesTree: a fake agy that would run far longer than the
+// timeout must be terminated (with its cmd.exe + ping child tree) by the Job
+// Object, and the job must record ExitTimeout without waiting out the full run.
+func TestRunHardTimeoutTerminatesTree(t *testing.T) {
+	dir := t.TempDir()
+	// ping -n 60 keeps the tree alive ~60s; the 500ms timeout must cut it short.
+	writeMetaWin(t, dir, "ping -n 60 127.0.0.1", 500*time.Millisecond)
+	start := time.Now()
+	if err := Run(dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 15*time.Second {
+		t.Fatalf("Run took %s; the hard timeout did not terminate agy promptly", elapsed)
+	}
+	if code := readExit(t, dir); code != jobstore.ExitTimeout {
+		t.Errorf("exit_code = %d, want %d (timeout)", code, jobstore.ExitTimeout)
+	}
+}
+
+// TestRunCancelViaSentinel: writing the cancel sentinel while agy is running must
+// make the supervisor terminate agy and record ExitSIGTERM (the cancelled state).
+func TestRunCancelViaSentinel(t *testing.T) {
+	dir := t.TempDir()
+	writeMetaWin(t, dir, "ping -n 60 127.0.0.1", time.Minute)
+
+	done := make(chan error, 1)
+	go func() { done <- Run(dir) }()
+
+	// Readiness barrier: once out exists, cancel is armed (Run arms waitForCancel
+	// before creating the job files), so the sentinel cannot be missed.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(jobstore.OutPath(dir)); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("agy job files never appeared")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err := os.WriteFile(jobstore.CancelPath(dir), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Run did not return after the cancel sentinel was written")
+	}
+	if code := readExit(t, dir); code != jobstore.ExitSIGTERM {
+		t.Errorf("exit_code = %d, want %d (cancelled)", code, jobstore.ExitSIGTERM)
+	}
+}

--- a/internal/supervisor/waitcancel_linux.go
+++ b/internal/supervisor/waitcancel_linux.go
@@ -1,0 +1,35 @@
+package supervisor
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// waitForCancel reports a manager cancel to Run. On Linux the manager sends the
+// supervisor SIGTERM, so this installs a SIGTERM handler and closes the returned
+// channel when one arrives. The signal channel is buffered so a SIGTERM that
+// lands before the forwarding goroutine reads it is held, not lost; Run installs
+// the handler before creating the job files, so the "out/err exist" readiness
+// barrier tests rely on also means the cancel handler is already in place.
+//
+// stop releases the handler and the goroutine; Run defers it. The jobDir is
+// unused on Linux (the signal carries the request); the Windows build polls a
+// sentinel in it.
+func waitForCancel(_ string) (cancel <-chan struct{}, stop func()) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM)
+	ch := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-sig:
+			close(ch)
+		case <-done:
+		}
+	}()
+	return ch, func() {
+		signal.Stop(sig)
+		close(done)
+	}
+}

--- a/internal/supervisor/waitcancel_other.go
+++ b/internal/supervisor/waitcancel_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !windows
+
+package supervisor
+
+// waitForCancel is never reached on unsupported platforms: Run refuses via
+// proc.Supported before the cancel wait. It returns a channel that never fires so
+// the package compiles.
+func waitForCancel(_ string) (cancel <-chan struct{}, stop func()) {
+	return make(chan struct{}), func() {}
+}

--- a/internal/supervisor/waitcancel_windows.go
+++ b/internal/supervisor/waitcancel_windows.go
@@ -1,0 +1,43 @@
+package supervisor
+
+import (
+	"os"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// cancelPollInterval is how often the supervisor checks for the cancel sentinel.
+// A few hundred ms bounds cancel latency without a busy loop; the hard timeout is
+// enforced by the same goroutine's timer, so cancel need not be instant.
+const cancelPollInterval = 200 * time.Millisecond
+
+// waitForCancel reports a manager cancel to Run. Windows has no POSIX signal to
+// deliver to an arbitrary process, so the manager writes a cancel sentinel file
+// into the job dir and this polls for it, closing the returned channel once it
+// appears. Run starts this before creating the job files, so the sentinel is
+// caught even if it was written before polling began (the file persists, unlike a
+// signal), and the "out/err exist" readiness barrier still implies cancel is armed.
+//
+// stop ends the polling goroutine; Run defers it.
+func waitForCancel(jobDir string) (cancel <-chan struct{}, stop func()) {
+	ch := make(chan struct{})
+	done := make(chan struct{})
+	cancelPath := jobstore.CancelPath(jobDir)
+	go func() {
+		t := time.NewTicker(cancelPollInterval)
+		defer t.Stop()
+		for {
+			if _, err := os.Stat(cancelPath); err == nil {
+				close(ch)
+				return
+			}
+			select {
+			case <-done:
+				return
+			case <-t.C:
+			}
+		}
+	}()
+	return ch, func() { close(done) }
+}

--- a/internal/supervisor/waitcancel_windows_test.go
+++ b/internal/supervisor/waitcancel_windows_test.go
@@ -1,0 +1,44 @@
+package supervisor
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+func TestWaitForCancelFiresOnSentinel(t *testing.T) {
+	dir := t.TempDir()
+	cancel, stop := waitForCancel(dir)
+	defer stop()
+
+	select {
+	case <-cancel:
+		t.Fatal("cancel fired before the sentinel was written")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := os.WriteFile(jobstore.CancelPath(dir), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-cancel:
+	case <-time.After(3 * time.Second):
+		t.Fatal("cancel did not fire after the sentinel was written")
+	}
+}
+
+// TestWaitForCancelStopWithoutSentinel: stop must end the polling goroutine
+// cleanly when no cancel ever arrives.
+func TestWaitForCancelStopWithoutSentinel(t *testing.T) {
+	dir := t.TempDir()
+	cancel, stop := waitForCancel(dir)
+	stop()
+	// The channel must not have been closed by stop (no cancel was requested).
+	select {
+	case <-cancel:
+		t.Fatal("cancel must not fire when only stop was called")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/testutil/fakeagy_test.go
+++ b/internal/testutil/fakeagy_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package testutil
 
 import (

--- a/internal/testutil/runscript_test.go
+++ b/internal/testutil/runscript_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package testutil
 
 import (

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -56,6 +57,12 @@ func TestMain(m *testing.M) {
 
 // Build the binary once and use it as its own supervisor against a fake agy.
 func TestRunJobSubcommandEndToEnd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The fake agy is a bash script (testutil.WriteFakeAgy), which the supervisor
+		// cannot exec on Windows. The run-job supervisor path is covered on Windows by
+		// internal/supervisor's TestRunCapturesOutputAndExit (fake agy via cmd.exe).
+		t.Skip("Unix-specific: bash-script fake agy is not executable on Windows")
+	}
 	bin, err := buildBinary()
 	if err != nil {
 		t.Fatal(err)
@@ -81,6 +88,12 @@ func TestRunJobSubcommandEndToEnd(t *testing.T) {
 // the signal to agy and writes the SIGTERM sentinel, which Status maps to
 // "cancelled".
 func TestRunJobCancelViaSignal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// This exercises cancel via SIGTERM, the Linux delivery mechanism; Windows
+		// delivers cancel through a sentinel file instead, covered by internal/supervisor's
+		// TestRunCancelViaSentinel. It also uses the bash-script fake agy.
+		t.Skip("Unix-specific: cancel-via-SIGTERM and bash-script fake agy do not apply on Windows")
+	}
 	bin, err := buildBinary()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Job supervision (the async `agy_run` / `agy_status` / `agy_cancel` tools) was Linux-only: `StartJob` and `supervisor.Run` refused early via `proc.Supported`. This implements it on Windows behind the existing `_linux.go` / `_windows.go` / `_other.go` build-tag split, so async jobs now work on Windows while macOS keeps the clear "unsupported" error. Linux behavior is unchanged.

Every Linux primitive maps to a Win32 analog:

| Mechanism (Linux) | Windows equivalent |
|---|---|
| Process group kill (`Setpgid`, `kill -pgid`) | **Job Objects** (`CreateJobObject` + `AssignProcessToJobObject` + `TerminateJobObject`) |
| `flock` cross-process key lock | `LockFileEx` (`LOCKFILE_EXCLUSIVE_LOCK \| LOCKFILE_FAIL_IMMEDIATELY`) |
| `/proc` liveness (boot_id + pid + starttime + comm) | `OpenProcess` + `GetProcessTimes` creation time + `WaitForSingleObject` + `QueryFullProcessImageName` |
| Detached supervisor (`Setpgid`, init adoption) | `DETACHED_PROCESS` + `CREATE_BREAKAWAY_FROM_JOB` (when the parent job permits it) |
| Cancel via `SIGTERM` to the supervisor | a `cancel` sentinel file the supervisor polls for |

### Key changes

- **`proc`**: replaced the pid-based `SetGroup` / `TerminateGroup(pid, sig)` with a handle-based `Group` API (`ConfigureGroup`, `StartDetached`, `Track`, `Group.Terminate`, `Group.Close`). Linux still uses process groups (behavior-preserving); Windows uses Job Objects. The supervisor tracks agy with **kill-on-close**, so if the supervisor process dies unexpectedly agy and its descendants are torn down too (stricter than the Linux orphan-and-reparent baseline). `StartDetached` adds `CREATE_BREAKAWAY_FROM_JOB` only after confirming the parent job permits breakaway.
- **Liveness (Windows)**: process creation time (`GetProcessTimes`) is an absolute wall-clock value, so it pins a PID across reboots and subsumes the Linux boot-id defense; `WaitForSingleObject` confirms the process is still running, with an image-name fallback for older metas.
- **Cancel**: Windows has no signal for an arbitrary process, so the manager writes a `cancel` sentinel into the job dir and the supervisor polls for it; Linux keeps `SIGTERM`. **Windows difference:** cancel and hard-timeout are hard kills (no `SIGTERM` grace window).
- **Cross-process key lock (Windows)**: `LockFileEx`, released on handle close, matching the Linux flock model.
- Retagged the `_other.go` stubs from `!linux` to `!linux && !windows`; added `signal_windows.go`.
- **CI**: the test suite now runs on `windows-latest`. **README**: documents the two Windows behavioral differences.

## Related Issues

Closes #67

## Test Plan

- [x] Builds and vets on Linux, macOS, and Windows (`GOOS={linux,darwin,windows} go build/vet ./...`)
- [x] Full test suite green on Linux (`go test ./... -race`), no regressions
- [x] Full test suite green on a Windows 11 host, covering the ported paths:
  - Job Object tree-kill and kill-on-close
  - hard-timeout termination of agy + its child tree (`ExitTimeout`)
  - cancel-via-sentinel (`ExitSIGTERM`)
  - creation-time liveness (live / dead / recycled-PID mismatch / image-name fallback)
  - `LockFileEx` cross-process contention and release-on-close
- [x] Unix-shell-based tests (fake agy/supervisor scripts) tagged `!windows`; the ported paths get dedicated `_windows_test.go` coverage plus a Windows supervisor integration test driving a fake agy via `cmd.exe`

### Known Windows differences (documented in the README)

- Cancel and hard timeout are **hard kills** (`TerminateJobObject`), with no `SIGTERM` flush window.
- Cancel is delivered via a **sentinel file**, not a signal.
- The assign-after-`Start` window (a grandchild spawned in the microseconds before `AssignProcessToJobObject`) is an accepted risk inherent to Go's `os/exec` (no `CREATE_SUSPENDED` + resume); agy spends its startup initializing before spawning children, so it is not a practical concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support for job supervision, including process tracking, cancellation, timeout handling, and liveness checks.
  * Supervisor cancellation now works via a sentinel file on Windows, while Linux continues using signal-based cancellation.
  * Expanded CI to run tests on Windows and added Windows-specific coverage.

* **Bug Fixes**
  * Improved process cleanup and termination behavior across platforms.
  * Updated unsupported-platform handling and documentation to reflect Linux, Windows, and macOS behavior more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->