### PR TITLE
manager: harden retry-loop error handling in a few tests

### DIFF
--- a/internal/manager/capture_posix_test.go
+++ b/internal/manager/capture_posix_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,7 +106,10 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 
 	// Wait for the job to finish; the id stays empty (no conversation was created).
 	testutil.WaitFor(t, 2*time.Second, func() bool {
-		st, _ := m.Status(job.ID)
+		st, err := m.Status(job.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if st.State != StateDone {
 			return false
 		}
@@ -116,12 +120,19 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 	}, "job never reached done state")
 
 	// The gate key must have been released after the capture budget: a second
-	// same-cwd fresh run eventually succeeds.
+	// same-cwd fresh run eventually succeeds. Any error other than the expected
+	// "conflicting" gate refusal is a genuine bug, not something to retry through.
 	var job2 Job
 	testutil.WaitFor(t, 2*time.Second, func() bool {
 		var err error
 		job2, err = m.StartJob(StartRequest{Prompt: "again", Cwd: cwd})
-		return err == nil
+		if err == nil {
+			return true
+		}
+		if !strings.Contains(err.Error(), "conflicting") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return false
 	}, "gate key was not released after a fresh run that created no conversation")
 	// Wait for the second job's supervisor to finish before returning. It writes
 	// into StateDir (a t.TempDir), and a still-running supervisor races the TempDir

--- a/internal/manager/capture_posix_test.go
+++ b/internal/manager/capture_posix_test.go
@@ -307,6 +307,12 @@ func waitForCapturedID(t *testing.T, m *Manager, id string, within time.Duration
 		if err != nil {
 			t.Fatal(err)
 		}
+		// The job is done and the capture goroutine has settled (armed pending
+		// cleared) with no id: that outcome is final, not something more waiting
+		// would change, so fail fast instead of burning the rest of the timeout.
+		if st.State == StateDone && !m.CapturePending(id) && st.ConversationID == "" {
+			t.Fatal("job finished and capture settled, but no conversation id was captured")
+		}
 		return st.State == StateDone && st.ConversationID != ""
 	}, fmt.Sprintf("job %s never captured a conversation id within %s", id, within))
 	return st

--- a/internal/manager/capture_posix_test.go
+++ b/internal/manager/capture_posix_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -120,8 +119,8 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 	}, "job never reached done state")
 
 	// The gate key must have been released after the capture budget: a second
-	// same-cwd fresh run eventually succeeds. Any error other than the expected
-	// "conflicting" gate refusal is a genuine bug, not something to retry through.
+	// same-cwd fresh run eventually succeeds. Any error other than a known
+	// retryable gate refusal is a genuine bug, not something to retry through.
 	var job2 Job
 	testutil.WaitFor(t, 2*time.Second, func() bool {
 		var err error
@@ -129,7 +128,7 @@ func TestFreshRunNoConversationReleasesKey(t *testing.T) {
 		if err == nil {
 			return true
 		}
-		if !strings.Contains(err.Error(), "conflicting") {
+		if !isRetryableGateRefusal(err) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		return false
@@ -305,7 +304,10 @@ func waitForCapturedID(t *testing.T, m *Manager, id string, within time.Duration
 	testutil.WaitFor(t, within, func() bool {
 		var err error
 		st, err = m.Status(id)
-		return err == nil && st.State == StateDone && st.ConversationID != ""
+		if err != nil {
+			t.Fatal(err)
+		}
+		return st.State == StateDone && st.ConversationID != ""
 	}, fmt.Sprintf("job %s never captured a conversation id within %s", id, within))
 	return st
 }

--- a/internal/manager/cleanup_posix_test.go
+++ b/internal/manager/cleanup_posix_test.go
@@ -67,7 +67,7 @@ func TestStartJobCleansUpDirOnUpdateMetaFailure(t *testing.T) {
 		case err2 != nil && strings.Contains(err2.Error(), "record supervisor pid"):
 			// Got past the gate, spawned, failed at UpdateMeta again: the gate was released.
 			return true
-		case err2 != nil && strings.Contains(err2.Error(), "conflicting"):
+		case isRetryableGateRefusal(err2):
 			return false
 		default:
 			t.Fatalf("unexpected second-run error: %v", err2)
@@ -93,4 +93,26 @@ func waitForEmptyStore(t *testing.T, m *Manager) {
 		}
 		return len(ids) == 0
 	}, "store did not drain")
+}
+
+// isRetryableGateRefusal reports whether err is one of the known transient
+// "another job holds this key, try again" outcomes a same-key StartJob retry
+// loop should keep polling through, rather than treating as a hard failure:
+//   - "conflicting": admit's acquireKeyBusy branch (manager.go), the common case.
+//   - "concurrency cap": admit's acquireAtCap branch, a sibling refusal for the
+//     same class of outcome (see concurrency.go's comment on why the two are
+//     reported with different text).
+//   - "already held by this process": releaseKey releases the in-process gate
+//     slot before the cross-process lock (admit.go), so a retry landing in that
+//     narrow window can observe the gate as free while xlock.tryLock still hits
+//     its own duplicate guard (keylock.go). Tracked for a real fix in #81; this
+//     is the test-side tolerance for it in the meantime.
+func isRetryableGateRefusal(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "conflicting") ||
+		strings.Contains(msg, "concurrency cap") ||
+		strings.Contains(msg, "already held by this process")
 }

--- a/internal/manager/gc_test.go
+++ b/internal/manager/gc_test.go
@@ -236,7 +236,10 @@ func TestRunPeriodicGCCollectsAndStops(t *testing.T) {
 
 	// The ticker collects the expired job.
 	testutil.WaitFor(t, 2*time.Second, func() bool {
-		ids, _ := m.store.List()
+		ids, err := m.store.List()
+		if err != nil {
+			t.Fatal(err)
+		}
 		return len(ids) == 0
 	}, "periodic GC did not collect the expired job")
 

--- a/internal/manager/restore_posix_test.go
+++ b/internal/manager/restore_posix_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -132,14 +131,14 @@ func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
 	reaped = true
 
 	// The watcher must release the key; a same-cwd run then succeeds. Any error
-	// other than the expected "conflicting" gate refusal is a genuine bug, not
-	// something to retry through.
+	// other than a known retryable gate refusal is a genuine bug, not something
+	// to retry through.
 	testutil.WaitFor(t, 2*time.Second, func() bool {
 		_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
 		if err == nil {
 			return true
 		}
-		if !strings.Contains(err.Error(), "conflicting") {
+		if !isRetryableGateRefusal(err) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		return false

--- a/internal/manager/restore_posix_test.go
+++ b/internal/manager/restore_posix_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,10 +131,18 @@ func TestRestoreGateReleasesKeyWhenSupervisorExits(t *testing.T) {
 	_ = cmd.Wait()
 	reaped = true
 
-	// The watcher must release the key; a same-cwd run then succeeds.
+	// The watcher must release the key; a same-cwd run then succeeds. Any error
+	// other than the expected "conflicting" gate refusal is a genuine bug, not
+	// something to retry through.
 	testutil.WaitFor(t, 2*time.Second, func() bool {
 		_, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd})
-		return err == nil
+		if err == nil {
+			return true
+		}
+		if !strings.Contains(err.Error(), "conflicting") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return false
 	}, "watcher did not release the restored key after the supervisor exited")
 }
 

--- a/internal/manager/spawn_darwin_test.go
+++ b/internal/manager/spawn_darwin_test.go
@@ -60,7 +60,7 @@ func TestStartJobAbortsSpawnOnDarwinStartTimeFailure(t *testing.T) {
 		switch {
 		case err2 != nil && strings.Contains(err2.Error(), "record supervisor start time"):
 			return true
-		case err2 != nil && strings.Contains(err2.Error(), "conflicting"):
+		case isRetryableGateRefusal(err2):
 			return false
 		default:
 			t.Fatalf("unexpected second-run error: %v", err2)


### PR DESCRIPTION
## Summary
- Resolves #79: 3 named test retry loops (`gc_test.go`, `capture_posix_test.go`, `restore_posix_test.go`) now fail fast on unexpected errors instead of silently retrying to a generic timeout.
- Gate review (6 agents + 2 independent Gemini cross-validation passes) found the initial "conflicting"-only retry predicate was too narrow (misses `acquireAtCap`'s "concurrency cap" message, and a genuine if narrow race in `releaseKey`'s two-step unlock) and one 4th retry loop (`waitForCapturedID`) had the identical bug but wasn't in #79's originally named scope. Both fixed here: added a shared `isRetryableGateRefusal` predicate covering all three known-retryable outcomes, wired into all 4 sites in the package with this shape (including the two pre-existing switch-based ones), and fixed `waitForCapturedID`.
- Filed #81 for the real production fix (the `releaseKey` unlock ordering), tracked separately since it's a production concurrency change, not test-only.

## Related Issues
Fixes #79

## Test Plan
- [x] `go build/vet/test ./... -race` (linux)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `gofmt -l .` clean
- [x] `GOOS=darwin/windows go vet ./...` and `GOOS=darwin go test -c` cross-compile checks
- [x] 30x `-count` stress run (90 combined invocations) on the affected tests under `-race`, zero flakes