### PR TITLE
feat: support macOS (darwin) as a first-class job-supervision platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      # build + vet on every OS proves the package compiles cross-platform (macOS gets
-      # the unsupported-platform stubs). Job supervision is implemented on Linux and
-      # Windows, so both run the test suite; macOS only builds and vets the stubs.
+      # build + vet on every OS proves the package compiles cross-platform. Job
+      # supervision runs on Linux, macOS, and Windows, so all three run the test
+      # suite; Linux and macOS add -race (both provide the cgo C toolchain), while
+      # Windows omits it (no C toolchain on PATH for the race detector).
       - run: go build ./...
       - run: go vet ./...
       - name: Test (race)
@@ -41,6 +42,9 @@ jobs:
       - name: Test (Windows)
         if: matrix.os == 'windows-latest'
         run: go test ./...
+      - name: Test (macOS, race)
+        if: matrix.os == 'macos-latest'
+        run: go test ./... -race
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Two transports run the same core:
 
 - The `agy` binary on `PATH` (or configured explicitly via `AGY_MCP_AGY_PATH`). agy 1.0.9 or newer is recommended (see the continuation note below).
 - Go 1.26+ to build.
-- The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) is implemented on **Linux** (process groups, `/proc`, the kernel boot id) and **Windows** (Job Objects, `OpenProcess` + process creation time, `LockFileEx`). On **macOS** those async tools return a clear "job supervision is only supported on Linux and Windows" error, while stdio/HTTP serving, `list_models`, and `list_sessions` work everywhere.
+- The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) is implemented on **Linux** and **macOS** (process groups, SIGTERM cancel, an advisory flock) and on **Windows** (Job Objects, `OpenProcess` + process creation time, `LockFileEx`); stdio/HTTP serving, `list_models`, and `list_sessions` work identically everywhere.
 
   Windows behaves the same as Linux with two documented differences:
   - **Cancel and hard timeout are hard kills.** Linux sends agy `SIGTERM` and waits a 10s grace before `SIGKILL`; Windows has no equivalent signal for a detached process, so `TerminateJobObject` ends the whole process tree immediately with no flush window.
@@ -142,7 +142,7 @@ go test ./... -race
 golangci-lint run
 ```
 
-CI builds and vets on Linux and macOS, runs the race-enabled test suite on Linux, and cross-compiles for Windows.
+CI builds and vets on Linux, macOS, and Windows; runs the race-enabled test suite on Linux and macOS; and runs the test suite (without the race detector) on Windows.
 
 ## License
 

--- a/internal/manager/admit_posix_test.go
+++ b/internal/manager/admit_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (

--- a/internal/manager/cancel_other.go
+++ b/internal/manager/cancel_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package manager
 

--- a/internal/manager/cancel_posix.go
+++ b/internal/manager/cancel_posix.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (

--- a/internal/manager/cancel_posix_test.go
+++ b/internal/manager/cancel_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (
@@ -24,8 +26,12 @@ func TestCancelSignalsSupervisor(t *testing.T) {
 		_ = cmd.Wait()
 	}()
 
+	startTicks, ok := readStartTimeTicks(cmd.Process.Pid)
+	if !ok {
+		t.Fatal("readStartTimeTicks(target) failed")
+	}
 	if _, err := m.store.Create(jobstore.Meta{
-		ID: "j", PID: cmd.Process.Pid, BootID: readBootID(), StartedAt: time.Now(),
+		ID: "j", PID: cmd.Process.Pid, BootID: readBootID(), StartTimeTicks: startTicks, StartedAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/manager/cancel_posix_test.go
+++ b/internal/manager/cancel_posix_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 func TestCancelSignalsSupervisor(t *testing.T) {
-	// The liveness guard requires the target's /proc comm to match the
-	// configured supervisor basename, so stand in "sleep" as the supervisor.
+	// processAlive pins liveness by the recorded start time (set below), so any
+	// real, signalable process stands in as the supervisor. SupervisorExe feeds
+	// only the Linux comm fallback, which a recorded start time bypasses.
 	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, SupervisorExe: "sleep"})
 
 	// Spawn a real sleeper process we can signal.

--- a/internal/manager/capture_posix_test.go
+++ b/internal/manager/capture_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (
@@ -21,7 +23,14 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cwd := t.TempDir()
+	// normalizeCwd (via StartJob) resolves symlinks before storing meta.Cwd, so
+	// the cache-lookup key must be resolved the same way: on darwin t.TempDir()
+	// is a symlink (/var/folders/... -> /private/var/folders/...), and a
+	// CacheJSON keyed by the unresolved path would never match meta.Cwd.
+	cwd, err := normalizeCwd(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	const newUUID = "11111111-2222-3333-4444-555555555555"
 
 	c := config.Config{
@@ -326,7 +335,13 @@ func TestCapturePendingSettles(t *testing.T) {
 	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cwd := t.TempDir()
+	// See the identical comment in TestFreshRunCapturesConversationID: the
+	// cache-lookup key must match the symlink-resolved path StartJob persists
+	// as meta.Cwd, or the fake supervisor's cache write is never attributed.
+	cwd, err := normalizeCwd(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	const newUUID = "55556666-7777-8888-9999-000011112222"
 
 	c := config.Config{

--- a/internal/manager/cleanup_posix_test.go
+++ b/internal/manager/cleanup_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (

--- a/internal/manager/gc_posix_test.go
+++ b/internal/manager/gc_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (
@@ -31,11 +33,16 @@ func TestGarbageCollectKeepsExpiredButAliveJob(t *testing.T) {
 	}()
 
 	// Expired (StartedAt well before the TTL cutoff) but its supervisor is alive.
+	startTicks, ok := readStartTimeTicks(cmd.Process.Pid)
+	if !ok {
+		t.Fatal("readStartTimeTicks(target) failed")
+	}
 	if _, err := m.store.Create(jobstore.Meta{
-		ID:        "alive",
-		PID:       cmd.Process.Pid,
-		BootID:    readBootID(),
-		StartedAt: time.Now().Add(-2 * time.Hour),
+		ID:             "alive",
+		PID:            cmd.Process.Pid,
+		BootID:         readBootID(),
+		StartTimeTicks: startTicks,
+		StartedAt:      time.Now().Add(-2 * time.Hour),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/manager/gc_posix_test.go
+++ b/internal/manager/gc_posix_test.go
@@ -18,8 +18,9 @@ import (
 // other GC test uses dead metas, so a regression that dropped the liveness
 // check would pass them; this one needs a real, live process to catch it.
 func TestGarbageCollectKeepsExpiredButAliveJob(t *testing.T) {
-	// processAlive matches the target's /proc comm against the supervisor
-	// basename, so stand in "sleep" as the supervisor.
+	// processAlive pins liveness by the recorded start time (set below), so any
+	// real, live process stands in as the supervisor. SupervisorExe feeds only
+	// the Linux comm fallback, which a recorded start time bypasses.
 	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour, SupervisorExe: "sleep"})
 
 	cmd := exec.Command("sleep", "30")

--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (

--- a/internal/manager/keylock_other.go
+++ b/internal/manager/keylock_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package manager
 

--- a/internal/manager/keylock_other.go
+++ b/internal/manager/keylock_other.go
@@ -5,8 +5,9 @@ package manager
 import "github.com/tphakala/agy-mcp/internal/proc"
 
 // flockExclusiveNB has no implementation on platforms without supervision (e.g.
-// macOS); Linux uses flock and Windows uses LockFileEx (keylock_windows.go).
-// StartJob refuses to spawn on unsupported platforms (proc.Supported) before any
-// admission, and restore never finds a live job there (processAlive is a stub),
-// so this is never reached for a real run; it exists only so the package compiles.
+// FreeBSD); Linux and macOS use flock (keylock_posix.go) and Windows uses
+// LockFileEx (keylock_windows.go). StartJob refuses to spawn on unsupported
+// platforms (proc.Supported) before any admission, and restore never finds a
+// live job there (processAlive is a stub), so this is never reached for a real
+// run; it exists only so the package compiles.
 func flockExclusiveNB(_ uintptr) (bool, error) { return false, proc.ErrUnsupported }

--- a/internal/manager/keylock_posix.go
+++ b/internal/manager/keylock_posix.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (

--- a/internal/manager/keylock_posix_test.go
+++ b/internal/manager/keylock_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (

--- a/internal/manager/liveness_darwin.go
+++ b/internal/manager/liveness_darwin.go
@@ -1,0 +1,71 @@
+//go:build darwin
+
+package manager
+
+import (
+	"encoding/binary"
+	"syscall"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"golang.org/x/sys/unix"
+)
+
+// startTimeMandatory is true on darwin: processAlive has no /proc/comm-style
+// name fallback (see the StartTimeTicks==0 branch in processAlive), so a
+// darwin-started job must carry a start time or a PID-recycled impostor could
+// not be told apart from the real supervisor. StartJob enforces this at spawn.
+const startTimeMandatory = true
+
+// readBootID returns a fixed sentinel on darwin. macOS has no kernel boot id,
+// and none is needed: readStartTimeTicks returns an absolute wall-clock start
+// time that already differs for a PID recycled after a reboot, so boot pinning
+// is subsumed (mirrors liveness_windows.go). The non-empty value keeps
+// StartJob's "boot id unreadable" warning dormant.
+func readBootID() string { return "darwin" }
+
+// readStartTimeTicks returns pid's start time as microseconds since the Unix
+// epoch, decoded from kp_proc.p_starttime — a struct timeval at offset 0 of the
+// kern.proc.pid kinfo_proc blob (Sec int64 @0, Usec int32 @8; LP64 and
+// little-endian on both darwin arches). p_starttime is the first union member
+// of the leading struct extern_proc, itself the first member of struct
+// kinfo_proc, so offset 0 is a stable ABI. Being absolute wall-clock it uniquely
+// pins a process across reboots, so a recycled PID never matches the original's
+// value. ok is false on any failure, so a transient error is never mistaken for
+// a recycled PID: callers only act on a successful read.
+func readStartTimeTicks(pid int) (uint64, bool) {
+	buf, err := unix.SysctlRaw("kern.proc.pid", pid)
+	if err != nil || len(buf) < 12 {
+		return 0, false
+	}
+	sec := binary.LittleEndian.Uint64(buf[0:8])
+	usec := uint64(binary.LittleEndian.Uint32(buf[8:12]))
+	return sec*1_000_000 + usec, true
+}
+
+// processAlive reports whether the job's recorded supervisor PID is still that
+// same live process, pinned by its absolute start time.
+func (m *Manager) processAlive(meta jobstore.Meta) bool {
+	if meta.PID <= 0 {
+		return false
+	}
+	// kill(pid, 0) probes existence without signaling. Any error (ESRCH: no such
+	// process; EPERM: a different user's process recycled the PID) means it is not
+	// our live supervisor. Mirrors the Linux kill(pid,0) probe.
+	if err := syscall.Kill(meta.PID, 0); err != nil {
+		return false
+	}
+	if meta.StartTimeTicks == 0 {
+		// Fail closed: darwin has no name fallback, and the spawn guarantee
+		// (manager.go, gated by startTimeMandatory) means a job this build started
+		// always has a start time. A 0 here is foreign or corrupt meta, correctly
+		// treated as collectable.
+		return false
+	}
+	// A definite mismatch proves PID recycling. A transient read failure
+	// (ok=false) does NOT force a "dead" verdict: the PID exists, so treat it as
+	// alive for this poll, exactly as liveness_windows.go does.
+	if cur, ok := readStartTimeTicks(meta.PID); ok {
+		return cur == meta.StartTimeTicks
+	}
+	return true
+}

--- a/internal/manager/liveness_darwin.go
+++ b/internal/manager/liveness_darwin.go
@@ -3,7 +3,6 @@
 package manager
 
 import (
-	"encoding/binary"
 	"syscall"
 
 	"github.com/tphakala/agy-mcp/internal/jobstore"
@@ -24,22 +23,25 @@ const startTimeMandatory = true
 func readBootID() string { return "darwin" }
 
 // readStartTimeTicks returns pid's start time as microseconds since the Unix
-// epoch, decoded from kp_proc.p_starttime — a struct timeval at offset 0 of the
-// kern.proc.pid kinfo_proc blob (Sec int64 @0, Usec int32 @8; LP64 and
-// little-endian on both darwin arches). p_starttime is the first union member
-// of the leading struct extern_proc, itself the first member of struct
-// kinfo_proc, so offset 0 is a stable ABI. Being absolute wall-clock it uniquely
-// pins a process across reboots, so a recycled PID never matches the original's
-// value. ok is false on any failure, so a transient error is never mistaken for
-// a recycled PID: callers only act on a successful read.
+// epoch, read from kp_proc.p_starttime via the typed kern.proc.pid accessor
+// unix.SysctlKinfoProc. Being an absolute wall-clock value it uniquely pins a
+// process across reboots, so a recycled PID never matches the original's value.
+//
+// A just-forked child we still hold is readable immediately, but a transient
+// sysctl error (e.g. an EINTR from a signal in the window right after fork) can
+// still occur, so retry a few times before concluding the read failed; a
+// genuinely dead PID errors on every attempt and correctly yields (0, false).
+// ok is false on any failure, so a transient error is never mistaken for a
+// recycled PID: callers only act on a successful read.
 func readStartTimeTicks(pid int) (uint64, bool) {
-	buf, err := unix.SysctlRaw("kern.proc.pid", pid)
-	if err != nil || len(buf) < 12 {
-		return 0, false
+	for range 3 {
+		kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+		if err == nil {
+			st := kp.Proc.P_starttime
+			return uint64(st.Sec)*1_000_000 + uint64(st.Usec), true
+		}
 	}
-	sec := binary.LittleEndian.Uint64(buf[0:8])
-	usec := uint64(binary.LittleEndian.Uint32(buf[8:12]))
-	return sec*1_000_000 + usec, true
+	return 0, false
 }
 
 // processAlive reports whether the job's recorded supervisor PID is still that

--- a/internal/manager/liveness_darwin_test.go
+++ b/internal/manager/liveness_darwin_test.go
@@ -1,0 +1,64 @@
+//go:build darwin
+
+package manager
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+func TestReadStartTimeTicksSelfAndBogus(t *testing.T) {
+	self, ok := readStartTimeTicks(os.Getpid())
+	if !ok || self == 0 {
+		t.Fatalf("readStartTimeTicks(self) = %d,%v, want non-zero,true", self, ok)
+	}
+	if v, ok := readStartTimeTicks(1 << 30); ok || v != 0 {
+		t.Errorf("readStartTimeTicks(bogus) = %d,%v, want 0,false", v, ok)
+	}
+}
+
+func TestReadBootIDSentinel(t *testing.T) {
+	if got := readBootID(); got != "darwin" {
+		t.Errorf("readBootID() = %q, want %q", got, "darwin")
+	}
+}
+
+func TestProcessAliveDarwin(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Process.Kill(); _ = cmd.Wait() }()
+
+	ticks, ok := readStartTimeTicks(cmd.Process.Pid)
+	if !ok {
+		t.Fatal("readStartTimeTicks(child) failed")
+	}
+
+	// Alive: matching pid + start time.
+	if !m.processAlive(jobstore.Meta{PID: cmd.Process.Pid, StartTimeTicks: ticks}) {
+		t.Error("processAlive(live pid, matching ticks) = false, want true")
+	}
+	// Recycled: same pid, different recorded start time -> dead.
+	if m.processAlive(jobstore.Meta{PID: cmd.Process.Pid, StartTimeTicks: ticks + 1}) {
+		t.Error("processAlive(live pid, mismatched ticks) = true, want false (recycled)")
+	}
+	// Fail closed: no recorded start time -> dead (no name fallback on darwin).
+	if m.processAlive(jobstore.Meta{PID: cmd.Process.Pid, StartTimeTicks: 0}) {
+		t.Error("processAlive(live pid, StartTimeTicks=0) = true, want false (fail closed)")
+	}
+	// Non-existent pid -> dead.
+	if m.processAlive(jobstore.Meta{PID: 1 << 30, StartTimeTicks: ticks}) {
+		t.Error("processAlive(bogus pid) = true, want false")
+	}
+	// Non-positive pid -> dead.
+	if m.processAlive(jobstore.Meta{PID: 0, StartTimeTicks: ticks}) {
+		t.Error("processAlive(pid 0) = true, want false")
+	}
+}

--- a/internal/manager/liveness_linux.go
+++ b/internal/manager/liveness_linux.go
@@ -12,6 +12,12 @@ import (
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
+// startTimeMandatory reports whether StartJob must fail when it cannot record a
+// supervisor start time. It is false wherever processAlive has a name-based
+// liveness fallback (Linux /proc/comm, Windows image name) or never runs a live
+// job (the unsupported stub); only darwin (no fallback) sets it true.
+const startTimeMandatory = false
+
 // bootID reads the kernel boot id once and caches it. The value is stable for
 // the lifetime of the process, so liveness checks (which run per poll) do not
 // re-read /proc each time.

--- a/internal/manager/liveness_other.go
+++ b/internal/manager/liveness_other.go
@@ -1,13 +1,20 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package manager
 
 import "github.com/tphakala/agy-mcp/internal/jobstore"
 
-// Liveness stubs for platforms with no supervision implementation (e.g. macOS).
+// Liveness stubs for platforms with no supervision implementation.
 // Linux reads the kernel boot id and /proc; Windows queries the process via
-// Win32 (liveness_windows.go). StartJob refuses to spawn on unsupported platforms,
+// Win32 (liveness_windows.go); darwin reads sysctl kern.proc.pid
+// (liveness_darwin.go). StartJob refuses to spawn on unsupported platforms,
 // so these are never reached for a live job; they exist so the package compiles.
+
+// startTimeMandatory reports whether StartJob must fail when it cannot record a
+// supervisor start time. It is false wherever processAlive has a name-based
+// liveness fallback (Linux /proc/comm, Windows image name) or never runs a live
+// job (the unsupported stub); only darwin (no fallback) sets it true.
+const startTimeMandatory = false
 
 func readBootID() string { return "" }
 

--- a/internal/manager/liveness_windows.go
+++ b/internal/manager/liveness_windows.go
@@ -9,6 +9,12 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// startTimeMandatory reports whether StartJob must fail when it cannot record a
+// supervisor start time. It is false wherever processAlive has a name-based
+// liveness fallback (Linux /proc/comm, Windows image name) or never runs a live
+// job (the unsupported stub); only darwin (no fallback) sets it true.
+const startTimeMandatory = false
+
 // readBootID has no kernel-boot-id analog on Windows, and none is needed:
 // readStartTimeTicks returns an absolute wall-clock creation time that already
 // differs for a PID recycled after a reboot, so boot pinning is subsumed. It

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -428,34 +428,17 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	} else if startTimeMandatory {
 		// darwin has no /proc/comm-style liveness fallback, so processAlive fails
 		// closed without a recorded start time; a job must never persist a 0. The
-		// read is a local lookup of a child we just forked, so a failure means it
-		// almost certainly died instantly. Tear it down like the UpdateMeta path
-		// below and release the gate.
-		_ = grp.Terminate(syscall.SIGTERM)
-		go func() {
-			_ = cmd.Wait()
-			_ = grp.Close()
-			_ = m.store.Remove(id)
-			m.pendingCaptures.Delete(id)
-			m.releaseKey(key)
-		}()
-		return Job{}, fmt.Errorf("record supervisor start time: sysctl kern.proc.pid failed for pid %d", cmd.Process.Pid)
+		// read is a local lookup of a child we just forked, so a failure (after the
+		// retries in readStartTimeTicks) means it almost certainly died instantly.
+		// Tear it down and release the gate.
+		m.abortSpawn(cmd, grp, id, key)
+		return Job{}, fmt.Errorf("record supervisor start time for pid %d", cmd.Process.Pid)
 	}
 	if err := m.store.UpdateMeta(meta); err != nil {
 		// Without a persisted PID the supervisor would be untrackable
-		// (uncancellable, and reported as not-alive). Fail closed: terminate it,
-		// then once it has fully exited (so nothing is still writing the job dir)
-		// remove the dir and release the gate. Releasing only after the agy process
-		// group is gone keeps a conflicting same-key run from starting while the
-		// dying agy still holds its session lock.
-		_ = grp.Terminate(syscall.SIGTERM)
-		go func() {
-			_ = cmd.Wait()
-			_ = grp.Close()
-			_ = m.store.Remove(id)
-			m.pendingCaptures.Delete(id)
-			m.releaseKey(key)
-		}()
+		// (uncancellable, and reported as not-alive). Fail closed: tear it down and
+		// release the gate once it has fully exited (see abortSpawn).
+		m.abortSpawn(cmd, grp, id, key)
 		return Job{}, fmt.Errorf("record supervisor pid: %w", err)
 	}
 	// Wait for the supervisor in the background. cmd.Wait returns exactly when
@@ -479,6 +462,24 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	}()
 
 	return Job{ID: id, ConversationID: req.ConversationID, State: StateRunning}, nil
+}
+
+// abortSpawn tears down a supervisor that was started but cannot be recorded as
+// a running job. It terminates the process group, then in the background reaps
+// it and — only once it has fully exited, so nothing is still writing the job
+// dir — removes the dir and releases the gate. Releasing only after the agy
+// process group is gone keeps a conflicting same-key run from starting while the
+// dying agy still holds its session lock. Both spawn-failure paths (start time
+// unreadable on darwin, and UpdateMeta failure) share it so they cannot diverge.
+func (m *Manager) abortSpawn(cmd *exec.Cmd, grp *proc.Group, id, key string) {
+	_ = grp.Terminate(syscall.SIGTERM)
+	go func() {
+		_ = cmd.Wait()
+		_ = grp.Close()
+		_ = m.store.Remove(id)
+		m.pendingCaptures.Delete(id)
+		m.releaseKey(key)
+	}()
 }
 
 // loadedJob is one job's meta from a single meta.json read, the shared input the

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -425,6 +425,21 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	meta.PID = cmd.Process.Pid
 	if ticks, ok := readStartTimeTicks(cmd.Process.Pid); ok {
 		meta.StartTimeTicks = ticks
+	} else if startTimeMandatory {
+		// darwin has no /proc/comm-style liveness fallback, so processAlive fails
+		// closed without a recorded start time; a job must never persist a 0. The
+		// read is a local lookup of a child we just forked, so a failure means it
+		// almost certainly died instantly. Tear it down like the UpdateMeta path
+		// below and release the gate.
+		_ = grp.Terminate(syscall.SIGTERM)
+		go func() {
+			_ = cmd.Wait()
+			_ = grp.Close()
+			_ = m.store.Remove(id)
+			m.pendingCaptures.Delete(id)
+			m.releaseKey(key)
+		}()
+		return Job{}, fmt.Errorf("record supervisor start time: sysctl kern.proc.pid failed for pid %d", cmd.Process.Pid)
 	}
 	if err := m.store.UpdateMeta(meta); err != nil {
 		// Without a persisted PID the supervisor would be untrackable

--- a/internal/manager/restore_posix_test.go
+++ b/internal/manager/restore_posix_test.go
@@ -16,8 +16,9 @@ import (
 
 // startFakeLiveSupervisor starts a real, long-lived process to stand in for a
 // detached job supervisor that survived a manager restart. It returns the pid and
-// the resolved path to the binary; the Manager's SupervisorExe must be set to that
-// path so processAlive's /proc/<pid>/comm check matches ("sleep").
+// the resolved path to the binary. Set the Manager's SupervisorExe to that path
+// for the Linux comm fallback; on darwin (and whenever a start time is recorded)
+// processAlive pins identity by start time and does not consult comm.
 func startFakeLiveSupervisor(t *testing.T) (pid int, exePath string) {
 	t.Helper()
 	exePath, err := exec.LookPath("sleep")

--- a/internal/manager/restore_posix_test.go
+++ b/internal/manager/restore_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package manager
 
 import (
@@ -46,15 +48,25 @@ func newManagerForRestore(t *testing.T, exePath string, maxConcurrency int) *Man
 	return m
 }
 
+// createLiveJob is shared by both "live" and "dead" restore tests: it records
+// pid's real start time when readable (a genuinely live pid) and otherwise
+// leaves StartTimeTicks at its zero value (a killed-and-reaped pid, whose
+// start time can no longer be read) — darwin's processAlive fails closed on a
+// live pid with no recorded start time, but a dead pid still reads as dead on
+// both platforms via kill(pid,0) regardless of StartTimeTicks.
 func createLiveJob(t *testing.T, m *Manager, id, cwd string, pid int) {
 	t.Helper()
-	if _, err := m.store.Create(jobstore.Meta{
+	meta := jobstore.Meta{
 		ID:        id,
 		Cwd:       cwd,
 		PID:       pid,
 		BootID:    readBootID(),
 		StartedAt: time.Now(),
-	}); err != nil {
+	}
+	if ticks, ok := readStartTimeTicks(pid); ok {
+		meta.StartTimeTicks = ticks
+	}
+	if _, err := m.store.Create(meta); err != nil {
 		t.Fatalf("create live job: %v", err)
 	}
 }
@@ -241,12 +253,17 @@ func TestRestoreAndCollectCollectsExpiredAndRestoresLive(t *testing.T) {
 	// A live job whose supervisor survived the restart, itself past the TTL: GC must
 	// keep it (alive), and the gate must re-occupy its key.
 	liveCwd := t.TempDir()
+	startTicks, ok := readStartTimeTicks(pid)
+	if !ok {
+		t.Fatal("readStartTimeTicks(target) failed")
+	}
 	if _, err := m.store.Create(jobstore.Meta{
-		ID:        "live-1",
-		Cwd:       liveCwd,
-		PID:       pid,
-		BootID:    readBootID(),
-		StartedAt: time.Now().Add(-2 * time.Hour),
+		ID:             "live-1",
+		Cwd:            liveCwd,
+		PID:            pid,
+		BootID:         readBootID(),
+		StartTimeTicks: startTicks,
+		StartedAt:      time.Now().Add(-2 * time.Hour),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcptools/run_sync_posix_test.go
+++ b/internal/mcptools/run_sync_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package mcptools
 
 import (

--- a/internal/mcptools/tools_posix_test.go
+++ b/internal/mcptools/tools_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package mcptools
 
 import (
@@ -9,10 +11,10 @@ import (
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
-// This file is _linux-gated: the tests drive StartJob, which only runs job
-// supervision on Linux. The cross-platform tool tests (toStartRequest
-// validation, HTTP serving) live in tools_test.go / serve_http_test.go so
-// `go test ./...` stays green on macOS and Windows.
+// This file is posix-gated (linux || darwin): the tests drive StartJob, which
+// only runs job supervision on Linux and macOS. The cross-platform tool tests
+// (toStartRequest validation, HTTP serving) live in tools_test.go /
+// serve_http_test.go so `go test ./...` stays green on Windows too.
 
 // TestListModelsOverMCP exercises the list_models tool end to end: the handler
 // runs `agy models` (the fake agy prints two lines) and returns them on the

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -1,7 +1,7 @@
 // Package proc holds the process-tree primitives shared by the manager (which
-// spawns the supervisor) and the supervisor (which spawns agy). They are
-// implemented on Linux (process groups) in proc_linux.go and on Windows (Job
-// Objects) in proc_windows.go; other platforms get the no-op/error stubs in
+// spawns the supervisor) and the supervisor (which spawns agy). Linux and macOS
+// share the process-group implementation in proc_posix.go; Windows uses Job
+// Objects in proc_windows.go; other platforms get the no-op/error stubs in
 // proc_other.go so both callers build everywhere and refuse early via Supported.
 package proc
 
@@ -9,7 +9,7 @@ import "errors"
 
 // ErrUnsupported is returned by the stubs on platforms without a supervision
 // implementation and by callers that refuse before spawning. It is a non-nil
-// sentinel on every platform, including Linux and Windows where it is never
-// returned, so an errors.Is/== comparison against it is always safe: a nil error
-// from a successful call must never match it.
-var ErrUnsupported = errors.New("agy-mcp: process supervision is only supported on Linux and Windows")
+// sentinel on every platform, including Linux, macOS, and Windows where it is
+// never returned, so an errors.Is/== comparison against it is always safe: a nil
+// error from a successful call must never match it.
+var ErrUnsupported = errors.New("agy-mcp: process supervision is only supported on Linux, macOS, and Windows")

--- a/internal/proc/proc_other.go
+++ b/internal/proc/proc_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package proc
 

--- a/internal/proc/proc_other.go
+++ b/internal/proc/proc_other.go
@@ -7,10 +7,10 @@ import (
 	"syscall"
 )
 
-// Non-Linux, non-Windows stubs so the manager and supervisor packages build on
-// platforms (e.g. macOS) without a supervision implementation. Both callers
-// check Supported and refuse before spawning, so these are never reached at
-// runtime.
+// Non-Linux, non-Windows, non-macOS stubs so the manager and supervisor packages
+// build on platforms (e.g. FreeBSD) without a supervision implementation. Both
+// callers check Supported and refuse before spawning, so these are never
+// reached at runtime.
 
 // Supported is false here: supervision relies on process groups / job objects.
 const Supported = false

--- a/internal/proc/proc_posix.go
+++ b/internal/proc/proc_posix.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package proc
 
 import (

--- a/internal/proc/proc_posix.go
+++ b/internal/proc/proc_posix.go
@@ -25,7 +25,7 @@ func ConfigureGroup(cmd *exec.Cmd) {
 
 // StartDetached configures cmd so the child leads its own process group and
 // starts it, so the child (the detached supervisor) can be tracked as a group
-// and survives the parent's death via init adoption. On Linux this is
+// and survives the parent's death via init adoption. On Linux and macOS this is
 // ConfigureGroup plus Start; the Windows build additionally sets the detach and
 // job-breakaway creation flags that let the supervisor outlive the manager.
 func StartDetached(cmd *exec.Cmd) error {
@@ -34,8 +34,8 @@ func StartDetached(cmd *exec.Cmd) error {
 }
 
 // Group is a handle to a spawned process tree that can be terminated as a unit.
-// On Linux it is identified by the leader pid (kill -pgid); the Windows build
-// wraps a Job Object handle.
+// On Linux and macOS it is identified by the leader pid (kill -pgid); the
+// Windows build wraps a Job Object handle.
 type Group struct {
 	pid int
 }
@@ -43,9 +43,9 @@ type Group struct {
 // Track captures a handle to the process group led by an already-started cmd, so
 // the group can later be terminated together. cmd.Start must have succeeded.
 // killOnClose is a Windows Job Object option (tear the tree down with the handle);
-// it has no effect on Linux, where a crashing tracker orphans its process group
-// rather than killing it, so the parameter is accepted for a common signature and
-// ignored.
+// it has no effect on Linux or macOS, where a crashing tracker orphans its
+// process group rather than killing it, so the parameter is accepted for a
+// common signature and ignored.
 func Track(cmd *exec.Cmd, _ bool) (*Group, error) {
 	if cmd.Process == nil {
 		return nil, errors.New("proc: Track before Start")
@@ -64,13 +64,14 @@ func (g *Group) Terminate(sig syscall.Signal) error {
 	return syscall.Kill(-g.pid, sig)
 }
 
-// Close releases the handle. On Linux there is nothing to release.
+// Close releases the handle. On Linux and macOS there is nothing to release.
 func (g *Group) Close() error { return nil }
 
 // Signal sends sig to a single pid (not its group). A pid that has already
 // exited (ESRCH) is treated as success: there is nothing left to signal. A
 // non-positive pid is rejected so it never signals the caller's own process
-// group. The manager's Linux cancel uses it to forward SIGTERM to the supervisor.
+// group. The manager's Linux and macOS cancel uses it to forward SIGTERM to the
+// supervisor.
 func Signal(pid int, sig syscall.Signal) error {
 	if pid <= 0 {
 		return syscall.EINVAL

--- a/internal/proc/proc_posix_test.go
+++ b/internal/proc/proc_posix_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || darwin
 
 package proc
 

--- a/internal/supervisor/signal_other.go
+++ b/internal/supervisor/signal_other.go
@@ -9,6 +9,6 @@ import (
 )
 
 // signalExitCode stub so the package builds on platforms without a supervision
-// implementation (e.g. macOS). Run refuses early there (proc.Supported is false),
+// implementation (e.g. FreeBSD). Run refuses early there (proc.Supported is false),
 // so this is never reached at runtime.
 func signalExitCode(_ *exec.ExitError) int { return jobstore.ExitSIGTERM }

--- a/internal/supervisor/signal_other.go
+++ b/internal/supervisor/signal_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package supervisor
 

--- a/internal/supervisor/signal_posix.go
+++ b/internal/supervisor/signal_posix.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || darwin
 
 package supervisor
 

--- a/internal/supervisor/signal_posix_test.go
+++ b/internal/supervisor/signal_posix_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || darwin
 
 package supervisor
 

--- a/internal/supervisor/signal_windows.go
+++ b/internal/supervisor/signal_windows.go
@@ -7,7 +7,7 @@ import "os/exec"
 // exec.ExitError.ExitCode() is negative, and a Windows exit status is an unsigned
 // 32-bit value that ExitCode() widens into a non-negative int on the 64-bit target
 // (the only way it goes negative is a 0xFFFFFFFF exit on 32-bit Windows). It exists
-// for build symmetry with signal_linux.go and returns a generic failure code, never
+// for build symmetry with signal_posix.go and returns a generic failure code, never
 // a cancel/timeout sentinel: a timeout or cancel is already applied by
 // resolveExitCode's overrides before this is consulted, so reaching here means a
 // genuine abnormal exit that must be reported as a failure, not a clean cancel.

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -79,10 +79,11 @@ func Run(jobDir string) error {
 // race-free.
 func run(jobDir string, grace time.Duration) error {
 	if !proc.Supported {
-		// Job supervision is implemented on Linux (process groups) and Windows (Job
-		// Objects). On other platforms the proc stubs cannot terminate agy, so the hard
-		// timeout would "fire" without killing anything and Run would block in cmd.Wait
-		// forever. Refuse here, matching StartJob's guard on the manager side.
+		// Job supervision is implemented on Linux and macOS (process groups) and
+		// Windows (Job Objects). On other platforms the proc stubs cannot terminate
+		// agy, so the hard timeout would "fire" without killing anything and Run
+		// would block in cmd.Wait forever. Refuse here, matching StartJob's guard on
+		// the manager side.
 		return proc.ErrUnsupported
 	}
 	m, err := jobstore.LoadDir(jobDir)

--- a/internal/supervisor/supervisor_posix_test.go
+++ b/internal/supervisor/supervisor_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package supervisor
 
 import (

--- a/internal/supervisor/waitcancel_other.go
+++ b/internal/supervisor/waitcancel_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !windows
+//go:build !linux && !windows && !darwin
 
 package supervisor
 

--- a/internal/supervisor/waitcancel_posix.go
+++ b/internal/supervisor/waitcancel_posix.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package supervisor
 
 import (

--- a/internal/supervisor/waitcancel_posix.go
+++ b/internal/supervisor/waitcancel_posix.go
@@ -8,16 +8,17 @@ import (
 	"syscall"
 )
 
-// waitForCancel reports a manager cancel to Run. On Linux the manager sends the
-// supervisor SIGTERM, so this installs a SIGTERM handler and closes the returned
-// channel when one arrives. The signal channel is buffered so a SIGTERM that
-// lands before the forwarding goroutine reads it is held, not lost; Run installs
-// the handler before creating the job files, so the "out/err exist" readiness
-// barrier tests rely on also means the cancel handler is already in place.
+// waitForCancel reports a manager cancel to Run. On Linux and macOS the manager
+// sends the supervisor SIGTERM, so this installs a SIGTERM handler and closes
+// the returned channel when one arrives. The signal channel is buffered so a
+// SIGTERM that lands before the forwarding goroutine reads it is held, not
+// lost; Run installs the handler before creating the job files, so the
+// "out/err exist" readiness barrier tests rely on also means the cancel handler
+// is already in place.
 //
 // stop releases the handler and the goroutine; Run defers it. The jobDir is
-// unused on Linux (the signal carries the request); the Windows build polls a
-// sentinel in it.
+// unused on Linux and macOS (the signal carries the request); the Windows
+// build polls a sentinel in it.
 func waitForCancel(_ string) (cancel <-chan struct{}, stop func()) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGTERM)

--- a/internal/testutil/fakesupervisor.go
+++ b/internal/testutil/fakesupervisor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -14,9 +15,11 @@ import (
 // FakeSupervisor configures a stand-in supervisor script for tests.
 //
 // The generated script mimics `agy-mcp run-job <jobdir>`: it takes the job
-// directory as $2, writes the job's out (and err/exit_code) files there, and
-// sets its comm to the script basename so the liveness comm fallback sees the
-// same value the real supervisor would report.
+// directory as $2, writes the job's out (and err/exit_code) files there, and,
+// on Linux only, sets its comm to the script basename so the liveness comm
+// fallback sees the same value the real supervisor would report. On
+// macOS/Windows, identity is pinned by process start time instead, so the
+// fake — a real spawned process — needs no comm trick there.
 type FakeSupervisor struct {
 	// AgyPath, when set, makes the script run that (fake) agy binary with
 	// `-p x`, streaming stdout to <dir>/out and stderr to <dir>/err and
@@ -59,13 +62,18 @@ func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 		t.Fatal("FakeSupervisor: CacheDelay requires CachePath")
 	}
 	dir := t.TempDir()
-	// The basename doubles as the comm value; it must stay under the kernel's
-	// 15-char comm limit for the liveness comm fallback to match.
+	// On Linux the basename doubles as the comm value; it must stay under the
+	// kernel's 15-char comm limit for the liveness comm fallback to match.
 	path := filepath.Join(dir, "fake-sup")
 
 	var sb strings.Builder
 	sb.WriteString("#!/usr/bin/env bash\n")
-	sb.WriteString("printf '%s' \"${0##*/}\" > /proc/$$/comm\n")
+	if runtime.GOOS == "linux" {
+		// Linux liveness matches /proc/<pid>/comm against the supervisor basename;
+		// set it so the fake looks like the real supervisor. macOS/Windows pin
+		// identity by start time instead, so the fake needs no comm trick.
+		sb.WriteString("printf '%s' \"${0##*/}\" > /proc/$$/comm\n")
+	}
 	sb.WriteString("dir=\"$2\"\n")
 	if cfg.AgyPath != "" {
 		fmt.Fprintf(&sb, "%q -p x > \"$dir/%s\" 2> \"$dir/%s\"\ncode=$?\n", cfg.AgyPath, jobstore.OutFile, jobstore.ErrFile)

--- a/internal/testutil/fakesupervisor.go
+++ b/internal/testutil/fakesupervisor.go
@@ -17,9 +17,9 @@ import (
 // The generated script mimics `agy-mcp run-job <jobdir>`: it takes the job
 // directory as $2, writes the job's out (and err/exit_code) files there, and,
 // on Linux only, sets its comm to the script basename so the liveness comm
-// fallback sees the same value the real supervisor would report. On
-// macOS/Windows, identity is pinned by process start time instead, so the
-// fake — a real spawned process — needs no comm trick there.
+// fallback sees the same value the real supervisor would report. On macOS,
+// identity is pinned by process start time instead, so the fake — a real
+// spawned process — needs no comm trick there.
 type FakeSupervisor struct {
 	// AgyPath, when set, makes the script run that (fake) agy binary with
 	// `-p x`, streaming stdout to <dir>/out and stderr to <dir>/err and
@@ -70,8 +70,8 @@ func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 	sb.WriteString("#!/usr/bin/env bash\n")
 	if runtime.GOOS == "linux" {
 		// Linux liveness matches /proc/<pid>/comm against the supervisor basename;
-		// set it so the fake looks like the real supervisor. macOS/Windows pin
-		// identity by start time instead, so the fake needs no comm trick.
+		// set it so the fake looks like the real supervisor. macOS pins identity
+		// by start time instead, so the fake needs no comm trick there.
 		sb.WriteString("printf '%s' \"${0##*/}\" > /proc/$$/comm\n")
 	}
 	sb.WriteString("dir=\"$2\"\n")

--- a/internal/testutil/fakesupervisor_posix_test.go
+++ b/internal/testutil/fakesupervisor_posix_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package testutil
 
 import (


### PR DESCRIPTION
## What

Makes agy-mcp run and supervise `agy` jobs natively on **macOS (darwin)** as a first-class, CI-tested platform alongside Linux and Windows. Previously every `agy_run` / `agy_run_sync` on macOS failed with *"process supervision is only supported on Linux and Windows"* — darwin fell into the refusing `_other.go` stubs (`proc.Supported == false`).

## How

Mirrors the existing Windows-port precedent (identity pinned by absolute wall-clock start time, no `/proc`):

- **Share the POSIX supervision code.** The five pure-POSIX files (`proc`, `cancel`, `keylock`, `signal`, `waitcancel`) move from `*_linux.go` → `*_posix.go` with `//go:build linux || darwin` — bodies unchanged. They use only syscalls that behave identically on darwin (`Flock`, `Kill`, `Setpgid`, `WaitStatus`, `signal.Notify`).
- **New `internal/manager/liveness_darwin.go`.** Reads the supervisor's start time via the typed `unix.SysctlKinfoProc("kern.proc.pid", …)` (`kp_proc.p_starttime`) and pins process identity by it — the darwin analog of the Windows FILETIME approach. `readBootID()` returns a `"darwin"` sentinel (an absolute start time subsumes boot pinning).
- **Darwin-scoped spawn guarantee.** darwin has no `/proc/comm`-style name fallback, so `processAlive` fails **closed** when no start time is recorded; a new per-platform `startTimeMandatory` const (true only on darwin) makes `StartJob` fail cleanly if it can't record one. Linux/Windows keep their name-based fallback and are unaffected (`startTimeMandatory == false` → dead branch).
- **Retag `_other.go` stubs** to `!linux && !windows && !darwin`.
- **CI:** `macos-latest` now runs the full `go test ./... -race` suite (was build+vet only).
- Docs/comments/`ErrUnsupported` message updated to reflect macOS support.

## Testing

- Full `go test ./... -race` green on darwin/arm64 (all 8 packages), including the supervision integration tests that were Linux-gated (renamed `*_linux_test.go` → `*_posix_test.go`, with hand-crafted live metas now recording a start time so they pass under darwin's fail-closed liveness).
- `go build`/`go vet` clean for linux, darwin, windows, and the `!linux && !windows && !darwin` "other" stub set.
- Behavior-preserving for existing Linux/Windows users: the POSIX renames are body-identical and the new spawn guard is a dead branch off-darwin.

## Review

Ran a parallel pre-push gate (correctness, reuse, quality, integration, plus an independent Gemini 3.1 Pro cross-validation). Gemini's verdict: *"completely behavior-preserving"* for Linux/Windows, correct sysctl decoding and fail-closed semantics, no bugs. Review findings addressed in the final commit: use the typed `SysctlKinfoProc` (1 syscall, no manual byte-decode), retry a transient sysctl read so a blip just after fork can't kill a healthy supervisor, dedupe the spawn-teardown into a shared `abortSpawn` helper, and correct stale `/proc-comm` comments.

Only `internal/manager/liveness_linux.go` / `liveness_linux_test.go` remain Linux-specific by necessity (they read/parse `/proc`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job supervision now works on macOS, matching Linux behavior.
  * CI now runs race-detection tests on Linux and macOS, with standard tests on Windows.

* **Bug Fixes**
  * Improved job liveness tracking so running jobs are less likely to be mistaken for stale ones.
  * Fixed path handling in job capture/restore flows to better match persisted locations.

* **Documentation**
  * Updated README and CI notes to reflect current platform support and testing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->