### PR TITLE
manager: consolidate test poll loops/builders, add darwin spawn-fail coverage

### DIFF
--- a/internal/manager/admit_posix_test.go
+++ b/internal/manager/admit_posix_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/tphakala/agy-mcp/internal/config"
 )
 
 // twoManagers returns two managers that share one state dir, modeling two sibling
@@ -16,8 +14,8 @@ import (
 func twoManagers(t *testing.T) (m1, m2 *Manager) {
 	t.Helper()
 	dir := t.TempDir()
-	cfg := config.Config{StateDir: dir, MaxConcurrency: 4}
-	return New(cfg), New(cfg)
+	opts := managerOpts{stateDir: dir, maxConcurrency: 4}
+	return newManager(t, opts), newManager(t, opts)
 }
 
 // TestAdmitExcludesAcrossManagers: a fresh-run key admitted by one manager must be
@@ -71,7 +69,7 @@ func TestAdmitEmptyKeyNotSerialized(t *testing.T) {
 // own outcomes (same-key busy, at-cap) and not let the cross-process layer mask
 // them, so the precise StartJob error is unchanged.
 func TestAdmitInProcessRefusalsStillApply(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 1})
+	m := newManager(t, managerOpts{maxConcurrency: 1})
 
 	if outcome, err := m.admit("conv:a"); err != nil || outcome != acquireOK {
 		t.Fatalf("first admit = (%v, %v), want (acquireOK, nil)", outcome, err)
@@ -96,7 +94,7 @@ func TestAdmitFailsClosedOnLockError(t *testing.T) {
 	if err := os.WriteFile(fileAsStateDir, []byte("not a dir"), 0o600); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	m := New(config.Config{StateDir: fileAsStateDir, MaxConcurrency: 4})
+	m := newManager(t, managerOpts{stateDir: fileAsStateDir, maxConcurrency: 4})
 
 	if _, err := m.admit("cwd:/w"); err == nil {
 		t.Fatal("admit must fail closed when the cross-process lock cannot be created")
@@ -149,7 +147,7 @@ func TestForceAdmitTracksDespiteSiblingLock(t *testing.T) {
 	}
 	// m1 never held the lock, so its release must not free the sibling's lock.
 	m1.releaseKey("cwd:/w")
-	m3 := New(config.Config{StateDir: m2.cfg.StateDir, MaxConcurrency: 4})
+	m3 := newManager(t, managerOpts{stateDir: m2.cfg.StateDir, maxConcurrency: 4})
 	if outcome, err := m3.admit("cwd:/w"); err != nil || outcome != acquireKeyBusy {
 		t.Fatalf("m3.admit while m2 still holds = (%v, %v), want (acquireKeyBusy, nil)", outcome, err)
 	}

--- a/internal/manager/cancel_posix_test.go
+++ b/internal/manager/cancel_posix_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
@@ -15,7 +14,7 @@ func TestCancelSignalsSupervisor(t *testing.T) {
 	// processAlive pins liveness by the recorded start time (set below), so any
 	// real, signalable process stands in as the supervisor. SupervisorExe feeds
 	// only the Linux comm fallback, which a recorded start time bypasses.
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, SupervisorExe: "sleep"})
+	m := newManager(t, managerOpts{maxConcurrency: 4, supervisorExe: "sleep"})
 
 	// Spawn a real sleeper process we can signal.
 	cmd := execpkg.Command("sleep", "30")

--- a/internal/manager/cancel_posix_test.go
+++ b/internal/manager/cancel_posix_test.go
@@ -60,7 +60,7 @@ func TestCancelSignalsSupervisor(t *testing.T) {
 // (a stale PID from a previous boot), Cancel is a no-op success; there is
 // nothing to signal and Status reports the terminal state from disk.
 func TestCancelDeadSupervisorNoOp(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	// A dead PID from a previous boot: processAlive is false, so Cancel must not
 	// signal anything and must return nil.
 	if _, err := m.store.Create(jobstore.Meta{ID: "j", PID: 999999, BootID: "old-boot", StartedAt: time.Now()}); err != nil {
@@ -74,7 +74,7 @@ func TestCancelDeadSupervisorNoOp(t *testing.T) {
 // TestCancelLoadError: cancelling an unknown job surfaces the store's load
 // error rather than silently succeeding.
 func TestCancelLoadError(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	if err := m.Cancel("does-not-exist"); err == nil {
 		t.Fatal("Cancel on an unknown job must return the load error")
 	}

--- a/internal/manager/capture_posix_test.go
+++ b/internal/manager/capture_posix_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
@@ -50,10 +49,8 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 		t.Fatalf("fresh run should start with no conversation id, got %q", job.ConversationID)
 	}
 
+	// waitForCapturedID's postcondition already guarantees st.State == StateDone.
 	st := waitForCapturedID(t, m, job.ID, 3*time.Second)
-	if st.State != StateDone {
-		t.Fatalf("state = %q, want done", st.State)
-	}
 	if st.ConversationID != newUUID {
 		t.Fatalf("captured conversation id = %q, want %q", st.ConversationID, newUUID)
 	}
@@ -144,12 +141,12 @@ func TestStatusLazilyCapturesConversationID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  "/bin/true",
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  "/bin/true",
+		stateDir:       state,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
 	})
 	m.cacheFile = cachePath
 
@@ -204,12 +201,12 @@ func TestStatusLazyCaptureNoOpWhenCacheUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  "/bin/true",
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  "/bin/true",
+		stateDir:       state,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
 	})
 	m.cacheFile = cachePath
 
@@ -251,14 +248,13 @@ func TestFreshRunWithCorruptCacheDisablesCapture(t *testing.T) {
 	}
 	cwd := t.TempDir()
 
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		stateDir:       state,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+	})
 	m.cacheFile = cachePath
 	m.captureBudget = 50 * time.Millisecond
 	m.capturePoll = 10 * time.Millisecond
@@ -358,12 +354,12 @@ func TestStatusLazyCaptureSkipsWhenLaterRunExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  "/bin/true",
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  "/bin/true",
+		stateDir:       state,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
 	})
 	m.cacheFile = cachePath
 
@@ -434,12 +430,12 @@ func TestStatusLazyCaptureSkipsButDoesNotSettleOnListError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  "/bin/true",
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  "/bin/true",
+		stateDir:       state,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
 	})
 	m.cacheFile = cachePath
 	fls := &failListStore{jobStore: m.store}
@@ -502,12 +498,12 @@ func TestStatusLazyCaptureSettlesAfterHorizon(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  "/bin/true",
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  "/bin/true",
+		stateDir:       state,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
 	})
 	m.cacheFile = cachePath
 
@@ -554,12 +550,12 @@ func TestStatusLazyCaptureSettlesViaFallbackHorizonWhenTimeoutZero(t *testing.T)
 		t.Fatal(err)
 	}
 
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  "/bin/true",
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  "/bin/true",
+		stateDir:       state,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
 	})
 	m.cacheFile = cachePath
 

--- a/internal/manager/capture_posix_test.go
+++ b/internal/manager/capture_posix_test.go
@@ -18,7 +18,6 @@ import (
 // A completed fresh run must report the conversation id agy created for it,
 // captured by diffing the conversation cache against the pre-run snapshot.
 func TestFreshRunCapturesConversationID(t *testing.T) {
-	state := t.TempDir()
 	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
 	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)
@@ -33,16 +32,14 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 	}
 	const newUUID = "11111111-2222-3333-4444-555555555555"
 
-	c := config.Config{
-		AgyPath: "/usr/bin/agy",
-		SupervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+	m := newManager(t, managerOpts{
+		agyPath: "/usr/bin/agy",
+		supervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
 			Out: "done", CachePath: cachePath, CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, newUUID),
 		}),
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+	})
 	m.cacheFile = cachePath
 
 	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
@@ -81,32 +78,25 @@ func TestFreshRunCapturesConversationID(t *testing.T) {
 // StateDir races the TempDir RemoveAll cleanup.
 func waitForExitCode(t *testing.T, m *Manager, id string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, ok := m.store.ExitCode(id); ok {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("job %s never wrote exit_code", id)
+	testutil.WaitFor(t, 2*time.Second, func() bool {
+		_, ok := m.store.ExitCode(id)
+		return ok
+	}, fmt.Sprintf("job %s never wrote exit_code", id))
 }
 
 func TestFreshRunNoConversationReleasesKey(t *testing.T) {
-	state := t.TempDir()
 	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
 	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	cwd := t.TempDir()
 
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}), // writes out + exit 0, never touches the cache
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}), // writes out + exit 0, never touches the cache
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+	})
 	m.cacheFile = cachePath
 	m.captureBudget = 50 * time.Millisecond
 	m.capturePoll = 10 * time.Millisecond
@@ -117,39 +107,29 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 	}
 
 	// Wait for the job to finish; the id stays empty (no conversation was created).
-	deadline := time.Now().Add(2 * time.Second)
-	seenDone := false
-	for time.Now().Before(deadline) {
-		if st, _ := m.Status(job.ID); st.State == StateDone {
-			if st.ConversationID != "" {
-				t.Fatalf("expected empty conversation id, got %q", st.ConversationID)
-			}
-			seenDone = true
-			break
+	testutil.WaitFor(t, 2*time.Second, func() bool {
+		st, _ := m.Status(job.ID)
+		if st.State != StateDone {
+			return false
 		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if !seenDone {
-		t.Fatal("job never reached done state")
-	}
+		if st.ConversationID != "" {
+			t.Fatalf("expected empty conversation id, got %q", st.ConversationID)
+		}
+		return true
+	}, "job never reached done state")
 
 	// The gate key must have been released after the capture budget: a second
 	// same-cwd fresh run eventually succeeds.
-	deadline = time.Now().Add(2 * time.Second)
-	for {
-		job2, err := m.StartJob(StartRequest{Prompt: "again", Cwd: cwd})
-		if err == nil {
-			// Wait for the second job's supervisor to finish before returning. It writes
-			// into StateDir (a t.TempDir), and a still-running supervisor races the TempDir
-			// RemoveAll cleanup ("directory not empty"). Waiting for exit removes the racer.
-			waitForExitCode(t, m, job2.ID)
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("gate key was not released after a fresh run that created no conversation")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	var job2 Job
+	testutil.WaitFor(t, 2*time.Second, func() bool {
+		var err error
+		job2, err = m.StartJob(StartRequest{Prompt: "again", Cwd: cwd})
+		return err == nil
+	}, "gate key was not released after a fresh run that created no conversation")
+	// Wait for the second job's supervisor to finish before returning. It writes
+	// into StateDir (a t.TempDir), and a still-running supervisor races the TempDir
+	// RemoveAll cleanup ("directory not empty"). Waiting for exit removes the racer.
+	waitForExitCode(t, m, job2.ID)
 }
 
 // If the manager dies after a fresh run completes but before its completion
@@ -314,23 +294,18 @@ func TestFreshRunWithCorruptCacheDisablesCapture(t *testing.T) {
 
 func waitForCapturedID(t *testing.T, m *Manager, id string, within time.Duration) Status {
 	t.Helper()
-	deadline := time.Now().Add(within)
 	var st Status
-	for time.Now().Before(deadline) {
+	testutil.WaitFor(t, within, func() bool {
 		var err error
 		st, err = m.Status(id)
-		if err == nil && st.State == StateDone && st.ConversationID != "" {
-			return st
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return err == nil && st.State == StateDone && st.ConversationID != ""
+	}, fmt.Sprintf("job %s never captured a conversation id within %s", id, within))
 	return st
 }
 
 // CapturePending must be armed synchronously by a fresh StartJob and settle
 // once the completion goroutine has captured (or given up on) the id.
 func TestCapturePendingSettles(t *testing.T) {
-	state := t.TempDir()
 	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
 	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)
@@ -344,16 +319,14 @@ func TestCapturePendingSettles(t *testing.T) {
 	}
 	const newUUID = "55556666-7777-8888-9999-000011112222"
 
-	c := config.Config{
-		AgyPath: "/usr/bin/agy",
-		SupervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+	m := newManager(t, managerOpts{
+		agyPath: "/usr/bin/agy",
+		supervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
 			Out: "done", CachePath: cachePath, CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, newUUID),
 		}),
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+	})
 	m.cacheFile = cachePath
 
 	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
@@ -368,13 +341,9 @@ func TestCapturePendingSettles(t *testing.T) {
 	if st.ConversationID != newUUID {
 		t.Fatalf("captured id = %q, want %q", st.ConversationID, newUUID)
 	}
-	deadline := time.Now().Add(2 * time.Second)
-	for m.CapturePending(job.ID) {
-		if time.Now().After(deadline) {
-			t.Fatal("capture never settled after the id was captured")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testutil.WaitFor(t, 2*time.Second, func() bool {
+		return !m.CapturePending(job.ID)
+	}, "capture never settled after the id was captured")
 }
 
 // A lazily captured id must not be stolen from a later same-cwd run: when

--- a/internal/manager/cleanup_posix_test.go
+++ b/internal/manager/cleanup_posix_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
@@ -34,15 +33,12 @@ func (f *failUpdateStore) UpdateMeta(m jobstore.Meta) error {
 // manager must terminate the supervisor, wait for it to exit, remove the job dir, and
 // release the gate. cleanup runs in a goroutine after cmd.Wait, so the assertions poll.
 func TestStartJobCleansUpDirOnUpdateMetaFailure(t *testing.T) {
-	state := t.TempDir()
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}), // real: cmd.Start succeeds and a supervisor runs
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 1,
-	}
-	m := New(c)
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}), // real: cmd.Start succeeds and a supervisor runs
+		defaultTimeout: time.Minute,
+		maxConcurrency: 1,
+	})
 	m.store = &failUpdateStore{jobStore: m.store, failUpdateMeta: true}
 	cwd := t.TempDir()
 
@@ -53,45 +49,36 @@ func TestStartJobCleansUpDirOnUpdateMetaFailure(t *testing.T) {
 
 	// The job dir must be removed (no orphan left for GarbageCollect). cleanup is
 	// asynchronous (after cmd.Wait), so poll with a bounded deadline.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
+	testutil.WaitFor(t, 5*time.Second, func() bool {
 		ids, lerr := m.store.List()
 		if lerr != nil {
 			t.Fatal(lerr)
 		}
-		if len(ids) == 0 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("job dir not removed after UpdateMeta-failure cleanup: %v", ids)
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+		return len(ids) == 0
+	}, "job dir not removed after UpdateMeta-failure cleanup")
 
 	// The gate slot and key must be released after the supervisor exits: a second
 	// same-cwd run must get PAST the gate (it then fails at UpdateMeta again with the
 	// same store) rather than being refused as a conflicting job. With MaxConcurrency
 	// 1, a leaked slot would also block it, so reaching the spawn proves both freed.
-	deadline = time.Now().Add(5 * time.Second)
-	for {
+	testutil.WaitFor(t, 5*time.Second, func() bool {
 		_, err2 := m.StartJob(StartRequest{Prompt: "again", Cwd: cwd})
 		switch {
 		case err2 != nil && strings.Contains(err2.Error(), "record supervisor pid"):
-			// Got past the gate, spawned, failed at UpdateMeta again: the gate was
-			// released. That second run also launched an async cleanup goroutine; wait
-			// for the store to drain before returning so its supervisor and dir removal
-			// don't race t.TempDir teardown (the same race the first poll above guards).
-			waitForEmptyStore(t, m)
-			return
+			// Got past the gate, spawned, failed at UpdateMeta again: the gate was released.
+			return true
 		case err2 != nil && strings.Contains(err2.Error(), "conflicting"):
-			if time.Now().After(deadline) {
-				t.Fatal("gate slot/key not released after UpdateMeta-failure cleanup")
-			}
-			time.Sleep(20 * time.Millisecond)
+			return false
 		default:
 			t.Fatalf("unexpected second-run error: %v", err2)
+			return false
 		}
-	}
+	}, "gate slot/key not released after UpdateMeta-failure cleanup")
+
+	// That second run also launched an async cleanup goroutine; wait for the store to
+	// drain before returning so its supervisor and dir removal don't race t.TempDir
+	// teardown (the same race the first poll above guards).
+	waitForEmptyStore(t, m)
 }
 
 // waitForEmptyStore blocks until no job dirs remain, i.e. every async cleanup goroutine
@@ -99,18 +86,11 @@ func TestStartJobCleansUpDirOnUpdateMetaFailure(t *testing.T) {
 // t.TempDir teardown.
 func waitForEmptyStore(t *testing.T, m *Manager) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for {
+	testutil.WaitFor(t, 5*time.Second, func() bool {
 		ids, err := m.store.List()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(ids) == 0 {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("store did not drain: %v", ids)
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+		return len(ids) == 0
+	}, "store did not drain")
 }

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
@@ -33,7 +32,7 @@ func (r *reReadExitStore) ExitCode(id string) (int, bool) {
 }
 
 func TestGarbageCollectReapsExpiredOrphanDir(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	// A job dir with no meta.json: a crash between Create's MkdirAll and its meta
 	// write, or a partial RemoveAll. Load fails on it, so the old GC skipped it
 	// forever and orphan dirs accumulated without bound.
@@ -61,7 +60,7 @@ func TestGarbageCollectReapsExpiredOrphanDir(t *testing.T) {
 }
 
 func TestGarbageCollectKeepsRecentOrphanDir(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	// A meta-less dir younger than the TTL may be a job mid-Create (MkdirAll done,
 	// meta write pending), so it must not be reaped.
 	dir, err := m.store.Dir("fresh-orphan")
@@ -84,7 +83,7 @@ func TestGarbageCollectKeepsRecentOrphanDir(t *testing.T) {
 }
 
 func TestGarbageCollectKeepsExpiredJobWithUnreadableMeta(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	// meta.json is present but unparseable (a transient read error, or a legacy
 	// corrupt write). This is NOT an orphan: only a genuinely missing meta.json is.
 	// A valid long-running job's dir mtime is old because writing to out/err does
@@ -117,7 +116,7 @@ func TestGarbageCollectKeepsExpiredJobWithUnreadableMeta(t *testing.T) {
 }
 
 func TestGarbageCollectKeepsTerminalJobWithCapturePending(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	// A fresh run that exited 0 and is past the TTL, but whose conversation-id
 	// capture is still in flight: the manager's post-cmd.Wait goroutine is inside
 	// captureFreshConversationID, still writing this dir (the sentinel is already on
@@ -144,7 +143,7 @@ func TestGarbageCollectKeepsTerminalJobWithCapturePending(t *testing.T) {
 }
 
 func TestGarbageCollectRereadsSentinelBeforeRemoval(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	// Old enough to collect, PID 0 so processAlive is false (the process has
 	// exited). The first ExitCode read sees no sentinel; the re-read after the
 	// liveness check sees the sentinel the supervisor wrote on its way out, so the
@@ -170,7 +169,7 @@ func TestGarbageCollectRereadsSentinelBeforeRemoval(t *testing.T) {
 }
 
 func TestGarbageCollectRemovesExpired(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +186,7 @@ func TestGarbageCollectRemovesExpired(t *testing.T) {
 }
 
 func TestGarbageCollectUntracksSettledCapture(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +250,7 @@ func TestRunPeriodicGCCollectsAndStops(t *testing.T) {
 }
 
 func TestGarbageCollectDisabledWhenTTLZero(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4}) // JobTTL 0
+	m := newManager(t, managerOpts{maxConcurrency: 4}) // JobTTL 0
 	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-100 * time.Hour)}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
 // reReadExitStore reports "no sentinel" on the first ExitCode(id) call and
@@ -225,7 +226,7 @@ func TestGCInterval(t *testing.T) {
 }
 
 func TestRunPeriodicGCCollectsAndStops(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4, JobTTL: time.Hour})
+	m := newManager(t, managerOpts{maxConcurrency: 4, jobTTL: time.Hour})
 	if _, err := m.store.Create(jobstore.Meta{ID: "old", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
 		t.Fatal(err)
 	}
@@ -235,17 +236,10 @@ func TestRunPeriodicGCCollectsAndStops(t *testing.T) {
 	go func() { m.runPeriodicGC(ctx, 10*time.Millisecond); close(done) }()
 
 	// The ticker collects the expired job.
-	deadline := time.Now().Add(2 * time.Second)
-	for {
+	testutil.WaitFor(t, 2*time.Second, func() bool {
 		ids, _ := m.store.List()
-		if len(ids) == 0 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("periodic GC did not collect the expired job")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return len(ids) == 0
+	}, "periodic GC did not collect the expired job")
 
 	// Cancelling the context stops the loop and returns.
 	cancel()

--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -10,23 +10,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
 func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
-	state := t.TempDir()
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
-	// Inject a test-owned cache file so the fresh run's id capture does not read
-	// the developer's real agy cache or leak a capture goroutine racing cleanup.
-	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	// withCacheFile injects a test-owned cache file so the fresh run's id capture
+	// does not read the developer's real agy cache or leak a capture goroutine
+	// racing cleanup.
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+		withCacheFile:  true,
+	})
 
 	job, err := m.StartJob(StartRequest{Prompt: "review main.go", Model: "Gemini 3.1 Pro (High)"})
 	if err != nil {
@@ -52,31 +49,23 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 	}
 
 	// The fake supervisor writes out/exit_code; wait briefly for it.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, ok := m.store.ExitCode(job.ID); ok {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if _, ok := m.store.ExitCode(job.ID); !ok {
-		t.Fatal("supervisor did not write exit_code")
-	}
+	testutil.WaitFor(t, 2*time.Second, func() bool {
+		_, ok := m.store.ExitCode(job.ID)
+		return ok
+	}, "supervisor did not write exit_code")
 }
 
 // TestStartJobWiresConversationID covers the continue-a-conversation path that
 // no other StartJob test drives: an explicit conversation id must be threaded
 // into the returned job, the persisted meta, and the agy --conversation arg.
 func TestStartJobWiresConversationID(t *testing.T) {
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
-		StateDir:       t.TempDir(),
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
-	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+		withCacheFile:  true,
+	})
 
 	const convID = "11111111-2222-3333-4444-555555555555"
 	job, err := m.StartJob(StartRequest{Prompt: "follow up", ConversationID: convID, Cwd: t.TempDir()})
@@ -99,15 +88,13 @@ func TestStartJobWiresConversationID(t *testing.T) {
 }
 
 func TestStartJobCleansUpDirOnSpawnFailure(t *testing.T) {
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  filepath.Join(t.TempDir(), "nonexistent-supervisor"),
-		StateDir:       t.TempDir(),
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
-	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  filepath.Join(t.TempDir(), "nonexistent-supervisor"),
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+		withCacheFile:  true,
+	})
 	cwd := t.TempDir()
 
 	_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
@@ -143,18 +130,17 @@ func TestStartJobNormalizesCwd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EvalSymlinks: %v", err)
 	}
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
-		StateDir:       t.TempDir(),
-		DefaultTimeout: time.Minute,
-		DefaultModel:   "Gemini 3.1 Pro (High)",
-		MaxConcurrency: 4,
-	}
-	m := New(c)
-	// Inject a temp cache file so the run does not read the real ~/.gemini cache,
-	// and shorten the post-exit capture so no capture goroutine outlives the test.
-	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	// withCacheFile injects a temp cache file so the run does not read the real
+	// ~/.gemini cache; captureBudget 0 shortens the post-exit capture so no
+	// capture goroutine outlives the test.
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		defaultTimeout: time.Minute,
+		defaultModel:   "Gemini 3.1 Pro (High)",
+		maxConcurrency: 4,
+		withCacheFile:  true,
+	})
 	m.captureBudget = 0
 
 	job, err := m.StartJob(StartRequest{Prompt: "x", Cwd: dir + "/"})
@@ -194,15 +180,13 @@ func TestStartJobSerializesEquivalentCwdSpellings(t *testing.T) {
 	// A sleeping fake agy keeps the first supervisor alive, so its gate key stays
 	// held while the second run is attempted.
 	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Sleep: 30 * time.Second})
-	c := config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy}),
-		StateDir:       t.TempDir(),
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	}
-	m := New(c)
-	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy}),
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+		withCacheFile:  true,
+	})
 
 	job1, err := m.StartJob(StartRequest{Prompt: "first", Cwd: dir})
 	if err != nil {

--- a/internal/manager/liveness_windows_test.go
+++ b/internal/manager/liveness_windows_test.go
@@ -34,7 +34,11 @@ func TestReadStartTimeTicksNonZero(t *testing.T) {
 }
 
 func TestProcessAliveLiveThenDead(t *testing.T) {
-	m := newManager(t, managerOpts{})
+	// maxConcurrency: 1 matches the old New(config.Config{StateDir: t.TempDir()})
+	// zero-value default (newGate(0) clamps to 1), which newManager's own default
+	// (4) would otherwise silently diverge from. Inert either way since this test
+	// only calls processAlive, never the gate, but pinned for defense in depth.
+	m := newManager(t, managerOpts{maxConcurrency: 1})
 	cmd := startSleeper(t)
 	ticks, ok := readStartTimeTicks(cmd.Process.Pid)
 	if !ok {

--- a/internal/manager/liveness_windows_test.go
+++ b/internal/manager/liveness_windows_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
 // startSleeper spawns a long-running process a liveness test can inspect and then
@@ -33,7 +34,7 @@ func TestReadStartTimeTicksNonZero(t *testing.T) {
 }
 
 func TestProcessAliveLiveThenDead(t *testing.T) {
-	m := New(config.Config{StateDir: t.TempDir()})
+	m := newManager(t, managerOpts{})
 	cmd := startSleeper(t)
 	ticks, ok := readStartTimeTicks(cmd.Process.Pid)
 	if !ok {
@@ -46,13 +47,9 @@ func TestProcessAliveLiveThenDead(t *testing.T) {
 	// Kill it and confirm liveness flips to false.
 	_ = cmd.Process.Kill()
 	_ = cmd.Wait()
-	deadline := time.Now().Add(5 * time.Second)
-	for m.processAlive(meta) && time.Now().Before(deadline) {
-		time.Sleep(50 * time.Millisecond)
-	}
-	if m.processAlive(meta) {
-		t.Fatal("processAlive must be false once the process has exited")
-	}
+	testutil.WaitFor(t, 5*time.Second, func() bool {
+		return !m.processAlive(meta)
+	}, "processAlive must be false once the process has exited")
 }
 
 func TestProcessAliveRejectsCreationTimeMismatch(t *testing.T) {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -66,6 +66,13 @@ type Manager struct {
 	restoredPollInterval time.Duration
 }
 
+// readStartTimeTicksFn is a package-level indirection over readStartTimeTicks
+// (a free function with no fault-injection seam of its own) so a darwin-tagged
+// test can force the startTimeMandatory fail-closed spawn path in StartJob
+// without depending on an actual sysctl read failure, which is not reliably
+// reproducible for a real child process.
+var readStartTimeTicksFn = readStartTimeTicks
+
 // New constructs a Manager.
 func New(c config.Config) *Manager {
 	// Prefer an explicitly configured cache path; only fall back to the default
@@ -423,7 +430,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// the supervisor) with an atomic rewrite, so the just-spawned supervisor never
 	// reads a half-written meta.json.
 	meta.PID = cmd.Process.Pid
-	if ticks, ok := readStartTimeTicks(cmd.Process.Pid); ok {
+	if ticks, ok := readStartTimeTicksFn(cmd.Process.Pid); ok {
 		meta.StartTimeTicks = ticks
 	} else if startTimeMandatory {
 		// darwin has no /proc/comm-style liveness fallback, so processAlive fails

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -64,14 +64,15 @@ type Manager struct {
 	captureBudget        time.Duration
 	capturePoll          time.Duration
 	restoredPollInterval time.Duration
-}
 
-// readStartTimeTicksFn is a package-level indirection over readStartTimeTicks
-// (a free function with no fault-injection seam of its own) so a darwin-tagged
-// test can force the startTimeMandatory fail-closed spawn path in StartJob
-// without depending on an actual sysctl read failure, which is not reliably
-// reproducible for a real child process.
-var readStartTimeTicksFn = readStartTimeTicks
+	// readStartTimeTicks is a per-instance indirection over the free function of
+	// the same name (which has no fault-injection seam of its own), defaulted in
+	// New, so a darwin-tagged test can force the startTimeMandatory fail-closed
+	// spawn path in StartJob on its own *Manager without depending on an actual
+	// sysctl read failure (not reliably reproducible for a real child process)
+	// and without any risk of a package-level var leaking into another test.
+	readStartTimeTicks func(int) (uint64, bool)
+}
 
 // New constructs a Manager.
 func New(c config.Config) *Manager {
@@ -94,6 +95,7 @@ func New(c config.Config) *Manager {
 		capturePoll:          100 * time.Millisecond,
 		restoredPollInterval: 2 * time.Second,
 		settledCapture:       make(map[string]struct{}),
+		readStartTimeTicks:   readStartTimeTicks,
 	}
 }
 
@@ -430,7 +432,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// the supervisor) with an atomic rewrite, so the just-spawned supervisor never
 	// reads a half-written meta.json.
 	meta.PID = cmd.Process.Pid
-	if ticks, ok := readStartTimeTicksFn(cmd.Process.Pid); ok {
+	if ticks, ok := m.readStartTimeTicks(cmd.Process.Pid); ok {
 		meta.StartTimeTicks = ticks
 	} else if startTimeMandatory {
 		// darwin has no /proc/comm-style liveness fallback, so processAlive fails

--- a/internal/manager/restore_posix_test.go
+++ b/internal/manager/restore_posix_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
 // startFakeLiveSupervisor starts a real, long-lived process to stand in for a
@@ -34,19 +34,6 @@ func startFakeLiveSupervisor(t *testing.T) (pid int, exePath string) {
 		_ = cmd.Wait()
 	})
 	return cmd.Process.Pid, exePath
-}
-
-func newManagerForRestore(t *testing.T, exePath string, maxConcurrency int) *Manager {
-	t.Helper()
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  exePath,
-		StateDir:       t.TempDir(),
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: maxConcurrency,
-	})
-	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
-	return m
 }
 
 // createLiveJob is shared by both "live" and "dead" restore tests: it records
@@ -76,7 +63,7 @@ func createLiveJob(t *testing.T, m *Manager, id, cwd string, pid int) {
 // re-occupy its serialization key so a conflicting new run is blocked.
 func TestRestoreGateBlocksConflictingRun(t *testing.T) {
 	pid, exePath := startFakeLiveSupervisor(t)
-	m := newManagerForRestore(t, exePath, 4)
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: exePath, defaultTimeout: time.Minute, maxConcurrency: 4, withCacheFile: true})
 	cwd := t.TempDir()
 	createLiveJob(t, m, "live-1", cwd, pid)
 
@@ -93,7 +80,7 @@ func TestRestoreGateBlocksConflictingRun(t *testing.T) {
 // non-conflicting run is refused once the cap is full.
 func TestRestoreGateCountsAgainstCap(t *testing.T) {
 	pid, exePath := startFakeLiveSupervisor(t)
-	m := newManagerForRestore(t, exePath, 1)
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: exePath, defaultTimeout: time.Minute, maxConcurrency: 1, withCacheFile: true})
 	createLiveJob(t, m, "live-1", t.TempDir(), pid)
 
 	if err := m.RestoreGate(); err != nil {
@@ -124,7 +111,7 @@ func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
 		}
 	})
 
-	m := newManagerForRestore(t, exePath, 4)
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: exePath, defaultTimeout: time.Minute, maxConcurrency: 4, withCacheFile: true})
 	m.restoredPollInterval = 10 * time.Millisecond
 	cwd := t.TempDir()
 	createLiveJob(t, m, "live-1", cwd, cmd.Process.Pid)
@@ -144,16 +131,10 @@ func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
 	reaped = true
 
 	// The watcher must release the key; a same-cwd run then succeeds.
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err == nil {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("watcher did not release the restored key after the supervisor exited")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	testutil.WaitFor(t, 2*time.Second, func() bool {
+		_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
+		return err == nil
+	}, "watcher did not release the restored key after the supervisor exited")
 }
 
 // RestoreGate must fail closed: if the on-disk jobs cannot be scanned, it returns
@@ -165,13 +146,7 @@ func TestRestoreGateFailsClosedOnScanError(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(state, "jobs"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  "/bin/true",
-		StateDir:       state,
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-	})
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: "/bin/true", stateDir: state, defaultTimeout: time.Minute, maxConcurrency: 4})
 	if err := m.RestoreGate(); err == nil {
 		t.Fatal("RestoreGate must return an error when the jobs dir cannot be scanned")
 	}
@@ -194,7 +169,7 @@ func TestRestoreGateSkipsDeadSupervisor(t *testing.T) {
 	_ = cmd.Process.Kill()
 	_ = cmd.Wait()
 
-	m := newManagerForRestore(t, exePath, 4)
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: exePath, defaultTimeout: time.Minute, maxConcurrency: 4, withCacheFile: true})
 	cwd := t.TempDir()
 	createLiveJob(t, m, "dead-1", cwd, deadPID)
 
@@ -211,7 +186,7 @@ func TestRestoreGateSkipsDeadSupervisor(t *testing.T) {
 // gate, even if its recorded pid happens to still be alive.
 func TestRestoreGateSkipsTerminalJobs(t *testing.T) {
 	pid, exePath := startFakeLiveSupervisor(t)
-	m := newManagerForRestore(t, exePath, 4)
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: exePath, defaultTimeout: time.Minute, maxConcurrency: 4, withCacheFile: true})
 	cwd := t.TempDir()
 	createLiveJob(t, m, "done-1", cwd, pid)
 	if err := m.store.WriteExitCode("done-1", 0); err != nil {
@@ -234,15 +209,7 @@ func TestRestoreGateSkipsTerminalJobs(t *testing.T) {
 // removing one job does not disturb restoring another.
 func TestRestoreAndCollectCollectsExpiredAndRestoresLive(t *testing.T) {
 	pid, exePath := startFakeLiveSupervisor(t)
-	m := New(config.Config{
-		AgyPath:        "/usr/bin/agy",
-		SupervisorExe:  exePath,
-		StateDir:       t.TempDir(),
-		DefaultTimeout: time.Minute,
-		MaxConcurrency: 4,
-		JobTTL:         time.Hour,
-	})
-	m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: exePath, defaultTimeout: time.Minute, maxConcurrency: 4, jobTTL: time.Hour, withCacheFile: true})
 
 	// An expired, finished job: past the TTL with an exit sentinel, so GC removes it.
 	if _, err := m.store.Create(jobstore.Meta{ID: "old-done", StartedAt: time.Now().Add(-2 * time.Hour)}); err != nil {
@@ -294,7 +261,7 @@ func TestRestoreAndCollectCollectsExpiredAndRestoresLive(t *testing.T) {
 // owns the capture while the gate key is held).
 func TestRestoreGateCapturesConversationIDOnExit(t *testing.T) {
 	pid, exePath := startFakeLiveSupervisor(t)
-	m := newManagerForRestore(t, exePath, 4)
+	m := newManager(t, managerOpts{agyPath: "/usr/bin/agy", supervisorExe: exePath, defaultTimeout: time.Minute, maxConcurrency: 4})
 	m.restoredPollInterval = 20 * time.Millisecond
 
 	cwd := t.TempDir()
@@ -324,18 +291,11 @@ func TestRestoreGateCapturesConversationIDOnExit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
-	for {
+	testutil.WaitFor(t, 3*time.Second, func() bool {
 		meta, err := m.store.Load("restored-fresh")
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		if meta.ConversationID == uuid {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("watcher never captured the id; meta.ConversationID = %q", meta.ConversationID)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return meta.ConversationID == uuid
+	}, "watcher never captured the conversation id")
 }

--- a/internal/manager/spawn_darwin_test.go
+++ b/internal/manager/spawn_darwin_test.go
@@ -17,23 +17,23 @@ import (
 // rather than persist StartTimeTicks==0 (which processAlive treats as dead on
 // darwin, since there is no /proc/comm fallback).
 //
-// The real trigger (a sysctl kern.proc.pid read of a child we still hold, now
-// retried) is essentially unreachable in practice, so this forces it via the
-// readStartTimeTicksFn seam instead of trying to reproduce a genuine sysctl
-// failure. abortSpawn's teardown sequence itself is exercised by proxy through
+// The real trigger (a sysctl kern.proc.pid read of a child we still hold,
+// already retried inside readStartTimeTicks) is essentially unreachable in
+// practice, so this forces it via the readStartTimeTicks seam instead of
+// trying to reproduce a genuine sysctl failure. abortSpawn's teardown
+// sequence itself is exercised by proxy through
 // TestStartJobCleansUpDirOnUpdateMetaFailure (cleanup_posix_test.go, via the
 // failUpdateStore seam); this test is the direct trigger for the darwin path.
 func TestStartJobAbortsSpawnOnDarwinStartTimeFailure(t *testing.T) {
-	orig := readStartTimeTicksFn
-	readStartTimeTicksFn = func(int) (uint64, bool) { return 0, false }
-	t.Cleanup(func() { readStartTimeTicksFn = orig })
-
 	m := newManager(t, managerOpts{
 		agyPath:        "/usr/bin/agy",
 		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
 		defaultTimeout: time.Minute,
 		maxConcurrency: 1,
 	})
+	// Scoped to this *Manager instance only, so it cannot leak into any other
+	// test even if the package's no-t.Parallel() convention changes later.
+	m.readStartTimeTicks = func(int) (uint64, bool) { return 0, false }
 	cwd := t.TempDir()
 
 	_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})

--- a/internal/manager/spawn_darwin_test.go
+++ b/internal/manager/spawn_darwin_test.go
@@ -1,0 +1,75 @@
+//go:build darwin
+
+package manager
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// TestStartJobAbortsSpawnOnDarwinStartTimeFailure exercises the darwin-only
+// fail-closed branch in StartJob: when readStartTimeTicks cannot read the
+// just-spawned supervisor's start time, startTimeMandatory (true on darwin)
+// makes StartJob tear the supervisor down via abortSpawn and return an error,
+// rather than persist StartTimeTicks==0 (which processAlive treats as dead on
+// darwin, since there is no /proc/comm fallback).
+//
+// The real trigger (a sysctl kern.proc.pid read of a child we still hold, now
+// retried) is essentially unreachable in practice, so this forces it via the
+// readStartTimeTicksFn seam instead of trying to reproduce a genuine sysctl
+// failure. abortSpawn's teardown sequence itself is exercised by proxy through
+// TestStartJobCleansUpDirOnUpdateMetaFailure (cleanup_posix_test.go, via the
+// failUpdateStore seam); this test is the direct trigger for the darwin path.
+func TestStartJobAbortsSpawnOnDarwinStartTimeFailure(t *testing.T) {
+	orig := readStartTimeTicksFn
+	readStartTimeTicksFn = func(int) (uint64, bool) { return 0, false }
+	t.Cleanup(func() { readStartTimeTicksFn = orig })
+
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		defaultTimeout: time.Minute,
+		maxConcurrency: 1,
+	})
+	cwd := t.TempDir()
+
+	_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
+	if err == nil || !strings.Contains(err.Error(), "record supervisor start time") {
+		t.Fatalf("StartJob error = %v, want a record-supervisor-start-time failure", err)
+	}
+
+	// abortSpawn tears the supervisor down asynchronously (after cmd.Wait), so
+	// the job dir removal is not immediate; poll with a bounded deadline.
+	testutil.WaitFor(t, 5*time.Second, func() bool {
+		ids, lerr := m.store.List()
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		return len(ids) == 0
+	}, "job dir not removed after darwin start-time-failure abort")
+
+	// The gate slot/key must also be released: a second same-cwd run must get
+	// PAST the gate (and hit the same start-time failure again) rather than
+	// being refused as a conflicting job. With MaxConcurrency 1, a leaked slot
+	// would also block it, so reaching the spawn proves both freed.
+	testutil.WaitFor(t, 5*time.Second, func() bool {
+		_, err2 := m.StartJob(StartRequest{Prompt: "again", Cwd: cwd})
+		switch {
+		case err2 != nil && strings.Contains(err2.Error(), "record supervisor start time"):
+			return true
+		case err2 != nil && strings.Contains(err2.Error(), "conflicting"):
+			return false
+		default:
+			t.Fatalf("unexpected second-run error: %v", err2)
+			return false
+		}
+	}, "gate slot/key not released after darwin start-time-failure abort")
+
+	// That second run also launched an async cleanup goroutine; wait for the
+	// store to drain before returning so its supervisor and dir removal don't
+	// race t.TempDir teardown.
+	waitForEmptyStore(t, m)
+}

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/jobstore"
 )
 
@@ -18,7 +17,7 @@ import (
 // is the branch TestStatusInterruptedAfterReboot does not cover (that one has
 // recovered output and asserts done).
 func TestStatusInterruptedNoOutput(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	// Dead PID from a previous boot, and no out/err/exit_code files at all.
 	if _, err := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), PID: 999999, BootID: "old-boot"}); err != nil {
 		t.Fatal(err)
@@ -40,7 +39,7 @@ func TestStatusInterruptedNoOutput(t *testing.T) {
 // than errTailBytes and the cut falls mid-rune, the reported error is advanced
 // to a valid UTF-8 boundary rather than emitting a split multi-byte rune.
 func TestErrorSummaryTruncatesOnUTF8Boundary(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	// 3-byte runes so the last errTailBytes window starts mid-rune (2000 % 3 != 0).
 	content := strings.Repeat("€", 1000) // 3000 bytes
@@ -61,13 +60,8 @@ func TestErrorSummaryTruncatesOnUTF8Boundary(t *testing.T) {
 	}
 }
 
-func newTestManager(t *testing.T) *Manager {
-	t.Helper()
-	return New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 4})
-}
-
 func TestStatusDone(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("the review"), 0o644)
 	_ = m.store.WriteExitCode("j", 0)
@@ -85,7 +79,7 @@ func TestStatusDone(t *testing.T) {
 }
 
 func TestStatusFailed(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("boom"), 0o644)
 	_ = m.store.WriteExitCode("j", 5)
@@ -97,7 +91,7 @@ func TestStatusFailed(t *testing.T) {
 }
 
 func TestStatusTimedOut(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("partial"), 0o644)
 	_ = m.store.WriteExitCode("j", jobstore.ExitTimeout)
@@ -147,7 +141,7 @@ func TestTailFileShorterThanRequested(t *testing.T) {
 // directory lets os.Open succeed while the read fails, exposing the old
 // readFile that collapsed every IO error into "".
 func TestStatusDoneButOutputUnreadable(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	if err := os.Mkdir(filepath.Join(dir, "out"), 0o755); err != nil {
 		t.Fatal(err)
@@ -163,7 +157,7 @@ func TestStatusDoneButOutputUnreadable(t *testing.T) {
 // TestStatusSpawnFail: ExitSpawnFail (127) with no stderr (a true spawn failure)
 // gets a dedicated message instead of a bare "exit 127:".
 func TestStatusSpawnFail(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "err"), []byte(""), 0o644)
 	_ = m.store.WriteExitCode("j", jobstore.ExitSpawnFail)
@@ -181,7 +175,7 @@ func TestStatusSpawnFail(t *testing.T) {
 // agy itself exits 127 (with stderr) the message must surface that stderr rather
 // than masking it behind the spawn-failure text.
 func TestStatusExit127SurfacesStderr(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("agy: internal tool not found\n"), 0o644)
 	_ = m.store.WriteExitCode("j", jobstore.ExitSpawnFail)
@@ -193,7 +187,7 @@ func TestStatusExit127SurfacesStderr(t *testing.T) {
 }
 
 func TestStatusInterruptedAfterReboot(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	// BootID differs from current -> the recorded PID is from a previous boot.
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), PID: 999999, BootID: "old-boot"})
 	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("partial"), 0o644)
@@ -216,7 +210,7 @@ func TestStatusInterruptedAfterReboot(t *testing.T) {
 // run's real duration (start to the sentinel's completion time), not an
 // ever-growing time.Since(StartedAt) for a job that finished long ago.
 func TestStatusElapsedFrozenAtCompletion(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	start := time.Now().Add(-time.Hour)
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: start, BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644)
@@ -242,7 +236,7 @@ func TestStatusElapsedFrozenAtCompletion(t *testing.T) {
 // freeze at the best available end time (the out file's mtime) rather than
 // growing forever as time.Since(StartedAt).
 func TestStatusRecoveredElapsedFrozen(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	start := time.Now().Add(-time.Hour)
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: start, PID: 999999, BootID: "old-boot"})
 	outPath := filepath.Join(dir, "out")
@@ -267,7 +261,7 @@ func TestStatusRecoveredElapsedFrozen(t *testing.T) {
 // implausibly precedes StartedAt (clock skew), a terminal job's elapsed must
 // stay frozen (clamped to 0), not fall back to an ever-growing time.Since.
 func TestStatusElapsedClampedOnClockSkew(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	start := time.Now().Add(-time.Hour)
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: start, BootID: readBootID()})
 	_ = os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644)
@@ -301,7 +295,7 @@ func TestStateMatchesStatusState(t *testing.T) {
 		{jobstore.ExitSpawnFail, StateFailed},
 		{5, StateFailed},
 	}
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	for _, c := range cases {
 		id := "code-" + strconv.Itoa(c.code)
 		dir, _ := m.store.Create(jobstore.Meta{ID: id, StartedAt: time.Now(), BootID: readBootID()})
@@ -328,7 +322,7 @@ func TestStateMatchesStatusState(t *testing.T) {
 // success), and State must report the same, not a bare "done" from the code.
 // Making out a directory lets os.Open succeed while the read fails.
 func TestStateMatchesStatusOnUnreadableCleanExit(t *testing.T) {
-	m := newTestManager(t)
+	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	if err := os.Mkdir(filepath.Join(dir, "out"), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/manager/testhelpers_test.go
+++ b/internal/manager/testhelpers_test.go
@@ -1,0 +1,50 @@
+package manager
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+)
+
+// managerOpts configures newManager's config.Config beyond its sensible
+// zero-value defaults (StateDir: t.TempDir(), MaxConcurrency: 4).
+type managerOpts struct {
+	stateDir       string // "" -> t.TempDir()
+	agyPath        string
+	supervisorExe  string
+	maxConcurrency int // 0 -> 4
+	defaultTimeout time.Duration
+	defaultModel   string
+	jobTTL         time.Duration
+	withCacheFile  bool // true -> m.cacheFile = a fresh t.TempDir()/last_conversations.json
+}
+
+// newManager builds a *Manager for tests, consolidating the suite's several
+// ad hoc builders (newTestManager, newManagerForRestore, twoManagers) into
+// one parameterized constructor.
+func newManager(t *testing.T, opts managerOpts) *Manager {
+	t.Helper()
+	stateDir := opts.stateDir
+	if stateDir == "" {
+		stateDir = t.TempDir()
+	}
+	maxConcurrency := opts.maxConcurrency
+	if maxConcurrency == 0 {
+		maxConcurrency = 4
+	}
+	m := New(config.Config{
+		AgyPath:        opts.agyPath,
+		SupervisorExe:  opts.supervisorExe,
+		StateDir:       stateDir,
+		DefaultTimeout: opts.defaultTimeout,
+		DefaultModel:   opts.defaultModel,
+		MaxConcurrency: maxConcurrency,
+		JobTTL:         opts.jobTTL,
+	})
+	if opts.withCacheFile {
+		m.cacheFile = filepath.Join(t.TempDir(), "last_conversations.json")
+	}
+	return m
+}

--- a/internal/testutil/waitfor.go
+++ b/internal/testutil/waitfor.go
@@ -1,0 +1,28 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+)
+
+// pollInterval is the fixed cadence WaitFor polls cond at. 10ms matches the
+// granularity most call sites already used before consolidation; it is fine
+// enough not to add meaningful latency and coarse enough not to spin the CPU.
+const pollInterval = 10 * time.Millisecond
+
+// WaitFor polls cond every pollInterval until it returns true, then returns.
+// If timeout elapses first, it fails the test with msg. cond may itself call
+// t.Fatal for a hard, non-retryable error instead of returning false.
+func WaitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal(msg)
+		}
+		time.Sleep(pollInterval)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -129,31 +129,21 @@ func TestRunJobCancelViaSignal(t *testing.T) {
 	// load, the supervisor process has not started yet and the signal would hit a
 	// process that is not running (dying without writing the sentinel, leaking the
 	// 60s agy and burning the poll below).
-	startDeadline := time.Now().Add(5 * time.Second)
-	for {
+	testutil.WaitFor(t, 5*time.Second, func() bool {
 		_, oerr := os.Stat(jobstore.OutPath(jobDir))
 		_, eerr := os.Stat(jobstore.ErrPath(jobDir))
-		if oerr == nil && eerr == nil {
-			break
-		}
-		if time.Now().After(startDeadline) {
-			t.Fatal("supervisor did not create out/err; cannot safely signal it")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return oerr == nil && eerr == nil
+	}, "supervisor did not create out/err; cannot safely signal it")
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		t.Fatal(err)
 	}
 	_ = cmd.Wait()
 	reaped = true
 
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(jobstore.ExitCodePath(jobDir)); err == nil {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	testutil.WaitFor(t, 10*time.Second, func() bool {
+		_, err := os.Stat(jobstore.ExitCodePath(jobDir))
+		return err == nil
+	}, "supervisor did not write exit_code after SIGTERM")
 	code, _ := os.ReadFile(jobstore.ExitCodePath(jobDir))
 	if strings.TrimSpace(string(code)) != strconv.Itoa(jobstore.ExitSIGTERM) {
 		t.Fatalf("exit_code = %q, want %d (SIGTERM cancel)", code, jobstore.ExitSIGTERM)


### PR DESCRIPTION
## Summary
- Resolves the remaining deferred item from #34 (the "big pass" its own progress comments called out: consolidating ~10 hand-rolled poll-until-deadline loops and 3 separate ad hoc `*Manager` test builders into two shared helpers, `testutil.WaitFor(t, timeout, cond, msg)` and `newManager(t, managerOpts)`).
- Resolves #71: adds a `readStartTimeTicks` fault-injection seam (a per-`Manager` struct field, defaulted in `New`, matching the existing `m.store` injection pattern) and a darwin-tagged test exercising `StartJob`'s fail-closed spawn path when a just-spawned supervisor's start time can't be read.
- Test-only except for the one production seam in `manager.go`, verified as a behavior-preserving no-op via 8 parallel gate review agents plus a Gemini cross-validation pass, all with actual `go test -race` runs and GOOS=darwin/windows cross-compile checks (no macOS/Windows runner available locally; CI's macos-latest/windows-latest jobs execute the new/changed tests for real).
- Gate review caught and I fixed: an incomplete conversion sweep in three already-touched files, a silent `MaxConcurrency` default drift in one test (verified inert, pinned anyway), a now-dead assertion left over from a `WaitFor` conversion, and moved the darwin seam from a package-level var to a per-instance struct field after two independent reviewers flagged the var as a dormant data-race risk if the package ever grows a `t.Parallel()` test.
- Filed #79 for three pre-existing (verified against the removed code, not introduced here) retry-loop error-handling patterns Gemini flagged, out of scope for a behavior-preserving consolidation PR.

## Related Issues
Fixes #34
Fixes #71

## Test Plan
- [x] `go build/vet/test ./... -race` (linux)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `gofmt -l .` clean
- [x] `GOOS=darwin/windows go vet ./...` and `GOOS=darwin go test -c` cross-compile checks