### PR TITLE
rules: resolve overlap and coverage policy calls

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,7 @@ linters:
     - modernize
     - nilerr
     - nilnil
+    - nosprintfhostport
     - predeclared
     - prealloc
     - revive
@@ -41,6 +42,7 @@ linters:
     - thelper
     - unconvert
     - unused
+    - usetesting
     - wastedassign
   settings:
     gocognit:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -72,6 +72,15 @@ linters:
       for-loops: true
     exhaustive:
       default-signifies-exhaustive: true
+    usetesting:
+      # Both default to false upstream (ldez/usetesting); without these,
+      # usetesting silently does not flag context.Background()/context.TODO()
+      # in tests at all, verified empirically with the pinned golangci-lint
+      # version, so leaving them off would make the rules/doc.go policy
+      # comment's "usetesting covers the same ground as TestingContext" claim
+      # false as configured.
+      context-background: true
+      context-todo: true
   exclusions:
     rules:
       # goconst gained cross-file scanning in golangci-lint v2.12 (the old

--- a/rules/builtins.go
+++ b/rules/builtins.go
@@ -151,21 +151,6 @@ func RangeOverInteger(m dsl.Matcher) {
 		Report("use for $i := range $n instead of for $i := 0; $i < $n; $i++ (Go 1.22+)")
 }
 
-// AppendWithoutValues detects append calls with no values which have no effect.
-//
-// Broken pattern:
-//
-//	slice = append(slice)  // No effect
-//
-// See: https://pkg.go.dev/builtin#append
-// Note: Go 1.22 vet tool also warns about this pattern.
-func AppendWithoutValues(m dsl.Matcher) {
-	m.Match(
-		`append($s)`,
-	).
-		Report("append with single argument has no effect; did you forget the values to append?")
-}
-
 // NewWithExpression detects the slice-literal hack for getting a pointer to a value
 // and suggests using Go 1.26's enhanced new() built-in.
 //

--- a/rules/doc.go
+++ b/rules/doc.go
@@ -6,4 +6,35 @@
 // settings.gocritic.settings.ruleguard.rules in .golangci.yaml). Every file
 // carries the //go:build ruleguard tag so the normal Go toolchain ignores
 // them; `go build -tags ruleguard ./rules/` compiles them as a canary.
+//
+// # Overlap with govet and staticcheck
+//
+// A few matchers deliberately duplicate a stock analyzer instead of ceding to
+// it, because .golangci.yaml sets issues.uniq-by-line: true: when two linters
+// flag the same line, only one message survives and the winner is arbitrary
+// run-order, not a quality choice. Two outcomes follow from that:
+//
+//   - Exact duplicates with no informational gain over the stock analyzer are
+//     deleted rather than kept as dead weight (AppendWithoutValues and
+//     DeferredTimeSince were removed: govet's default appends/defers
+//     analyzers already flag the identical patterns with an equivalent
+//     message; verified with `go vet` and a minimal govet-only golangci-lint
+//     config). DeferredTimeNow stays: govet's defers analyzer does not flag a
+//     bare deferred time.Now(), only defer-wrapped time.Since().
+//   - The crypto.go and reflect.go Deprecated* matchers keep duplicating
+//     staticcheck's SA1019 anyway: their messages name the concrete attack
+//     class (Bleichenbacher, active-attack vulnerability in unauthenticated
+//     cipher modes, etc.) and the specific replacement API, which is more
+//     actionable than SA1019's generic "X is deprecated" text. Sometimes
+//     staticcheck's message wins the uniq-by-line lottery instead and the
+//     richer text doesn't show, but the line is still flagged either way, so
+//     this only costs message quality, never a missed violation. That trade
+//     is accepted deliberately.
+//
+// JoinHostPort and TestingContext were removed in favor of enabling the
+// nosprintfhostport and usetesting stock linters (see .golangci.yaml), which
+// cover the same ground with proper type/control-flow analysis instead of
+// ruleguard's syntactic matching. This also fixes TestingContext's known
+// false positive in TestMain/benchmarks (ruleguard matches by file name and
+// cannot see the enclosing function signature; usetesting can).
 package gorules

--- a/rules/doc.go
+++ b/rules/doc.go
@@ -21,20 +21,36 @@
 //     message; verified with `go vet` and a minimal govet-only golangci-lint
 //     config). DeferredTimeNow stays: govet's defers analyzer does not flag a
 //     bare deferred time.Now(), only defer-wrapped time.Since().
-//   - The crypto.go and reflect.go Deprecated* matchers keep duplicating
-//     staticcheck's SA1019 anyway: their messages name the concrete attack
-//     class (Bleichenbacher, active-attack vulnerability in unauthenticated
-//     cipher modes, etc.) and the specific replacement API, which is more
+//   - Some Deprecated* matchers (crypto.go, reflect.go, and net.go's
+//     DeprecatedReverseProxyDirector) keep duplicating staticcheck's SA1019
+//     anyway: their messages name the concrete attack class (Bleichenbacher,
+//     active-attack vulnerability in unauthenticated cipher modes, hop-by-hop
+//     header abuse, etc.) and the specific replacement API, which is more
 //     actionable than SA1019's generic "X is deprecated" text. Sometimes
 //     staticcheck's message wins the uniq-by-line lottery instead and the
 //     richer text doesn't show, but the line is still flagged either way, so
 //     this only costs message quality, never a missed violation. That trade
-//     is accepted deliberately.
+//     is accepted deliberately. This is not a full audit of every
+//     Deprecated*-flavored matcher in the package against SA1019 or against
+//     the now-enabled modernize linter; see #77 for the remaining candidates.
 //
-// JoinHostPort and TestingContext were removed in favor of enabling the
-// nosprintfhostport and usetesting stock linters (see .golangci.yaml), which
-// cover the same ground with proper type/control-flow analysis instead of
-// ruleguard's syntactic matching. This also fixes TestingContext's known
-// false positive in TestMain/benchmarks (ruleguard matches by file name and
-// cannot see the enclosing function signature; usetesting can).
+// TestingContext was removed in favor of enabling the stock usetesting
+// linter with its context-background and context-todo settings explicitly
+// turned on (see .golangci.yaml linters.settings.usetesting; both default to
+// false upstream, so enabling the linter alone does NOT reproduce
+// TestingContext's coverage, verified empirically). With those settings on,
+// usetesting also fixes TestingContext's known false positive in
+// TestMain/benchmarks, since it has real control-flow visibility into the
+// enclosing function signature where ruleguard's file-name-only matching did
+// not. Enabling usetesting's os-mkdir-temp check as a side effect newly
+// overlaps testing.go's TestingArtifactDir matcher; that pair is kept
+// deliberately for the same richer-message reason as the SA1019 duplicates
+// above.
+//
+// JoinHostPort was kept, not removed: the stock nosprintfhostport linter
+// only matches a scheme-prefixed URL ("scheme://%s:..."), never the bare
+// "%s:%d"/"%v:%d" pattern JoinHostPort targets (the common case for building
+// a raw net.Dial/net.Listen/http.Server.Addr address), verified empirically.
+// nosprintfhostport is enabled anyway as complementary coverage for the
+// URL-embedded case, which JoinHostPort deliberately does not flag.
 package gorules

--- a/rules/net.go
+++ b/rules/net.go
@@ -4,6 +4,39 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
+// JoinHostPort detects fmt.Sprintf patterns for a bare host:port and suggests
+// net.JoinHostPort. Kept alongside the stock nosprintfhostport linter rather
+// than being superseded by it: nosprintfhostport's upstream analyzer only
+// matches a scheme-prefixed URL ("scheme://%s:..."), never the bare
+// "%s:%d"/"%v:%d" form this rule targets (verified empirically), which is the
+// common case for building a raw net.Dial/net.Listen/http.Server.Addr address.
+//
+// The old pattern:
+//
+//	addr := fmt.Sprintf("%s:%d", host, port)
+//
+// Should be:
+//
+//	addr := net.JoinHostPort(host, strconv.Itoa(port))
+//
+// net.JoinHostPort properly handles IPv6 addresses by wrapping them in brackets,
+// which fmt.Sprintf does not. This is critical for network code correctness.
+//
+// Note: This rule only flags patterns with integer ports to reduce false positives.
+// String concatenation patterns like "host + : + port" are too common for non-network
+// use cases (cache keys, identifiers, etc.) and are not flagged.
+//
+// See: https://pkg.go.dev/net#JoinHostPort
+func JoinHostPort(m dsl.Matcher) {
+	// Only flag fmt.Sprintf with integer port - this is a strong signal for network addresses
+	// String ports could be cache keys, identifiers, etc.
+	m.Match(
+		`fmt.Sprintf("%s:%d", $host, $port)`,
+		`fmt.Sprintf("%v:%d", $host, $port)`,
+	).
+		Report("use net.JoinHostPort($host, strconv.Itoa($port)) instead of fmt.Sprintf for host:port (handles IPv6 correctly)")
+}
+
 // FilepathIsLocal detects simple path traversal checks that could use filepath.IsLocal.
 //
 // Old pattern (manual path traversal check):

--- a/rules/net.go
+++ b/rules/net.go
@@ -4,34 +4,6 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// JoinHostPort detects fmt.Sprintf patterns for host:port and suggests net.JoinHostPort.
-//
-// The old pattern:
-//
-//	addr := fmt.Sprintf("%s:%d", host, port)
-//
-// Should be:
-//
-//	addr := net.JoinHostPort(host, strconv.Itoa(port))
-//
-// net.JoinHostPort properly handles IPv6 addresses by wrapping them in brackets,
-// which fmt.Sprintf does not. This is critical for network code correctness.
-//
-// Note: This rule only flags patterns with integer ports to reduce false positives.
-// String concatenation patterns like "host + : + port" are too common for non-network
-// use cases (cache keys, identifiers, etc.) and are not flagged.
-//
-// See: https://pkg.go.dev/net#JoinHostPort
-func JoinHostPort(m dsl.Matcher) {
-	// Only flag fmt.Sprintf with integer port - this is a strong signal for network addresses
-	// String ports could be cache keys, identifiers, etc.
-	m.Match(
-		`fmt.Sprintf("%s:%d", $host, $port)`,
-		`fmt.Sprintf("%v:%d", $host, $port)`,
-	).
-		Report("use net.JoinHostPort($host, strconv.Itoa($port)) instead of fmt.Sprintf for host:port (handles IPv6 correctly)")
-}
-
 // FilepathIsLocal detects simple path traversal checks that could use filepath.IsLocal.
 //
 // Old pattern (manual path traversal check):

--- a/rules/testing.go
+++ b/rules/testing.go
@@ -54,67 +54,6 @@ func BenchmarkLoop(m dsl.Matcher) {
 		Suggest("for $b.Loop() { $body }")
 }
 
-// TestingContext detects context.Background() or context.TODO() in test functions
-// and suggests using t.Context() instead.
-//
-// The old pattern:
-//
-//	func TestFoo(t *testing.T) {
-//	    ctx := context.Background()
-//	    result, err := doSomething(ctx)
-//	}
-//
-// New pattern (Go 1.24+):
-//
-//	func TestFoo(t *testing.T) {
-//	    ctx := t.Context()
-//	    result, err := doSomething(ctx)
-//	}
-//
-// Benefits:
-//   - Context is automatically canceled when test completes
-//   - Test cleanup is properly signaled to goroutines
-//   - Resources are released promptly on test failure
-//
-// Caveat: this matches by file name (_test.go), so it also fires inside
-// TestMain(m *testing.M) and any plain helper where no *testing.T or *testing.B
-// is in scope; in those spots neither t.Context() nor b.Context() applies and
-// the suggestion should be ignored.
-//
-// See: https://pkg.go.dev/testing#T.Context
-// See: https://pkg.go.dev/testing#B.Context
-func TestingContext(m dsl.Matcher) {
-	// Pattern 1: Assigning context.Background() to a variable
-	m.Match(
-		`$ctx := context.Background()`,
-		`$ctx = context.Background()`,
-	).
-		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.Background() for automatic cancellation on test completion (Go 1.24+)")
-
-	// Pattern 2: Assigning context.TODO() to a variable
-	m.Match(
-		`$ctx := context.TODO()`,
-		`$ctx = context.TODO()`,
-	).
-		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.TODO() for automatic cancellation on test completion (Go 1.24+)")
-
-	// Pattern 3: Passing context.Background() directly to a function
-	m.Match(
-		`$fn(context.Background(), $*args)`,
-	).
-		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.Background() (Go 1.24+)")
-
-	// Pattern 4: Passing context.TODO() directly to a function
-	m.Match(
-		`$fn(context.TODO(), $*args)`,
-	).
-		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report("in tests, use t.Context() (or b.Context() in benchmarks) instead of context.TODO() (Go 1.24+)")
-}
-
 // TestingArtifactDir detects os.MkdirTemp in test files and suggests using
 // the testing.T.ArtifactDir method added in Go 1.26.
 //

--- a/rules/time.go
+++ b/rules/time.go
@@ -131,40 +131,6 @@ func TimerChannelLen(m dsl.Matcher) {
 		Report("cap() on ticker channel is always 0 in Go 1.23+ (channels are now unbuffered)")
 }
 
-// DeferredTimeSince detects deferred calls to time.Since which evaluate
-// the duration at defer time, not at function exit.
-//
-// Broken pattern:
-//
-//	func foo() {
-//	    start := time.Now()
-//	    defer log.Println(time.Since(start))  // Evaluated NOW, not at exit!
-//	    // ... work ...
-//	}
-//
-// The time.Since(start) is called immediately when defer is executed,
-// so it will always report ~0 duration.
-//
-// Correct pattern:
-//
-//	func foo() {
-//	    start := time.Now()
-//	    defer func() { log.Println(time.Since(start)) }()
-//	    // ... work ...
-//	}
-//
-// See: https://pkg.go.dev/time#Since
-// Note: Go 1.22 vet tool also warns about this pattern.
-func DeferredTimeSince(m dsl.Matcher) {
-	// One clause covers time.Since in any argument position: the two variadic
-	// captures absorb any preceding and trailing args (including none), so the
-	// earlier per-position clauses were redundant.
-	m.Match(
-		`defer $fn($*_, time.Since($start), $*_)`,
-	).
-		Report("time.Since($start) is evaluated at defer time, not function exit; wrap in func() to measure actual duration")
-}
-
 // DeferredTimeNow detects deferred calls to time.Now which evaluate
 // the time at defer time, not at function exit.
 //


### PR DESCRIPTION
## Summary
- Resolves the 3 open policy items from #31: drops `AppendWithoutValues`/`DeferredTimeSince` as exact govet duplicates (verified empirically), keeps `DeferredTimeNow` (not covered by govet), enables `nosprintfhostport`/`usetesting` alongside the existing ruleguard matchers.
- Documents the overlap policy in `rules/doc.go` so the reasoning survives the next contributor, including the SA1019-duplication rationale for the crypto.go/reflect.go/net.go `Deprecated*` matchers.
- Pre-push gate review (5 independent agents + Gemini) found the original "usetesting/nosprintfhostport supersede TestingContext/JoinHostPort" claim was only half true: `usetesting`'s context checks default to off upstream, and `nosprintfhostport` only matches scheme-prefixed URLs, not the bare `host:port` pattern. Fixed by adding explicit `usetesting` settings and restoring `JoinHostPort` as complementary coverage (not a duplicate) alongside `nosprintfhostport`.
- Filed #77 to track a broader overlap audit (runtime.go, random.go, sync.go, builtins.go vs the now-enabled `modernize` linter) that came up during review but is out of this PR's scope.

## Related Issues
Fixes #31

## Test Plan
- [x] `go build -tags ruleguard ./rules/` (CI canary)
- [x] `golangci-lint run ./...` (0 issues, CI-pinned v2.12.2)
- [x] `go build/vet/test ./...`
- [x] Repro test confirming both `JoinHostPort` and `usetesting`'s context checks fire against the real `.golangci.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lint checks for direct `time.Now()` use in deferred calls.
  * Added guidance for replacing slice-literal pointer expressions with Go’s enhanced `new(...)` syntax.
  * Added lint coverage for bare host-and-port formatting patterns.

* **Bug Fixes**
  * Improved detection of invalid or ineffective coding patterns.

* **Documentation**
  * Expanded guidance explaining overlapping lint checks and their behavior.

* **Chores**
  * Updated testing-related lint configuration and removed redundant checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->