### PR TITLE
Add completion wake: agy_wait tool, wait-job and hook-wait subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Driving `agy` from a shell for automation has two recurring problems:
 
 - `agy_run` / `agy_status` / `agy_cancel`: start an `agy` prompt, poll for completion, cancel if needed.
 - `agy_run_sync`: start a prompt and wait for it inline (bounded, with MCP progress notifications); returns the `job_id` to poll if it outlives the wait cap.
+- `agy_wait`: block until an already-started job finishes (bounded, with MCP progress notifications); one call replaces an `agy_status` poll loop.
 - `list_models`: enumerate available `agy` models.
 - `list_sessions`: list known conversations so review threads can be continued.
 
@@ -77,6 +78,7 @@ Or add to your MCP client config:
 - `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?)` -> `{ job_id, conversation_id?, state }`
 - `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`
 - `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id? }`
+- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
 - `list_models()` -> `{ models }`
 - `list_sessions(dir?)` -> `{ sessions }`
@@ -107,6 +109,41 @@ brief window, while the manager process is down, before it re-takes the locks fo
 supervisor outlived it; a sibling process that starts the same-`cwd` run during that window is not
 blocked. The in-process gate is always restored at startup, so this gap is limited to the restart
 window itself.
+
+## Completion wake for Claude Code
+
+Claude Code does not surface MCP server notifications to the model: progress notifications are UI-only, and there is no server-initiated push that can wake the model when an async job finishes. Polling `agy_status` after `agy_run` is the protocol-level baseline. agy-mcp ships a hook bridge that turns job completion into a real wake instead, built on Claude Code's `asyncRewake` hook mechanism: a background PostToolUse hook that exits with code 2 wakes the model with the hook's stderr as a system reminder.
+
+Add to your Claude Code `settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "mcp__agy__agy_run(_sync)?",
+        "hooks": [
+          { "type": "command", "command": "agy-mcp hook-wait", "asyncRewake": true, "timeout": 3600 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+How it behaves:
+
+- After every `agy_run`, the hook waits (in the background, off the session's critical path) for the job's completion sentinel and then wakes Claude with a one-line message naming the job id and final state, so the model calls `agy_status` exactly once, when the result is actually ready.
+- `agy_run_sync` calls that returned their result inline produce no wake; a sync call that overran its wait cap (and so returned a still-running job) gets the same completion wake as `agy_run`.
+- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes.
+- The matcher entry name `agy` is the server name from `claude mcp add agy`; adjust both if you registered the server under a different name.
+
+Two related subcommands, useful beyond Claude Code:
+
+- `agy-mcp wait-job [-timeout 1h] <job_id>` blocks until the job is terminal and prints the final state word (`done`, `failed`, or `cancelled`) to stdout. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout. It needs only the job state directory, not the agy binary, so it works in minimal environments.
+- `agy-mcp hook-wait [-timeout 1h]` is the hook entrypoint described above: it reads the PostToolUse payload from stdin, so it is not useful to invoke by hand, but it is a single self-contained binary call, no shell wrapper or jq required, and it works on Linux, macOS, and Windows.
+
+MCP clients other than Claude Code get the same no-polling benefit in-protocol: call `agy_wait` with the `job_id` returned by `agy_run` and the tool blocks (bounded by `wait`, default 2m, max 10m) until the job finishes.
 
 ## HTTP mode
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ How it behaves:
 
 Two related subcommands, useful beyond Claude Code:
 
-- `agy-mcp wait-job [-timeout 1h] <job_id>` blocks until the job is terminal and prints the final state word (`done`, `failed`, or `cancelled`) to stdout. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout. It needs only the job state directory, not the agy binary, so it works in minimal environments.
+- `agy-mcp wait-job [-timeout 1h] <job_id>` blocks until the job is terminal and prints the final state word (`done`, `failed`, or `cancelled`) to stdout. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout, 130 interrupted. It needs only the job state directory, not the agy binary, so it works in minimal environments.
 - `agy-mcp hook-wait [-timeout 1h]` is the hook entrypoint described above: it reads the PostToolUse payload from stdin, so it is not useful to invoke by hand, but it is a single self-contained binary call, no shell wrapper or jq required, and it works on Linux, macOS, and Windows.
 
 MCP clients other than Claude Code get the same no-polling benefit in-protocol: call `agy_wait` with the `job_id` returned by `agy_run` and the tool blocks (bounded by `wait`, default 2m, max 10m) until the job finishes.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Or add to your MCP client config:
 ## Tools
 
 - `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?)` -> `{ job_id, conversation_id?, state }`
-- `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`
-- `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id? }`
-- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`
+- `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, note? }`
+- `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, partial? }`
+- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
 - `list_models()` -> `{ models }`
 - `list_sessions(dir?)` -> `{ sessions }`
@@ -133,16 +133,16 @@ Add to your Claude Code `settings.json`:
 
 How it behaves:
 
-- After every `agy_run`, the hook waits (in the background, off the session's critical path) for the job's completion sentinel and then wakes Claude with a one-line message naming the job id and final state, so the model calls `agy_status` exactly once, when the result is actually ready.
+- After every `agy_run`, the hook waits (in the background, off the session's critical path) for the job's completion sentinel and then wakes Claude with a one-line message naming the `job_id` and final state, prompting the model to call `agy_status` when the result is actually ready.
 - `agy_run_sync` calls that returned their result inline produce no wake; a sync call that overran its wait cap (and so returned a still-running job) gets the same completion wake as `agy_run`.
-- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes. The hook-level `timeout` in `settings.json` (3700 above) must exceed hook-wait's own `-timeout` (1h by default), so hook-wait's internal timeout always fires first and reports the wake itself; if the outer `timeout` is equal or lower, Claude Code kills the hook process first and the exit-2 wake is lost, silently defeating the "never silently lost" guarantee.
-- The matcher entry name `agy` is the server name from `claude mcp add agy`; adjust both if you registered the server under a different name.
-- Claude Code runs hooks with the user's shell environment, not the MCP server entry's own env block, so if the server is registered with a custom `AGY_MCP_STATE_DIR` the same value must also be exported in the shell (or passed inline in the hook command) or hook-wait will silently watch the wrong state directory and never wake.
+- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost, provided the outer hook `timeout` exceeds hook-wait's own `-timeout` (see the `settings.json` note below). An externally interrupted wait (a SIGINT or SIGTERM delivered to hook-wait) also wakes, with a distinct "wait interrupted" message pointing at `agy_status`, rather than exiting silently and dropping the owed wake. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes. The hook-level `timeout` in `settings.json` (3700 above) must exceed hook-wait's own `-timeout` (1h by default), so hook-wait's internal timeout always fires first and reports the wake itself; if the outer `timeout` is equal or lower, Claude Code kills the hook process first and the exit-2 wake is lost, silently defeating that guarantee.
+- The `agy` in the matcher pattern `mcp__agy__agy_run(_sync)?` is the server name you passed to `claude mcp add agy`; if you registered the server under a different name, change both the `claude mcp add` name and that `agy` segment of the matcher.
+- Claude Code runs hooks with the user's shell environment, not the MCP server entry's own env block, so if the server is registered with a custom `AGY_MCP_STATE_DIR` the same value must also be exported in the shell (or passed inline in the hook command) or hook-wait will silently look in the wrong state directory and never wake.
 
 Two related subcommands, useful beyond Claude Code:
 
 - `agy-mcp wait-job [-timeout 1h] <job_id>` blocks until the job is terminal and prints the final state word (`done`, `failed`, or `cancelled`) to stdout. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout, 130 interrupted. It needs only the job state directory, not the agy binary, so it works in minimal environments.
-- `agy-mcp hook-wait [-timeout 1h]` is the hook entrypoint described above: it reads the PostToolUse payload from stdin, so it is not useful to invoke by hand, but it is a single self-contained binary call, no shell wrapper or jq required, and it works on Linux, macOS, and Windows.
+- `agy-mcp hook-wait [-timeout 1h]` is the hook entrypoint described above: it reads the PostToolUse payload from stdin, so it is not useful to invoke by hand, but it is a single self-contained binary call, no shell wrapper or jq required, and it works on Linux, macOS, and Windows. The file-based wake contract is exercised by tests on all three platforms; the signal-interrupt wake (SIGINT/SIGTERM) is a POSIX behavior and is tested there.
 
 MCP clients other than Claude Code get the same no-polling benefit in-protocol: call `agy_wait` with the `job_id` returned by `agy_run` and the tool blocks (bounded by `wait`, default 2m, max 10m) until the job finishes.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Add to your Claude Code `settings.json`:
       {
         "matcher": "mcp__agy__agy_run(_sync)?",
         "hooks": [
-          { "type": "command", "command": "agy-mcp hook-wait", "asyncRewake": true, "timeout": 3600 }
+          { "type": "command", "command": "agy-mcp hook-wait", "asyncRewake": true, "timeout": 3700 }
         ]
       }
     ]
@@ -135,8 +135,9 @@ How it behaves:
 
 - After every `agy_run`, the hook waits (in the background, off the session's critical path) for the job's completion sentinel and then wakes Claude with a one-line message naming the job id and final state, so the model calls `agy_status` exactly once, when the result is actually ready.
 - `agy_run_sync` calls that returned their result inline produce no wake; a sync call that overran its wait cap (and so returned a still-running job) gets the same completion wake as `agy_run`.
-- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes.
+- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes. The hook-level `timeout` in `settings.json` (3700 above) must exceed hook-wait's own `-timeout` (1h by default), so hook-wait's internal timeout always fires first and reports the wake itself; if the outer `timeout` is equal or lower, Claude Code kills the hook process first and the exit-2 wake is lost, silently defeating the "never silently lost" guarantee.
 - The matcher entry name `agy` is the server name from `claude mcp add agy`; adjust both if you registered the server under a different name.
+- Claude Code runs hooks with the user's shell environment, not the MCP server entry's own env block, so if the server is registered with a custom `AGY_MCP_STATE_DIR` the same value must also be exported in the shell (or passed inline in the hook command) or hook-wait will silently watch the wrong state directory and never wake.
 
 Two related subcommands, useful beyond Claude Code:
 

--- a/hookwait.go
+++ b/hookwait.go
@@ -45,10 +45,10 @@ func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
 		return 0
 	}
 	if terminal {
-		fmt.Fprintf(stderr, "agy job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",
+		_, _ = fmt.Fprintf(stderr, "agy job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",
 			jobID, st.State, st.Elapsed.Round(time.Second))
 	} else {
-		fmt.Fprintf(stderr, "agy job %s still running after %s; poll agy_status\n", jobID, *timeout)
+		_, _ = fmt.Fprintf(stderr, "agy job %s still running after %s; poll agy_status\n", jobID, *timeout)
 	}
 	return 2
 }

--- a/hookwait.go
+++ b/hookwait.go
@@ -26,14 +26,19 @@ func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 0
 	}
-	jobID, toolName, ok := hookinput.Parse(stdin)
+	jobID, toolName, respState, ok := hookinput.Parse(stdin)
 	if !ok {
 		return 0
 	}
 	// A sync tool that already returned a terminal result delivered it inline;
-	// waking Claude again would be noise. agy_run never delivers inline, so
-	// for it even an already-terminal job still gets its wake.
-	if strings.HasSuffix(toolName, "agy_run_sync") {
+	// waking Claude again would be noise. But if the response itself still
+	// says "running", the sync call overran its wait cap and returned before
+	// the job finished, so no result was delivered inline, no matter what the
+	// live status says by the time this hook runs (the job may well have
+	// finished on disk in the meantime): the wake is still owed. agy_run
+	// never delivers inline, so for it even an already-terminal job always
+	// gets its wake, regardless of respState.
+	if strings.HasSuffix(toolName, "agy_run_sync") && respState != "running" {
 		if cfg, err := config.ResolveWait(); err == nil {
 			if st, err := manager.New(cfg).Status(jobID); err == nil && st.State != manager.StateRunning {
 				return 0

--- a/hookwait.go
+++ b/hookwait.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/hookinput"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// hookWaitMain implements "agy-mcp hook-wait [-timeout 1h]": read a Claude
+// Code PostToolUse hook payload from stdin, wait for the agy job it
+// references, and exit 2 with a wake message on stderr. Exit 2 is Claude
+// Code's asyncRewake wake signal; every other outcome exits 0 with no output,
+// because a hook that fails must never disrupt the tool flow it observes.
+// A timeout also wakes (exit 2): the model should learn the job is
+// long-running rather than never hearing back.
+func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
+	fs := flag.NewFlagSet("hook-wait", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // usage noise would land in the transcript; stay quiet
+	timeout := fs.Duration("timeout", time.Hour, "max time to wait for the job")
+	if err := fs.Parse(args); err != nil {
+		return 0
+	}
+	jobID, toolName, ok := hookinput.Parse(stdin)
+	if !ok {
+		return 0
+	}
+	// A sync tool that already returned a terminal result delivered it inline;
+	// waking Claude again would be noise. agy_run never delivers inline, so
+	// for it even an already-terminal job still gets its wake.
+	if strings.HasSuffix(toolName, "agy_run_sync") {
+		if cfg, err := config.ResolveWait(); err == nil {
+			if st, err := manager.New(cfg).Status(jobID); err == nil && st.State != manager.StateRunning {
+				return 0
+			}
+		}
+	}
+	st, terminal, err := waitForJob(jobID, *timeout)
+	if err != nil {
+		return 0
+	}
+	if terminal {
+		fmt.Fprintf(stderr, "agy job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",
+			jobID, st.State, st.Elapsed.Round(time.Second))
+	} else {
+		fmt.Fprintf(stderr, "agy job %s still running after %s; poll agy_status\n", jobID, *timeout)
+	}
+	return 2
+}

--- a/hookwait.go
+++ b/hookwait.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 	"time"
 
-	"github.com/tphakala/agy-mcp/internal/config"
 	"github.com/tphakala/agy-mcp/internal/hookinput"
 	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/mcptools"
 )
 
 // hookWaitMain implements "agy-mcp hook-wait [-timeout 1h]": read a Claude
@@ -20,6 +23,10 @@ import (
 // A timeout also wakes (exit 2): the model should learn the job is
 // long-running rather than never hearing back.
 func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
+	// Manager internals log via the std logger on rare error paths; any stray line
+	// would land in the transcript on a non-wake exit or prepend noise to the wake
+	// message, so silence the std logger for the whole hook run.
+	log.SetOutput(io.Discard)
 	fs := flag.NewFlagSet("hook-wait", flag.ContinueOnError)
 	fs.SetOutput(io.Discard) // usage noise would land in the transcript; stay quiet
 	timeout := fs.Duration("timeout", time.Hour, "max time to wait for the job")
@@ -30,24 +37,42 @@ func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
 	if !ok {
 		return 0
 	}
-	// A sync tool that already returned a terminal result delivered it inline;
-	// waking Claude again would be noise. But if the response itself still
-	// says "running", the sync call overran its wait cap and returned before
-	// the job finished, so no result was delivered inline, no matter what the
-	// live status says by the time this hook runs (the job may well have
-	// finished on disk in the meantime): the wake is still owed. agy_run
-	// never delivers inline, so for it even an already-terminal job always
-	// gets its wake, regardless of respState.
-	if strings.HasSuffix(toolName, "agy_run_sync") && respState != "running" {
-		if cfg, err := config.ResolveWait(); err == nil {
-			if st, err := manager.New(cfg).Status(jobID); err == nil && st.State != manager.StateRunning {
-				return 0
-			}
-		}
-	}
-	st, terminal, err := waitForJob(jobID, *timeout)
+	// Resolve the wait manager once and reuse it for both the run_sync
+	// short-circuit and the wait below. A resolve failure means there is no way to
+	// observe the job, so stay quiet rather than wake with nothing to report.
+	mgr, err := resolveWaitManager()
 	if err != nil {
 		return 0
+	}
+	// A sync tool that already returned a terminal result delivered it inline, so
+	// waking Claude again would be noise. Suppress only when all three hold: the
+	// tool is agy_run_sync, its recorded response state is a KNOWN terminal state
+	// (not "" and not running), AND the job is terminal on disk now. An absent or
+	// unknown payload state must fail toward waking: a "running" response means the
+	// sync call overran its wait cap and delivered no result inline (the wake is
+	// owed no matter what the live status now says), and an empty/odd state is not
+	// proof of inline delivery either. A redundant wake is only noise; a suppressed
+	// owed wake is a lost result. agy_run never delivers inline, so it always wakes.
+	if strings.HasSuffix(toolName, mcptools.ToolAgyRunSync) &&
+		respState != "" && respState != manager.StateRunning {
+		if st, err := mgr.Status(jobID); err == nil && st.State != manager.StateRunning {
+			return 0
+		}
+	}
+	st, terminal, err := waitForJobWith(mgr, jobID, *timeout)
+	if err != nil {
+		// An externally delivered SIGINT/SIGTERM cancels only this observer, not the
+		// job, which keeps running under its detached supervisor. Exiting 0 would
+		// silently drop an owed wake, contradicting the documented guarantee, so wake
+		// with a distinct message and point the model at agy_status. Only cancellation
+		// wakes here; a genuine internal error still exits 0 to stay out of the tool
+		// flow. When the outer hook timeout killed this process the parent has already
+		// stopped listening, so the extra exit 2 is harmless.
+		if !errors.Is(err, context.Canceled) {
+			return 0
+		}
+		_, _ = fmt.Fprintf(stderr, "agy job %s wait interrupted; the job may still be running; poll agy_status with this job_id\n", jobID)
+		return 2
 	}
 	if terminal {
 		_, _ = fmt.Fprintf(stderr, "agy job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",

--- a/hookwait_posix_test.go
+++ b/hookwait_posix_test.go
@@ -5,185 +5,24 @@ package main
 import (
 	"bytes"
 	"errors"
-	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/tphakala/agy-mcp/internal/config"
-	"github.com/tphakala/agy-mcp/internal/manager"
-	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
-// hookPayload builds the stdin JSON hook-wait expects from a PostToolUse
-// hook, with the given state carried in the tool response (the state the
-// tool call itself observed, distinct from whatever the job's state is on
-// disk by the time the hook runs).
-func hookPayload(tool, id, state string) string {
-	return fmt.Sprintf(`{"tool_name":%q,"tool_response":{"job_id":%q,"state":%q}}`, tool, id, state)
-}
-
-func TestHookWaitWakesOnDoneJob(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	writeTerminalJob(t, stateDir, "job-hw-1")
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-hw-1", "running")), &errb)
-	if code != 2 {
-		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
-	}
-	out := errb.String()
-	if !strings.Contains(out, "job-hw-1") {
-		t.Fatalf("stderr = %q, want it to mention the job id", out)
-	}
-	if !strings.Contains(out, "state=done") {
-		t.Fatalf("stderr = %q, want it to mention state=done", out)
-	}
-	if !strings.Contains(out, "agy_status") {
-		t.Fatalf("stderr = %q, want it to mention agy_status", out)
-	}
-}
-
-func TestHookWaitQuietWhenRunSyncAlreadyTerminal(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	writeTerminalJob(t, stateDir, "job-hw-1")
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1", "done")), &errb)
-	if code != 0 {
-		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
-	}
-	if errb.String() != "" {
-		t.Fatalf("stderr = %q, want empty", errb.String())
-	}
-}
-
-// TestHookWaitWakesOnRunSyncOverrunRace covers the overrun-then-finished race:
-// a run_sync call overran its wait cap and returned with the response still
-// reporting state "running" (no result delivered inline), but by the time
-// this hook checks, the job has already finished on disk. The response state
-// says "running", so the result was never delivered inline; the wake is
-// owed regardless of what the live status now says.
-func TestHookWaitWakesOnRunSyncOverrunRace(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	writeTerminalJob(t, stateDir, "job-hw-1")
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1", "running")), &errb)
-	if code != 2 {
-		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
-	}
-	if !strings.Contains(errb.String(), "job-hw-1") {
-		t.Fatalf("stderr = %q, want it to mention the job id", errb.String())
-	}
-}
-
-// TestHookWaitWakesOnRunSyncMissingState covers a run_sync response that carries
-// a job_id but no state field. An absent state is not proof the result was
-// delivered inline, so it must fail toward waking (exit 2) rather than suppress
-// an owed wake, even though the job is already terminal on disk.
-func TestHookWaitWakesOnRunSyncMissingState(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	writeTerminalJob(t, stateDir, "job-hw-1")
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	payload := `{"tool_name":"mcp__agy__agy_run_sync","tool_response":{"job_id":"job-hw-1"}}`
-	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(payload), &errb)
-	if code != 2 {
-		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
-	}
-	if !strings.Contains(errb.String(), "job-hw-1") {
-		t.Fatalf("stderr = %q, want it to mention the job id", errb.String())
-	}
-}
-
-func TestHookWaitQuietOnNoJobID(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(`{"tool_name":"mcp__agy__agy_run","tool_response":{"error":"x"}}`), &errb)
-	if code != 0 {
-		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
-	}
-	if errb.String() != "" {
-		t.Fatalf("stderr = %q, want empty", errb.String())
-	}
-}
-
 func TestHookWaitWakesOnTimeout(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 2 * time.Second})
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
-	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
-		AgyPath:   agy,
-		CachePath: cachePath,
-		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-hookwait-timeout-test"),
-	})
-	stateDir := t.TempDir()
-	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
-		DefaultTimeout: time.Minute, MaxConcurrency: 4,
-		ConversationCacheFile: cachePath}
-	mgr := manager.New(c)
-
-	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Drain the started job once the test is done polling hookWaitMain, so a
-	// slow fake agy never outlives the test.
-	t.Cleanup(func() {
-		testutil.WaitFor(t, 5*time.Second, func() bool {
-			st, err := mgr.State(job.ID)
-			return err == nil && st != manager.StateRunning
-		}, "job did not finish before test cleanup")
-	})
-
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+	setFakeHome(t)
+	jobID := startRunningJobForWait(t, 2*time.Second, "conv-hookwait-timeout-test", 5*time.Second)
 
 	var errb bytes.Buffer
-	code := hookWaitMain([]string{"-timeout", "100ms"}, strings.NewReader(hookPayload("mcp__agy__agy_run", job.ID, "running")), &errb)
+	code := hookWaitMain([]string{"-timeout", "100ms"}, strings.NewReader(hookPayload("mcp__agy__agy_run", jobID, "running")), &errb)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
 	}
 	if !strings.Contains(errb.String(), "still running") {
 		t.Fatalf("stderr = %q, want it to mention still running", errb.String())
-	}
-}
-
-func TestHookWaitQuietOnUnknownJob(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-none", "running")), &errb)
-	if code != 0 {
-		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
-	}
-	if errb.String() != "" {
-		t.Fatalf("stderr = %q, want empty", errb.String())
 	}
 }
 
@@ -198,53 +37,19 @@ func TestHookWaitWakesOnInterrupt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
-
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 5 * time.Second})
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
-	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
-		AgyPath:   agy,
-		CachePath: cachePath,
-		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-hookwait-interrupt-test"),
-	})
-	stateDir := t.TempDir()
-	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
-		DefaultTimeout: time.Minute, MaxConcurrency: 4,
-		ConversationCacheFile: cachePath}
-	mgr := manager.New(c)
-
-	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Drain the started job once the test is done, so the 5s fake agy never
-	// outlives the test.
-	t.Cleanup(func() {
-		testutil.WaitFor(t, 10*time.Second, func() bool {
-			st, err := mgr.State(job.ID)
-			return err == nil && st != manager.StateRunning
-		}, "job did not finish before test cleanup")
-	})
-
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+	setFakeHome(t)
+	jobID := startRunningJobForWait(t, 5*time.Second, "conv-hookwait-interrupt-test", 10*time.Second)
 
 	cmd := exec.Command(bin, "hook-wait", "-timeout", "1h")
-	cmd.Stdin = strings.NewReader(hookPayload("mcp__agy__agy_run", job.ID, "running"))
+	cmd.Stdin = strings.NewReader(hookPayload("mcp__agy__agy_run", jobID, "running"))
 	var out, errb bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errb
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	// Signal the child if the test aborts before it is reaped below, so neither it
-	// nor its 5s fake agy leaks.
+	// Kill and reap the child if the test aborts before the happy-path Wait below,
+	// so neither it nor its 5s fake agy leaks.
 	reaped := false
 	t.Cleanup(func() {
 		if !reaped {

--- a/hookwait_posix_test.go
+++ b/hookwait_posix_test.go
@@ -4,10 +4,13 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -77,6 +80,27 @@ func TestHookWaitWakesOnRunSyncOverrunRace(t *testing.T) {
 
 	var errb bytes.Buffer
 	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1", "running")), &errb)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "job-hw-1") {
+		t.Fatalf("stderr = %q, want it to mention the job id", errb.String())
+	}
+}
+
+// TestHookWaitWakesOnRunSyncMissingState covers a run_sync response that carries
+// a job_id but no state field. An absent state is not proof the result was
+// delivered inline, so it must fail toward waking (exit 2) rather than suppress
+// an owed wake, even though the job is already terminal on disk.
+func TestHookWaitWakesOnRunSyncMissingState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	payload := `{"tool_name":"mcp__agy__agy_run_sync","tool_response":{"job_id":"job-hw-1"}}`
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(payload), &errb)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
 	}
@@ -160,5 +184,91 @@ func TestHookWaitQuietOnUnknownJob(t *testing.T) {
 	}
 	if errb.String() != "" {
 		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}
+
+// TestHookWaitWakesOnInterrupt proves a SIGINT delivered to a waiting hook-wait
+// wakes with the distinct interrupt message and exit 2, rather than silently
+// exiting 0 and dropping the owed wake. hookWaitMain runs in-process for the
+// other tests, but a SIGINT sent to the test binary itself would kill the whole
+// run, so this execs the real binary as a child and signals that, mirroring
+// TestWaitJobInterrupted.
+func TestHookWaitWakesOnInterrupt(t *testing.T) {
+	bin, err := buildBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 5 * time.Second})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:   agy,
+		CachePath: cachePath,
+		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-hookwait-interrupt-test"),
+	})
+	stateDir := t.TempDir()
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	mgr := manager.New(c)
+
+	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain the started job once the test is done, so the 5s fake agy never
+	// outlives the test.
+	t.Cleanup(func() {
+		testutil.WaitFor(t, 10*time.Second, func() bool {
+			st, err := mgr.State(job.ID)
+			return err == nil && st != manager.StateRunning
+		}, "job did not finish before test cleanup")
+	})
+
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	cmd := exec.Command(bin, "hook-wait", "-timeout", "1h")
+	cmd.Stdin = strings.NewReader(hookPayload("mcp__agy__agy_run", job.ID, "running"))
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Signal the child if the test aborts before it is reaped below, so neither it
+	// nor its 5s fake agy leaks.
+	reaped := false
+	t.Cleanup(func() {
+		if !reaped {
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+			_ = cmd.Wait()
+		}
+	})
+	// Give the child a moment to reach signal.NotifyContext (resolveWaitManager and
+	// Parse run first; the job sleeps 5s, so there is ample margin either way)
+	// before signalling it.
+	time.Sleep(300 * time.Millisecond)
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatal(err)
+	}
+	waitErr := cmd.Wait()
+	reaped = true
+	exitErr, ok := errors.AsType[*exec.ExitError](waitErr)
+	if !ok {
+		t.Fatalf("hook-wait did not exit with an error after SIGINT: %v (stdout=%q stderr=%q)", waitErr, out.String(), errb.String())
+	}
+	if code := exitErr.ExitCode(); code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stdout=%q stderr=%q)", code, out.String(), errb.String())
+	}
+	if !strings.Contains(errb.String(), "wait interrupted") {
+		t.Fatalf("stderr = %q, want it to mention wait interrupted", errb.String())
 	}
 }

--- a/hookwait_posix_test.go
+++ b/hookwait_posix_test.go
@@ -1,0 +1,139 @@
+//go:build linux || darwin
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// hookPayload builds the stdin JSON hook-wait expects from a PostToolUse hook.
+func hookPayload(tool, id string) string {
+	return fmt.Sprintf(`{"tool_name":%q,"tool_response":{"job_id":%q,"state":"running"}}`, tool, id)
+}
+
+func TestHookWaitWakesOnDoneJob(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-hw-1")), &errb)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	out := errb.String()
+	if !strings.Contains(out, "job-hw-1") {
+		t.Fatalf("stderr = %q, want it to mention the job id", out)
+	}
+	if !strings.Contains(out, "state=done") {
+		t.Fatalf("stderr = %q, want it to mention state=done", out)
+	}
+	if !strings.Contains(out, "agy_status") {
+		t.Fatalf("stderr = %q, want it to mention agy_status", out)
+	}
+}
+
+func TestHookWaitQuietWhenRunSyncAlreadyTerminal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1")), &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if errb.String() != "" {
+		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}
+
+func TestHookWaitQuietOnNoJobID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(`{"tool_name":"mcp__agy__agy_run","tool_response":{"error":"x"}}`), &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if errb.String() != "" {
+		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}
+
+func TestHookWaitWakesOnTimeout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 2 * time.Second})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:   agy,
+		CachePath: cachePath,
+		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-hookwait-timeout-test"),
+	})
+	stateDir := t.TempDir()
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	mgr := manager.New(c)
+
+	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain the started job once the test is done polling hookWaitMain, so a
+	// slow fake agy never outlives the test.
+	t.Cleanup(func() {
+		testutil.WaitFor(t, 5*time.Second, func() bool {
+			st, err := mgr.State(job.ID)
+			return err == nil && st != manager.StateRunning
+		}, "job did not finish before test cleanup")
+	})
+
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain([]string{"-timeout", "100ms"}, strings.NewReader(hookPayload("mcp__agy__agy_run", job.ID)), &errb)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "still running") {
+		t.Fatalf("stderr = %q, want it to mention still running", errb.String())
+	}
+}
+
+func TestHookWaitQuietOnUnknownJob(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-none")), &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if errb.String() != "" {
+		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}

--- a/hookwait_posix_test.go
+++ b/hookwait_posix_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
-// hookPayload builds the stdin JSON hook-wait expects from a PostToolUse hook.
-func hookPayload(tool, id string) string {
-	return fmt.Sprintf(`{"tool_name":%q,"tool_response":{"job_id":%q,"state":"running"}}`, tool, id)
+// hookPayload builds the stdin JSON hook-wait expects from a PostToolUse
+// hook, with the given state carried in the tool response (the state the
+// tool call itself observed, distinct from whatever the job's state is on
+// disk by the time the hook runs).
+func hookPayload(tool, id, state string) string {
+	return fmt.Sprintf(`{"tool_name":%q,"tool_response":{"job_id":%q,"state":%q}}`, tool, id, state)
 }
 
 func TestHookWaitWakesOnDoneJob(t *testing.T) {
@@ -28,7 +31,7 @@ func TestHookWaitWakesOnDoneJob(t *testing.T) {
 	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
 
 	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-hw-1")), &errb)
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-hw-1", "running")), &errb)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
 	}
@@ -51,12 +54,34 @@ func TestHookWaitQuietWhenRunSyncAlreadyTerminal(t *testing.T) {
 	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
 
 	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1")), &errb)
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1", "done")), &errb)
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
 	}
 	if errb.String() != "" {
 		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}
+
+// TestHookWaitWakesOnRunSyncOverrunRace covers the overrun-then-finished race:
+// a run_sync call overran its wait cap and returned with the response still
+// reporting state "running" (no result delivered inline), but by the time
+// this hook checks, the job has already finished on disk. The response state
+// says "running", so the result was never delivered inline; the wake is
+// owed regardless of what the live status now says.
+func TestHookWaitWakesOnRunSyncOverrunRace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1", "running")), &errb)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "job-hw-1") {
+		t.Fatalf("stderr = %q, want it to mention the job id", errb.String())
 	}
 }
 
@@ -114,7 +139,7 @@ func TestHookWaitWakesOnTimeout(t *testing.T) {
 	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
 
 	var errb bytes.Buffer
-	code := hookWaitMain([]string{"-timeout", "100ms"}, strings.NewReader(hookPayload("mcp__agy__agy_run", job.ID)), &errb)
+	code := hookWaitMain([]string{"-timeout", "100ms"}, strings.NewReader(hookPayload("mcp__agy__agy_run", job.ID, "running")), &errb)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
 	}
@@ -129,7 +154,7 @@ func TestHookWaitQuietOnUnknownJob(t *testing.T) {
 	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
 
 	var errb bytes.Buffer
-	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-none")), &errb)
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-none", "running")), &errb)
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
 	}

--- a/hookwait_test.go
+++ b/hookwait_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The file-based hook-wait tests live in this untagged file (not the posix one)
+// so they run on Windows CI too; they only read and write files and never exec a
+// shell fake or send a signal. The shell-driven timeout and signal-interrupt
+// tests stay in hookwait_posix_test.go.
+
+func TestHookWaitWakesOnDoneJob(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-hw-1", "running")), &errb)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	out := errb.String()
+	if !strings.Contains(out, "job-hw-1") {
+		t.Fatalf("stderr = %q, want it to mention the job id", out)
+	}
+	if !strings.Contains(out, "state=done") {
+		t.Fatalf("stderr = %q, want it to mention state=done", out)
+	}
+	if !strings.Contains(out, "agy_status") {
+		t.Fatalf("stderr = %q, want it to mention agy_status", out)
+	}
+}
+
+func TestHookWaitQuietWhenRunSyncAlreadyTerminal(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1", "done")), &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if errb.String() != "" {
+		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}
+
+// TestHookWaitWakesOnRunSyncOverrunRace covers the overrun-then-finished race:
+// a run_sync call overran its wait cap and returned with the response still
+// reporting state "running" (no result delivered inline), but by the time this
+// hook checks, the job has already finished on disk. The response state says
+// "running", so the result was never delivered inline; the wake is owed
+// regardless of what the live status now says.
+func TestHookWaitWakesOnRunSyncOverrunRace(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run_sync", "job-hw-1", "running")), &errb)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "job-hw-1") {
+		t.Fatalf("stderr = %q, want it to mention the job id", errb.String())
+	}
+}
+
+// TestHookWaitWakesOnRunSyncMissingState covers a run_sync response that carries
+// a job_id but no state field. An absent state is not proof the result was
+// delivered inline, so it must fail toward waking (exit 2) rather than suppress
+// an owed wake, even though the job is already terminal on disk.
+func TestHookWaitWakesOnRunSyncMissingState(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-hw-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	payload := `{"tool_name":"mcp__agy__agy_run_sync","tool_response":{"job_id":"job-hw-1"}}`
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(payload), &errb)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "job-hw-1") {
+		t.Fatalf("stderr = %q, want it to mention the job id", errb.String())
+	}
+}
+
+func TestHookWaitQuietOnNoJobID(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(`{"tool_name":"mcp__agy__agy_run","tool_response":{"error":"x"}}`), &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if errb.String() != "" {
+		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}
+
+func TestHookWaitQuietOnUnknownJob(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var errb bytes.Buffer
+	code := hookWaitMain(nil, strings.NewReader(hookPayload("mcp__agy__agy_run", "job-none", "running")), &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if errb.String() != "" {
+		t.Fatalf("stderr = %q, want empty", errb.String())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,15 +104,26 @@ func resolveStateDir() (string, error) {
 }
 
 // ResolveWait builds the minimal Config the wait-only subcommands (wait-job,
-// hook-wait) need: the state dir and defaults, with no agy binary lookup and
-// no supervisor path. Reading job status never execs agy, so requiring it on
-// PATH would be an artificial failure for a pure observer.
+// hook-wait) need: the state dir, defaults, and its own executable path, with
+// no agy binary lookup. Reading job status never execs agy, so requiring it on
+// PATH would be an artificial failure for a pure observer. SupervisorExe is
+// still resolved (unlike AgyPath): processAlive's fallback liveness check
+// compares a job's recorded supervisor process name against
+// m.cfg.SupervisorExe, and the wait subcommands run from the same agy-mcp
+// binary that supervises jobs in the normal single-install case, so leaving
+// it empty would make that fallback compare against filepath.Base(""), which
+// can never match a real comm value and would misreport a live job as dead.
 func ResolveWait() (Config, error) {
 	stateDir, err := resolveStateDir()
 	if err != nil {
 		return Config{}, err
 	}
+	self, err := os.Executable()
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve own executable: %w", err)
+	}
 	c := baseConfig()
 	c.StateDir = stateDir
+	c.SupervisorExe = self
 	return c, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,15 +26,22 @@ type Config struct {
 	ConversationCacheFile string
 }
 
-// Resolve builds a Config from environment variables and defaults.
-func Resolve() (Config, error) {
-	c := Config{
-		DefaultModel:   os.Getenv("AGY_MCP_DEFAULT_MODEL"),
+// baseConfig returns a Config carrying exactly the defaults shared by Resolve
+// and ResolveWait (DefaultTimeout, MaxConcurrency, JobTTL). It is the single
+// source of those defaults, so the two resolvers cannot drift apart.
+func baseConfig() Config {
+	return Config{
 		DefaultTimeout: 30 * time.Minute,
 		MaxConcurrency: 4,
 		JobTTL:         24 * time.Hour,
-		HTTPToken:      os.Getenv("AGY_MCP_HTTP_TOKEN"),
 	}
+}
+
+// Resolve builds a Config from environment variables and defaults.
+func Resolve() (Config, error) {
+	c := baseConfig()
+	c.DefaultModel = os.Getenv("AGY_MCP_DEFAULT_MODEL")
+	c.HTTPToken = os.Getenv("AGY_MCP_HTTP_TOKEN")
 
 	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {
 		// Resolve the override with LookPath, symmetric with the PATH branch below, so
@@ -69,19 +76,43 @@ func Resolve() (Config, error) {
 	}
 	c.SupervisorExe = self
 
-	stateRoot := os.Getenv("AGY_MCP_STATE_DIR")
-	if stateRoot == "" {
-		xdg := os.Getenv("XDG_STATE_HOME")
-		if xdg == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return Config{}, fmt.Errorf("resolve home: %w", err)
-			}
-			xdg = filepath.Join(home, ".local", "state")
-		}
-		stateRoot = filepath.Join(xdg, "agy-mcp")
+	stateRoot, err := resolveStateDir()
+	if err != nil {
+		return Config{}, err
 	}
 	c.StateDir = stateRoot
 
+	return c, nil
+}
+
+// resolveStateDir returns the job-state root: AGY_MCP_STATE_DIR verbatim, or
+// the XDG state-home fallback. Shared by Resolve and ResolveWait so the two
+// cannot drift.
+func resolveStateDir() (string, error) {
+	if stateRoot := os.Getenv("AGY_MCP_STATE_DIR"); stateRoot != "" {
+		return stateRoot, nil
+	}
+	xdg := os.Getenv("XDG_STATE_HOME")
+	if xdg == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home: %w", err)
+		}
+		xdg = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(xdg, "agy-mcp"), nil
+}
+
+// ResolveWait builds the minimal Config the wait-only subcommands (wait-job,
+// hook-wait) need: the state dir and defaults, with no agy binary lookup and
+// no supervisor path. Reading job status never execs agy, so requiring it on
+// PATH would be an artificial failure for a pure observer.
+func ResolveWait() (Config, error) {
+	stateDir, err := resolveStateDir()
+	if err != nil {
+		return Config{}, err
+	}
+	c := baseConfig()
+	c.StateDir = stateDir
 	return c, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,9 +70,9 @@ func Resolve() (Config, error) {
 	}
 	c.AgyPath = abs
 
-	self, err := os.Executable()
+	self, err := resolveSupervisorExe()
 	if err != nil {
-		return Config{}, fmt.Errorf("resolve own executable: %w", err)
+		return Config{}, err
 	}
 	c.SupervisorExe = self
 
@@ -85,22 +85,42 @@ func Resolve() (Config, error) {
 	return c, nil
 }
 
-// resolveStateDir returns the job-state root: AGY_MCP_STATE_DIR verbatim, or
-// the XDG state-home fallback. Shared by Resolve and ResolveWait so the two
+// resolveStateDir returns the job-state root: AGY_MCP_STATE_DIR (made absolute)
+// or the XDG state-home fallback. Shared by Resolve and ResolveWait so the two
 // cannot drift.
 func resolveStateDir() (string, error) {
-	if stateRoot := os.Getenv("AGY_MCP_STATE_DIR"); stateRoot != "" {
-		return stateRoot, nil
-	}
-	xdg := os.Getenv("XDG_STATE_HOME")
-	if xdg == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("resolve home: %w", err)
+	stateRoot := os.Getenv("AGY_MCP_STATE_DIR")
+	if stateRoot == "" {
+		xdg := os.Getenv("XDG_STATE_HOME")
+		if xdg == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolve home: %w", err)
+			}
+			xdg = filepath.Join(home, ".local", "state")
 		}
-		xdg = filepath.Join(home, ".local", "state")
+		stateRoot = filepath.Join(xdg, "agy-mcp")
 	}
-	return filepath.Join(xdg, "agy-mcp"), nil
+	// A relative override resolves against each process's own cwd; hook-wait runs
+	// from the session cwd while the server does not, so the same relative value
+	// would silently split the job store. Absolutize so every consumer agrees,
+	// covering both the override and the XDG fallback.
+	abs, err := filepath.Abs(stateRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve state dir %q: %w", stateRoot, err)
+	}
+	return abs, nil
+}
+
+// resolveSupervisorExe returns the path to the running agy-mcp binary, used as
+// the run-job supervisor. Shared by Resolve and ResolveWait so the two cannot
+// drift.
+func resolveSupervisorExe() (string, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve own executable: %w", err)
+	}
+	return self, nil
 }
 
 // ResolveWait builds the minimal Config the wait-only subcommands (wait-job,
@@ -118,12 +138,16 @@ func ResolveWait() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	self, err := os.Executable()
+	self, err := resolveSupervisorExe()
 	if err != nil {
-		return Config{}, fmt.Errorf("resolve own executable: %w", err)
+		return Config{}, err
 	}
 	c := baseConfig()
 	c.StateDir = stateDir
 	c.SupervisorExe = self
+	// Cheap env reads carried for uniformity with Resolve; the wait paths do not
+	// consume them today.
+	c.DefaultModel = os.Getenv("AGY_MCP_DEFAULT_MODEL")
+	c.HTTPToken = os.Getenv("AGY_MCP_HTTP_TOKEN")
 	return c, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,7 +208,14 @@ func TestResolveWaitNeedsNoAgy(t *testing.T) {
 	if c.StateDir != "/custom/state" {
 		t.Fatalf("StateDir = %q, want /custom/state", c.StateDir)
 	}
-	if c.AgyPath != "" || c.SupervisorExe != "" {
-		t.Fatalf("wait config resolved binaries it must not need: agy=%q supervisor=%q", c.AgyPath, c.SupervisorExe)
+	if c.AgyPath != "" {
+		t.Fatalf("wait config resolved a binary it must not need: agy=%q", c.AgyPath)
+	}
+	// SupervisorExe IS resolved (unlike AgyPath): processAlive's fallback
+	// liveness check compares a job's recorded supervisor process name against
+	// it, so leaving it empty would make that comparison always fail and
+	// misreport a live job as dead.
+	if c.SupervisorExe == "" {
+		t.Fatal("SupervisorExe = \"\", want the wait config's own executable path")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -189,33 +189,3 @@ func TestResolveHTTPToken(t *testing.T) {
 		}
 	})
 }
-
-// TestResolveWaitNeedsNoAgy: ResolveWait must succeed with no agy anywhere on
-// PATH (the wait-only subcommands are pure observers of the job store), while
-// Resolve fails in the same environment, proving the seam matters.
-func TestResolveWaitNeedsNoAgy(t *testing.T) {
-	t.Setenv("AGY_MCP_AGY_PATH", "")
-	t.Setenv("PATH", t.TempDir()) // empty dir: no agy
-	t.Setenv("AGY_MCP_STATE_DIR", "/custom/state")
-
-	if _, err := Resolve(); err == nil {
-		t.Fatal("Resolve succeeded without agy on PATH; the control condition is broken")
-	}
-	c, err := ResolveWait()
-	if err != nil {
-		t.Fatalf("ResolveWait: %v", err)
-	}
-	if c.StateDir != "/custom/state" {
-		t.Fatalf("StateDir = %q, want /custom/state", c.StateDir)
-	}
-	if c.AgyPath != "" {
-		t.Fatalf("wait config resolved a binary it must not need: agy=%q", c.AgyPath)
-	}
-	// SupervisorExe IS resolved (unlike AgyPath): processAlive's fallback
-	// liveness check compares a job's recorded supervisor process name against
-	// it, so leaving it empty would make that comparison always fail and
-	// misreport a live job as dead.
-	if c.SupervisorExe == "" {
-		t.Fatal("SupervisorExe = \"\", want the wait config's own executable path")
-	}
-}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -189,3 +189,26 @@ func TestResolveHTTPToken(t *testing.T) {
 		}
 	})
 }
+
+// TestResolveWaitNeedsNoAgy: ResolveWait must succeed with no agy anywhere on
+// PATH (the wait-only subcommands are pure observers of the job store), while
+// Resolve fails in the same environment, proving the seam matters.
+func TestResolveWaitNeedsNoAgy(t *testing.T) {
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	t.Setenv("PATH", t.TempDir()) // empty dir: no agy
+	t.Setenv("AGY_MCP_STATE_DIR", "/custom/state")
+
+	if _, err := Resolve(); err == nil {
+		t.Fatal("Resolve succeeded without agy on PATH; the control condition is broken")
+	}
+	c, err := ResolveWait()
+	if err != nil {
+		t.Fatalf("ResolveWait: %v", err)
+	}
+	if c.StateDir != "/custom/state" {
+		t.Fatalf("StateDir = %q, want /custom/state", c.StateDir)
+	}
+	if c.AgyPath != "" || c.SupervisorExe != "" {
+		t.Fatalf("wait config resolved binaries it must not need: agy=%q supervisor=%q", c.AgyPath, c.SupervisorExe)
+	}
+}

--- a/internal/config/config_wait_test.go
+++ b/internal/config/config_wait_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"testing"
+)
+
+// TestResolveWaitNeedsNoAgy: ResolveWait must succeed with no agy anywhere on
+// PATH (the wait-only subcommands are pure observers of the job store), while
+// Resolve fails in the same environment, proving the seam matters. Untagged so
+// it runs on Windows too, where the wait subcommands ship the same guarantee.
+func TestResolveWaitNeedsNoAgy(t *testing.T) {
+	// os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows; pin both to
+	// temp dirs so the XDG fallback (should Resolve reach it) never touches the
+	// real home on either platform.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	t.Setenv("PATH", t.TempDir()) // empty dir: no agy
+	// An absolute state override so the post-absolutization value is stable on
+	// every platform (a POSIX-absolute literal is relative on Windows).
+	stateDir := t.TempDir()
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	if _, err := Resolve(); err == nil {
+		t.Fatal("Resolve succeeded without agy on PATH; the control condition is broken")
+	}
+	c, err := ResolveWait()
+	if err != nil {
+		t.Fatalf("ResolveWait: %v", err)
+	}
+	if c.StateDir != stateDir {
+		t.Fatalf("StateDir = %q, want %q", c.StateDir, stateDir)
+	}
+	if c.AgyPath != "" {
+		t.Fatalf("wait config resolved a binary it must not need: agy=%q", c.AgyPath)
+	}
+	// SupervisorExe IS resolved (unlike AgyPath): processAlive's fallback
+	// liveness check compares a job's recorded supervisor process name against
+	// it, so leaving it empty would make that comparison always fail and
+	// misreport a live job as dead.
+	if c.SupervisorExe == "" {
+		t.Fatal("SupervisorExe = \"\", want the wait config's own executable path")
+	}
+}

--- a/internal/hookinput/hookinput.go
+++ b/internal/hookinput/hookinput.go
@@ -21,50 +21,82 @@ type payload struct {
 	ToolResponse json.RawMessage `json:"tool_response"`
 }
 
-// Parse decodes a PostToolUse payload from r and extracts the agy job id from
-// its tool response. ok is false when no job id is present; that is not an
-// error, a failed or foreign tool call simply has no job to wait for.
-func Parse(r io.Reader) (jobID, toolName string, ok bool) {
+// Parse decodes a PostToolUse payload from r and extracts the agy job id and
+// state from its tool response. ok is false when no job id is present; that
+// is not an error, a failed or foreign tool call simply has no job to wait
+// for. state is the response's own job-state string when present (e.g.
+// "running", "done"), or empty; it lets a caller tell a result that was
+// still running when the tool returned (an overrun) apart from one that had
+// already settled.
+func Parse(r io.Reader) (jobID, toolName, state string, ok bool) {
 	var p payload
 	if err := json.NewDecoder(r).Decode(&p); err != nil {
-		return "", "", false
+		return "", "", "", false
 	}
 	var resp any
 	if err := json.Unmarshal(p.ToolResponse, &resp); err != nil {
-		return "", p.ToolName, false
+		return "", p.ToolName, "", false
 	}
-	id := findJobID(resp, 0)
-	return id, p.ToolName, id != ""
+	id := extractField(resp, "job_id", `"job_id"`)
+	st := extractField(resp, "state", `"state"`)
+	return id, p.ToolName, st, id != ""
 }
 
-// findJobID walks maps and slices for a "job_id" string field. String values
-// that look like they embed JSON with a job id (MCP text content) are parsed
-// and walked too, so the id is found regardless of which layer carries it.
-func findJobID(v any, depth int) string {
+// extractField finds a named string field in a tool response, checking the
+// well-known MCP result keys in a fixed priority order before falling back
+// to an unordered walk of the whole response. A response can carry both an
+// authoritative structuredContent object and a content list whose text is
+// free-form model output; that free-form text might itself contain
+// something that looks like the field being searched for (an adversarial
+// payload, or an unlucky coincidence), so structuredContent is checked, and
+// wins, before content is ever consulted. The final fallback walk covers
+// every other shape, including the field sitting directly on the response
+// (as it does today from the MCP SDK's own tool results).
+func extractField(resp any, key, marker string) string {
+	if m, isMap := resp.(map[string]any); isMap {
+		if sc, has := m["structuredContent"]; has {
+			if v := findField(sc, key, marker, 0); v != "" {
+				return v
+			}
+		}
+		if content, has := m["content"]; has {
+			if v := findField(content, key, marker, 0); v != "" {
+				return v
+			}
+		}
+	}
+	return findField(resp, key, marker, 0)
+}
+
+// findField walks maps and slices for a string field named key. String
+// values that look like they embed JSON with that field (detected via
+// marker, the field's quoted JSON name) are parsed and walked too, so the
+// field is found regardless of which layer carries it.
+func findField(v any, key, marker string, depth int) string {
 	if depth > maxDepth {
 		return ""
 	}
 	switch t := v.(type) {
 	case map[string]any:
-		if id, isStr := t["job_id"].(string); isStr && id != "" {
-			return id
+		if val, isStr := t[key].(string); isStr && val != "" {
+			return val
 		}
 		for _, child := range t {
-			if id := findJobID(child, depth+1); id != "" {
-				return id
+			if val := findField(child, key, marker, depth+1); val != "" {
+				return val
 			}
 		}
 	case []any:
 		for _, child := range t {
-			if id := findJobID(child, depth+1); id != "" {
-				return id
+			if val := findField(child, key, marker, depth+1); val != "" {
+				return val
 			}
 		}
 	case string:
-		if strings.Contains(t, `"job_id"`) {
+		if strings.Contains(t, marker) {
 			var embedded any
 			if err := json.Unmarshal([]byte(t), &embedded); err == nil {
-				return findJobID(embedded, depth+1)
+				return findField(embedded, key, marker, depth+1)
 			}
 		}
 	}

--- a/internal/hookinput/hookinput.go
+++ b/internal/hookinput/hookinput.go
@@ -1,0 +1,72 @@
+// Package hookinput extracts the agy job id from a Claude Code PostToolUse
+// hook payload, for the hook-wait subcommand. Parsing is deliberately loose:
+// the payload's tool_response shape depends on the MCP client version (plain
+// structured output, or a content list whose text embeds the output JSON), so
+// the job id is found by walking, not by a fixed schema.
+package hookinput
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// maxDepth bounds the recursive walk so a pathological payload cannot
+// exhaust the stack. Real payloads are a handful of levels deep.
+const maxDepth = 32
+
+// payload is the subset of the PostToolUse hook input hook-wait needs.
+type payload struct {
+	ToolName     string          `json:"tool_name"`
+	ToolResponse json.RawMessage `json:"tool_response"`
+}
+
+// Parse decodes a PostToolUse payload from r and extracts the agy job id from
+// its tool response. ok is false when no job id is present; that is not an
+// error, a failed or foreign tool call simply has no job to wait for.
+func Parse(r io.Reader) (jobID, toolName string, ok bool) {
+	var p payload
+	if err := json.NewDecoder(r).Decode(&p); err != nil {
+		return "", "", false
+	}
+	var resp any
+	if err := json.Unmarshal(p.ToolResponse, &resp); err != nil {
+		return "", p.ToolName, false
+	}
+	id := findJobID(resp, 0)
+	return id, p.ToolName, id != ""
+}
+
+// findJobID walks maps and slices for a "job_id" string field. String values
+// that look like they embed JSON with a job id (MCP text content) are parsed
+// and walked too, so the id is found regardless of which layer carries it.
+func findJobID(v any, depth int) string {
+	if depth > maxDepth {
+		return ""
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		if id, isStr := t["job_id"].(string); isStr && id != "" {
+			return id
+		}
+		for _, child := range t {
+			if id := findJobID(child, depth+1); id != "" {
+				return id
+			}
+		}
+	case []any:
+		for _, child := range t {
+			if id := findJobID(child, depth+1); id != "" {
+				return id
+			}
+		}
+	case string:
+		if strings.Contains(t, `"job_id"`) {
+			var embedded any
+			if err := json.Unmarshal([]byte(t), &embedded); err == nil {
+				return findJobID(embedded, depth+1)
+			}
+		}
+	}
+	return ""
+}

--- a/internal/hookinput/hookinput.go
+++ b/internal/hookinput/hookinput.go
@@ -15,6 +15,19 @@ import (
 // exhaust the stack. Real payloads are a handful of levels deep.
 const maxDepth = 32
 
+// maxNodes bounds the total nodes findField visits per field extraction, so a
+// payload that is shallow but very wide, or that nests re-parseable JSON strings,
+// cannot make the walk do unbounded work within the depth limit. Real payloads
+// visit a handful of nodes.
+const maxNodes = 1 << 20
+
+// maxPayloadBytes caps how much of stdin Parse decodes. It is generous against
+// legitimate agy outputs (tens of MiB of captured review text is plausible) yet
+// stops an unbounded read from a stuck or hostile producer. A truncated decode
+// fails and Parse returns ok=false, so the hook simply stays quiet; the cap must
+// keep real margin over real payloads for that quiet-on-failure to be safe.
+const maxPayloadBytes = 64 << 20
+
 // payload is the subset of the PostToolUse hook input hook-wait needs.
 type payload struct {
 	ToolName     string          `json:"tool_name"`
@@ -30,15 +43,17 @@ type payload struct {
 // already settled.
 func Parse(r io.Reader) (jobID, toolName, state string, ok bool) {
 	var p payload
-	if err := json.NewDecoder(r).Decode(&p); err != nil {
+	// Cap the decode so a stuck or hostile producer cannot make the hook read
+	// without bound; a truncated read fails here and the hook stays quiet.
+	if err := json.NewDecoder(io.LimitReader(r, maxPayloadBytes)).Decode(&p); err != nil {
 		return "", "", "", false
 	}
 	var resp any
 	if err := json.Unmarshal(p.ToolResponse, &resp); err != nil {
 		return "", p.ToolName, "", false
 	}
-	id := extractField(resp, "job_id", `"job_id"`)
-	st := extractField(resp, "state", `"state"`)
+	id := extractField(resp, "job_id")
+	st := extractField(resp, "state")
 	return id, p.ToolName, st, id != ""
 }
 
@@ -52,43 +67,56 @@ func Parse(r io.Reader) (jobID, toolName, state string, ok bool) {
 // wins, before content is ever consulted. The final fallback walk covers
 // every other shape, including the field sitting directly on the response
 // (as it does today from the MCP SDK's own tool results).
-func extractField(resp any, key, marker string) string {
+func extractField(resp any, key string) string {
+	// The marker is the field's quoted JSON name, derived from key so the two
+	// cannot drift; findField uses it to spot the field embedded in a JSON string.
+	marker := `"` + key + `"`
+	// One work budget per extraction, shared across the priority sources below, so
+	// breadth or re-parse repetition cannot make the walk do unbounded work.
+	budget := maxNodes
 	if m, isMap := resp.(map[string]any); isMap {
 		if sc, has := m["structuredContent"]; has {
-			if v := findField(sc, key, marker, 0); v != "" {
+			if v := findField(sc, key, marker, &budget, 0); v != "" {
 				return v
 			}
 		}
 		if content, has := m["content"]; has {
-			if v := findField(content, key, marker, 0); v != "" {
+			if v := findField(content, key, marker, &budget, 0); v != "" {
 				return v
 			}
 		}
 	}
-	return findField(resp, key, marker, 0)
+	return findField(resp, key, marker, &budget, 0)
 }
 
-// findField walks maps and slices for a string field named key. String
-// values that look like they embed JSON with that field (detected via
-// marker, the field's quoted JSON name) are parsed and walked too, so the
-// field is found regardless of which layer carries it.
-func findField(v any, key, marker string, depth int) string {
-	if depth > maxDepth {
+// findField walks maps and slices for a string field named key. String values
+// that look like they embed JSON with that field (detected via marker, the
+// field's quoted JSON name) are parsed and walked too, so the field is found
+// regardless of which layer carries it. budget is decremented once per node
+// visited and the walk bails when it reaches zero, so a wide or re-parse-heavy
+// payload cannot defeat the depth limit by doing unbounded work at shallow depth.
+func findField(v any, key, marker string, budget *int, depth int) string {
+	if depth > maxDepth || *budget <= 0 {
 		return ""
 	}
+	*budget--
 	switch t := v.(type) {
 	case map[string]any:
-		if val, isStr := t[key].(string); isStr && val != "" {
+		// A present key wins for this object even when its value is the empty
+		// string: present-but-empty reads as absent upstream (the safe direction),
+		// and this object's own field must not be overridden by one nested deeper,
+		// so stop here rather than scavenge this object's other keys.
+		if val, isStr := t[key].(string); isStr {
 			return val
 		}
 		for _, child := range t {
-			if val := findField(child, key, marker, depth+1); val != "" {
+			if val := findField(child, key, marker, budget, depth+1); val != "" {
 				return val
 			}
 		}
 	case []any:
 		for _, child := range t {
-			if val := findField(child, key, marker, depth+1); val != "" {
+			if val := findField(child, key, marker, budget, depth+1); val != "" {
 				return val
 			}
 		}
@@ -96,7 +124,7 @@ func findField(v any, key, marker string, depth int) string {
 		if strings.Contains(t, marker) {
 			var embedded any
 			if err := json.Unmarshal([]byte(t), &embedded); err == nil {
-				return findField(embedded, key, marker, depth+1)
+				return findField(embedded, key, marker, budget, depth+1)
 			}
 		}
 	}

--- a/internal/hookinput/hookinput_test.go
+++ b/internal/hookinput/hookinput_test.go
@@ -1,0 +1,57 @@
+package hookinput
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name, in         string
+		wantID, wantTool string
+		wantOK           bool
+	}{
+		{
+			name: "structured job_id",
+			in: `{"hook_event_name":"PostToolUse","tool_name":"mcp__agy__agy_run",
+			      "tool_input":{"prompt":"review"},
+			      "tool_response":{"job_id":"job-abc-123","state":"running"}}`,
+			wantID: "job-abc-123", wantTool: "mcp__agy__agy_run", wantOK: true,
+		},
+		{
+			name: "job_id nested in MCP content list",
+			in: `{"tool_name":"mcp__agy__agy_run",
+			      "tool_response":{"content":[{"type":"text","text":"{\"job_id\":\"job-xyz-9\",\"state\":\"running\"}"}]}}`,
+			wantID: "job-xyz-9", wantTool: "mcp__agy__agy_run", wantOK: true,
+		},
+		{
+			name:   "no job id",
+			in:     `{"tool_name":"mcp__agy__agy_run","tool_response":{"error":"conflict"}}`,
+			wantOK: false,
+		},
+		{
+			name:   "malformed json",
+			in:     `{"tool_name": `,
+			wantOK: false,
+		},
+		{
+			name:   "empty input",
+			in:     ``,
+			wantOK: false,
+		},
+		{
+			name: "run_sync tool name carried through",
+			in: `{"tool_name":"mcp__agy__agy_run_sync",
+			      "tool_response":{"job_id":"job-s-1","state":"done"}}`,
+			wantID: "job-s-1", wantTool: "mcp__agy__agy_run_sync", wantOK: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, tool, ok := Parse(strings.NewReader(tc.in))
+			if ok != tc.wantOK || id != tc.wantID || (ok && tool != tc.wantTool) {
+				t.Fatalf("Parse = (%q, %q, %v), want (%q, %q, %v)", id, tool, ok, tc.wantID, tc.wantTool, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/hookinput/hookinput_test.go
+++ b/internal/hookinput/hookinput_test.go
@@ -7,22 +7,22 @@ import (
 
 func TestParse(t *testing.T) {
 	cases := []struct {
-		name, in         string
-		wantID, wantTool string
-		wantOK           bool
+		name, in                 string
+		wantID, wantTool, wantSt string
+		wantOK                   bool
 	}{
 		{
 			name: "structured job_id",
 			in: `{"hook_event_name":"PostToolUse","tool_name":"mcp__agy__agy_run",
 			      "tool_input":{"prompt":"review"},
 			      "tool_response":{"job_id":"job-abc-123","state":"running"}}`,
-			wantID: "job-abc-123", wantTool: "mcp__agy__agy_run", wantOK: true,
+			wantID: "job-abc-123", wantTool: "mcp__agy__agy_run", wantSt: "running", wantOK: true,
 		},
 		{
 			name: "job_id nested in MCP content list",
 			in: `{"tool_name":"mcp__agy__agy_run",
 			      "tool_response":{"content":[{"type":"text","text":"{\"job_id\":\"job-xyz-9\",\"state\":\"running\"}"}]}}`,
-			wantID: "job-xyz-9", wantTool: "mcp__agy__agy_run", wantOK: true,
+			wantID: "job-xyz-9", wantTool: "mcp__agy__agy_run", wantSt: "running", wantOK: true,
 		},
 		{
 			name:   "no job id",
@@ -43,15 +43,48 @@ func TestParse(t *testing.T) {
 			name: "run_sync tool name carried through",
 			in: `{"tool_name":"mcp__agy__agy_run_sync",
 			      "tool_response":{"job_id":"job-s-1","state":"done"}}`,
-			wantID: "job-s-1", wantTool: "mcp__agy__agy_run_sync", wantOK: true,
+			wantID: "job-s-1", wantTool: "mcp__agy__agy_run_sync", wantSt: "done", wantOK: true,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			id, tool, ok := Parse(strings.NewReader(tc.in))
-			if ok != tc.wantOK || id != tc.wantID || (ok && tool != tc.wantTool) {
-				t.Fatalf("Parse = (%q, %q, %v), want (%q, %q, %v)", id, tool, ok, tc.wantID, tc.wantTool, tc.wantOK)
+			id, tool, st, ok := Parse(strings.NewReader(tc.in))
+			if ok != tc.wantOK || id != tc.wantID || (ok && (tool != tc.wantTool || st != tc.wantSt)) {
+				t.Fatalf("Parse = (%q, %q, %q, %v), want (%q, %q, %q, %v)", id, tool, st, ok, tc.wantID, tc.wantTool, tc.wantSt, tc.wantOK)
 			}
 		})
+	}
+}
+
+// TestParseStructuredContentWinsOverContentText guards against a real hazard: a
+// run_sync response can carry both an authoritative structuredContent object
+// (the real job_id and state) and a content list whose text is the model's
+// free-form result, which might itself contain the substring "job_id" (an
+// adversarial payload, or just an unlucky review that discusses this very
+// feature). The generic recursive walk visits a Go map's keys in randomized
+// order, so without a deterministic priority the wrong id could win on some
+// runs and not others. structuredContent must be checked, and must win,
+// before content is ever consulted. Looped to catch that kind of flakiness,
+// which a single run cannot rule out.
+func TestParseStructuredContentWinsOverContentText(t *testing.T) {
+	in := `{"tool_name":"mcp__agy__agy_run_sync",
+	        "tool_response":{
+	          "structuredContent":{"job_id":"job-real-1","state":"done"},
+	          "content":[{"type":"text","text":"Review complete. Adversarial payload: {\"job_id\":\"job-fake-evil\",\"state\":\"running\"}"}]
+	        }}`
+	for i := range 20 {
+		id, tool, st, ok := Parse(strings.NewReader(in))
+		if !ok {
+			t.Fatalf("run %d: Parse ok = false, want true", i)
+		}
+		if id != "job-real-1" {
+			t.Fatalf("run %d: Parse id = %q, want %q (structuredContent must win over content text)", i, id, "job-real-1")
+		}
+		if tool != "mcp__agy__agy_run_sync" {
+			t.Fatalf("run %d: Parse tool = %q, want %q", i, tool, "mcp__agy__agy_run_sync")
+		}
+		if st != "done" {
+			t.Fatalf("run %d: Parse state = %q, want %q", i, st, "done")
+		}
 	}
 }

--- a/internal/hookinput/hookinput_test.go
+++ b/internal/hookinput/hookinput_test.go
@@ -45,6 +45,21 @@ func TestParse(t *testing.T) {
 			      "tool_response":{"job_id":"job-s-1","state":"done"}}`,
 			wantID: "job-s-1", wantTool: "mcp__agy__agy_run_sync", wantSt: "done", wantOK: true,
 		},
+		{
+			// No tool_response at all: valid JSON, but the response cannot be walked,
+			// so there is no job to wait for.
+			name:   "missing tool_response",
+			in:     `{"tool_name":"mcp__agy__agy_run"}`,
+			wantOK: false,
+		},
+		{
+			// A present-but-empty state must read as empty (absent upstream) and must
+			// not scavenge the nested state; the id is still found and carried.
+			name: "present but empty state does not scavenge nested",
+			in: `{"tool_name":"mcp__agy__agy_run_sync",
+			      "tool_response":{"job_id":"job-e-2","state":"","extra":{"state":"done"}}}`,
+			wantID: "job-e-2", wantTool: "mcp__agy__agy_run_sync", wantSt: "", wantOK: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -54,6 +69,51 @@ func TestParse(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseDepthGuard proves a payload nested deeper than maxDepth is handled
+// cleanly: the walk bails at the depth limit and reports no id (ok=false) rather
+// than recursing without bound or panicking.
+func TestParseDepthGuard(t *testing.T) {
+	const depth = maxDepth + 5
+	var sb strings.Builder
+	sb.WriteString(`{"tool_name":"mcp__agy__agy_run","tool_response":`)
+	for range depth {
+		sb.WriteString(`{"a":`)
+	}
+	sb.WriteString(`{"job_id":"buried-too-deep"}`)
+	for range depth {
+		sb.WriteString(`}`)
+	}
+	sb.WriteString(`}`)
+
+	id, _, _, ok := Parse(strings.NewReader(sb.String()))
+	if ok || id != "" {
+		t.Fatalf("Parse = (id=%q, ok=%v), want empty id and ok=false for over-deep nesting", id, ok)
+	}
+}
+
+// FuzzParse asserts Parse never panics on arbitrary input; its return values are
+// unconstrained. Seeded with every table payload plus the adversarial and
+// depth-guard shapes so the corpus starts from the known-interesting cases.
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		`{"hook_event_name":"PostToolUse","tool_name":"mcp__agy__agy_run","tool_input":{"prompt":"review"},"tool_response":{"job_id":"job-abc-123","state":"running"}}`,
+		`{"tool_name":"mcp__agy__agy_run","tool_response":{"content":[{"type":"text","text":"{\"job_id\":\"job-xyz-9\",\"state\":\"running\"}"}]}}`,
+		`{"tool_name":"mcp__agy__agy_run","tool_response":{"error":"conflict"}}`,
+		`{"tool_name": `,
+		``,
+		`{"tool_name":"mcp__agy__agy_run_sync","tool_response":{"job_id":"job-s-1","state":"done"}}`,
+		`{"tool_name":"mcp__agy__agy_run"}`,
+		`{"tool_name":"mcp__agy__agy_run_sync","tool_response":{"job_id":"job-e-2","state":"","extra":{"state":"done"}}}`,
+		`{"tool_name":"mcp__agy__agy_run_sync","tool_response":{"structuredContent":{"job_id":"job-real-1","state":"done"},"content":[{"type":"text","text":"x {\"job_id\":\"job-fake\"}"}]}}`,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(_ *testing.T, in string) {
+		_, _, _, _ = Parse(strings.NewReader(in))
+	})
 }
 
 // TestParseStructuredContentWinsOverContentText guards against a real hazard: a

--- a/internal/manager/capture_budget_test.go
+++ b/internal/manager/capture_budget_test.go
@@ -1,0 +1,17 @@
+package manager
+
+import "testing"
+
+// captureGraceWindow (wait.go) must stay strictly larger than defaultCaptureBudget
+// (the eager in-process capture window). A cross-process waiter has no
+// CapturePending signal and relies on the completion-recency window to outlast the
+// owning server's capture retry; were the grace window to shrink to or below the
+// budget, that waiter could stop polling before the late cache flush lands and
+// silently return a done job with an empty conversation id. Untagged so the
+// relationship is checked on every platform.
+func TestCaptureGraceWindowExceedsBudget(t *testing.T) {
+	if captureGraceWindow <= defaultCaptureBudget {
+		t.Fatalf("captureGraceWindow (%s) must exceed defaultCaptureBudget (%s); a cross-process waiter would stop polling before the late capture lands",
+			captureGraceWindow, defaultCaptureBudget)
+	}
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -40,11 +40,12 @@ type Manager struct {
 	// stop re-reading the cache on every Status poll.
 	//
 	// concludedCapture memoizes job ids whose in-process eager capture attempt
-	// has finished (the completion goroutine ran its capture and cleared
-	// pendingCaptures). It ends WaitTerminal's capture grace for an in-process
-	// waiter but, unlike settledCapture, does NOT stop the lazy capture: a slow
-	// cache flush must still be picked up by a later Status read. Both maps share
-	// settledMu.
+	// has finished. concludeCapture sets this BEFORE it clears pendingCaptures, so
+	// !CapturePending implies concluded, never the reverse (concluded can be true
+	// for a moment while pendingCaptures is still set). WaitTerminal's capture-grace
+	// exit for an in-process waiter relies on that direction. Unlike settledCapture
+	// it does NOT stop the lazy capture: a slow cache flush must still be picked up
+	// by a later Status read. Both maps share settledMu.
 	settledMu        sync.Mutex
 	settledCapture   map[string]struct{}
 	concludedCapture map[string]struct{}
@@ -82,6 +83,12 @@ type Manager struct {
 	readStartTimeTicks func(int) (uint64, bool)
 }
 
+// defaultCaptureBudget bounds how long captureFreshConversationID waits for
+// agy's cache daemon to flush the new conversation id after a clean exit; it is
+// the eager (in-process) capture window. captureGraceWindow in wait.go must stay
+// strictly larger so a cross-process waiter still outlasts this budget.
+const defaultCaptureBudget = 2 * time.Second
+
 // New constructs a Manager.
 func New(c config.Config) *Manager {
 	// Prefer an explicitly configured cache path; only fall back to the default
@@ -99,7 +106,7 @@ func New(c config.Config) *Manager {
 		gate:                 newGate(c.MaxConcurrency),
 		xlock:                newCrossLock(c.StateDir),
 		cacheFile:            cacheFile,
-		captureBudget:        2 * time.Second,
+		captureBudget:        defaultCaptureBudget,
 		capturePoll:          100 * time.Millisecond,
 		restoredPollInterval: 2 * time.Second,
 		settledCapture:       make(map[string]struct{}),
@@ -224,10 +231,12 @@ func (m *Manager) settleCapture(id string) {
 }
 
 // captureConcluded reports whether this process's eager capture attempt for a
-// job has finished (the completion goroutine ran and cleared pendingCaptures).
-// WaitTerminal reads it to end an in-process waiter's grace once no more id can
-// come from the eager path. Unlike captureSettled it does not disable the lazy
-// capture, which keeps retrying on later Status reads.
+// job has finished. concludeCapture marks this before it clears pendingCaptures,
+// so !CapturePending implies concluded, not the reverse (concluded can be true
+// while pendingCaptures is momentarily still set). WaitTerminal reads it to end
+// an in-process waiter's grace once no more id can come from the eager path.
+// Unlike captureSettled it does not disable the lazy capture, which keeps
+// retrying on later Status reads.
 func (m *Manager) captureConcluded(id string) bool {
 	m.settledMu.Lock()
 	defer m.settledMu.Unlock()
@@ -486,22 +495,11 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	go func() {
 		_ = cmd.Wait()
 		_ = grp.Close()
-		// For a successful fresh run, capture the conversation id agy created
-		// while the gate key is still held, then release. Gating on exit 0 avoids
-		// waiting out the capture budget for a run that created no conversation.
-		if code, ok := m.store.ExitCode(id); ok && code == 0 {
-			m.captureFreshConversationID(&meta)
-		}
-		// Record that this process's eager capture attempt finished before releasing
-		// the key. markCaptureConcluded ends WaitTerminal's grace for an in-process
-		// waiter (no more id is coming from the eager path); it deliberately does NOT
-		// settle the lazy capture, which must keep retrying on later Status reads until
-		// its own horizon so a slow cache flush still delivers the id. Clearing
-		// pendingCaptures makes CapturePending false; conclude first so
-		// CapturePending=false always implies the eager attempt is concluded.
-		m.markCaptureConcluded(id)
-		m.pendingCaptures.Delete(id)
-		m.releaseKey(key)
+		// Capture the conversation id agy created while the gate key is still held,
+		// then conclude and release. concludeCapture gates the capture on a clean
+		// exit and finishes the bookkeeping in the order WaitTerminal's grace exit
+		// depends on (id == meta.ID for this fresh run).
+		m.concludeCapture(&meta, key)
 	}()
 
 	return Job{ID: id, ConversationID: req.ConversationID, State: StateRunning}, nil
@@ -523,6 +521,22 @@ func (m *Manager) abortSpawn(cmd *exec.Cmd, grp *proc.Group, id, key string) {
 		m.pendingCaptures.Delete(id)
 		m.releaseKey(key)
 	}()
+}
+
+// concludeCapture finishes a completed job's capture bookkeeping: attempt the
+// eager conversation-id capture for a clean exit, mark this process's capture
+// attempt concluded, clear the pending marker, and release the job's gate key,
+// in that exact order. Conclude-before-delete is load bearing: it is what makes
+// !CapturePending imply captureConcluded for in-process waiters (WaitTerminal's
+// grace exit depends on it). Shared by both completion goroutines so a third
+// completion path cannot silently reorder it.
+func (m *Manager) concludeCapture(meta *jobstore.Meta, key string) {
+	if code, ok := m.store.ExitCode(meta.ID); ok && code == 0 {
+		m.captureFreshConversationID(meta)
+	}
+	m.markCaptureConcluded(meta.ID)
+	m.pendingCaptures.Delete(meta.ID)
+	m.releaseKey(key)
 }
 
 // loadedJob is one job's meta from a single meta.json read, the shared input the
@@ -846,17 +860,11 @@ func (m *Manager) watchRestored(meta jobstore.Meta, key string) {
 			}
 		}
 		// Mirror the StartJob completion path: a restored fresh run that exited 0
-		// still needs its conversation id captured, and like there the capture
-		// must happen while the gate key is held, so a new same-cwd run cannot
-		// overwrite the cache entry first.
-		if code, ok := m.store.ExitCode(meta.ID); ok && code == 0 {
-			m.captureFreshConversationID(&meta)
-		}
-		// Conclude this process's eager capture attempt (see the StartJob completion
-		// path); this does not settle the lazy capture.
-		m.markCaptureConcluded(meta.ID)
-		m.pendingCaptures.Delete(meta.ID)
-		m.releaseKey(key)
+		// still needs its conversation id captured, and like there the capture must
+		// happen while the gate key is held, so a new same-cwd run cannot overwrite
+		// the cache entry first. concludeCapture does the capture, conclusion, and
+		// release as one unit shared with StartJob.
+		m.concludeCapture(&meta, key)
 	}()
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -38,8 +38,16 @@ type Manager struct {
 	// (no id is coming): either the run is long past its timeout with no cache
 	// change, or a later same-cwd run made attribution unsafe. Settled jobs
 	// stop re-reading the cache on every Status poll.
-	settledMu      sync.Mutex
-	settledCapture map[string]struct{}
+	//
+	// concludedCapture memoizes job ids whose in-process eager capture attempt
+	// has finished (the completion goroutine ran its capture and cleared
+	// pendingCaptures). It ends WaitTerminal's capture grace for an in-process
+	// waiter but, unlike settledCapture, does NOT stop the lazy capture: a slow
+	// cache flush must still be picked up by a later Status read. Both maps share
+	// settledMu.
+	settledMu        sync.Mutex
+	settledCapture   map[string]struct{}
+	concludedCapture map[string]struct{}
 
 	// Timing for the fresh-run conversation-id capture and the restored-job
 	// liveness watcher. Fields (not package globals) so tests stay isolated and can
@@ -95,6 +103,7 @@ func New(c config.Config) *Manager {
 		capturePoll:          100 * time.Millisecond,
 		restoredPollInterval: 2 * time.Second,
 		settledCapture:       make(map[string]struct{}),
+		concludedCapture:     make(map[string]struct{}),
 		readStartTimeTicks:   readStartTimeTicks,
 	}
 }
@@ -214,6 +223,24 @@ func (m *Manager) settleCapture(id string) {
 	m.settledCapture[id] = struct{}{}
 }
 
+// captureConcluded reports whether this process's eager capture attempt for a
+// job has finished (the completion goroutine ran and cleared pendingCaptures).
+// WaitTerminal reads it to end an in-process waiter's grace once no more id can
+// come from the eager path. Unlike captureSettled it does not disable the lazy
+// capture, which keeps retrying on later Status reads.
+func (m *Manager) captureConcluded(id string) bool {
+	m.settledMu.Lock()
+	defer m.settledMu.Unlock()
+	_, ok := m.concludedCapture[id]
+	return ok
+}
+
+func (m *Manager) markCaptureConcluded(id string) {
+	m.settledMu.Lock()
+	defer m.settledMu.Unlock()
+	m.concludedCapture[id] = struct{}{}
+}
+
 // untrackCapture forgets a job's capture-tracking state once the job is gone
 // (garbage-collected from the store), so neither map grows without bound in a
 // long-running server. pendingCaptures is normally already cleared by the time
@@ -222,6 +249,7 @@ func (m *Manager) untrackCapture(id string) {
 	m.pendingCaptures.Delete(id)
 	m.settledMu.Lock()
 	delete(m.settledCapture, id)
+	delete(m.concludedCapture, id)
 	m.settledMu.Unlock()
 }
 
@@ -464,8 +492,14 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		if code, ok := m.store.ExitCode(id); ok && code == 0 {
 			m.captureFreshConversationID(&meta)
 		}
-		// Settle the capture (success or give-up) before releasing the key, so
-		// CapturePending=false means the reported status is final.
+		// Record that this process's eager capture attempt finished before releasing
+		// the key. markCaptureConcluded ends WaitTerminal's grace for an in-process
+		// waiter (no more id is coming from the eager path); it deliberately does NOT
+		// settle the lazy capture, which must keep retrying on later Status reads until
+		// its own horizon so a slow cache flush still delivers the id. Clearing
+		// pendingCaptures makes CapturePending false; conclude first so
+		// CapturePending=false always implies the eager attempt is concluded.
+		m.markCaptureConcluded(id)
 		m.pendingCaptures.Delete(id)
 		m.releaseKey(key)
 	}()
@@ -475,8 +509,8 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 
 // abortSpawn tears down a supervisor that was started but cannot be recorded as
 // a running job. It terminates the process group, then in the background reaps
-// it and — only once it has fully exited, so nothing is still writing the job
-// dir — removes the dir and releases the gate. Releasing only after the agy
+// it and, only once it has fully exited (so nothing is still writing the job
+// dir), removes the dir and releases the gate. Releasing only after the agy
 // process group is gone keeps a conflicting same-key run from starting while the
 // dying agy still holds its session lock. Both spawn-failure paths (start time
 // unreadable on darwin, and UpdateMeta failure) share it so they cannot diverge.
@@ -818,6 +852,9 @@ func (m *Manager) watchRestored(meta jobstore.Meta, key string) {
 		if code, ok := m.store.ExitCode(meta.ID); ok && code == 0 {
 			m.captureFreshConversationID(&meta)
 		}
+		// Conclude this process's eager capture attempt (see the StartJob completion
+		// path); this does not settle the lazy capture.
+		m.markCaptureConcluded(meta.ID)
 		m.pendingCaptures.Delete(meta.ID)
 		m.releaseKey(key)
 	}()

--- a/internal/manager/wait.go
+++ b/internal/manager/wait.go
@@ -1,0 +1,62 @@
+package manager
+
+import (
+	"context"
+	"time"
+)
+
+// waitPollInterval is how often WaitTerminal re-reads job status and invokes
+// onTick. Status reads a few small files, so this is cheap. agy_run_sync's
+// wait loop used the same 250ms cadence before it moved here.
+const waitPollInterval = 250 * time.Millisecond
+
+// WaitTerminal polls the job until it reaches a terminal state, the deadline
+// passes, or ctx is cancelled. It returns the latest observed Status and
+// whether the job was terminal when the wait ended. The deadline is observed
+// on poll ticks only, so a wait can overshoot it by up to one poll interval.
+//
+// onTick, if non-nil, is invoked once per poll from the calling goroutine
+// while the job is still running; it must not block longer than the poll
+// interval (it is for progress reporting, not work).
+//
+// One refinement carried over from the original agy_run_sync loop: when the
+// job is done but its conversation id is still being captured in this process
+// (CapturePending), WaitTerminal keeps polling until the capture settles or
+// the deadline passes, so a caller that will never poll again does not lose
+// the id to agy's cache-flush lag. If ctx is cancelled during that grace the
+// job is already terminal, so the status is returned with a nil error.
+// Cross-process callers always observe CapturePending == false; for them
+// Status lazy-captures on read instead and no grace applies.
+func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Time, onTick func(Status)) (Status, bool, error) {
+	ticker := time.NewTicker(waitPollInterval)
+	defer ticker.Stop()
+	for {
+		st, err := m.Status(id)
+		if err != nil {
+			return Status{}, false, err
+		}
+		if st.State != StateRunning {
+			if st.State == StateDone && st.ConversationID == "" &&
+				time.Now().Before(deadline) && m.CapturePending(id) {
+				select {
+				case <-ctx.Done():
+					return st, true, nil
+				case <-ticker.C:
+				}
+				continue
+			}
+			return st, true, nil
+		}
+		if time.Now().After(deadline) {
+			return st, false, nil
+		}
+		if onTick != nil {
+			onTick(st)
+		}
+		select {
+		case <-ctx.Done():
+			return st, false, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/manager/wait.go
+++ b/internal/manager/wait.go
@@ -36,14 +36,23 @@ func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Tim
 			return Status{}, false, err
 		}
 		if st.State != StateRunning {
-			if st.State == StateDone && st.ConversationID == "" &&
-				time.Now().Before(deadline) && m.CapturePending(id) {
-				select {
-				case <-ctx.Done():
-					return st, true, nil
-				case <-ticker.C:
+			if st.State == StateDone && st.ConversationID == "" && time.Now().Before(deadline) {
+				if m.CapturePending(id) {
+					select {
+					case <-ctx.Done():
+						return st, true, nil
+					case <-ticker.C:
+					}
+					continue
 				}
-				continue
+				// CapturePending went false between the Status read above and this
+				// check: the completion goroutine persists the captured id and only
+				// then clears pendingCaptures, so the st we hold can predate a
+				// just-settled id. Re-read once so that id is delivered instead of a
+				// stale empty one; keep the original st if the re-read fails.
+				if fresh, ferr := m.Status(id); ferr == nil {
+					return fresh, true, nil
+				}
 			}
 			return st, true, nil
 		}

--- a/internal/manager/wait.go
+++ b/internal/manager/wait.go
@@ -13,7 +13,7 @@ const waitPollInterval = 250 * time.Millisecond
 // captureGraceWindow bounds how long after a job completes WaitTerminal keeps
 // polling a done, id-less job for a waiter that does not own the in-process
 // capture state (a cross-process hook-wait or wait-job, whose pending/settled
-// maps are empty). It must comfortably exceed the manager's captureBudget (2s)
+// maps are empty). It must comfortably exceed the manager's defaultCaptureBudget
 // so such a waiter outlasts the owning server's capture retry, and it bounds the
 // extra polling a genuinely id-less fresh run can cost that waiter.
 const captureGraceWindow = 5 * time.Second
@@ -54,12 +54,15 @@ func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Tim
 					}
 					continue
 				}
-				// The grace no longer applies. CapturePending may have flipped false
-				// between the Status read above and this check: the completion
-				// goroutine persists the captured id and only then clears
-				// pendingCaptures, so the st we hold can predate a just-settled id.
-				// Re-read once so that id is delivered instead of a stale empty one;
-				// keep the original st if the re-read fails.
+				// The grace no longer applies. The primary reason to re-read here is
+				// the pending-to-concluded window: the completion goroutine persists
+				// the captured id and only then clears pendingCaptures, so once
+				// CapturePending flips false the st we hold can predate a just-settled
+				// id. Re-read once so that id is delivered instead of a stale empty
+				// one. The re-read also harmlessly covers the other grace-exit paths
+				// (a capture-disabled job, or a cross-process waiter's recency window
+				// ending): the extra Status read simply returns the same empty id or a
+				// freshly lazy-captured one. Keep the original st if the re-read fails.
 				if fresh, ferr := m.Status(id); ferr == nil {
 					return fresh, true, nil
 				}

--- a/internal/manager/wait.go
+++ b/internal/manager/wait.go
@@ -10,6 +10,14 @@ import (
 // wait loop used the same 250ms cadence before it moved here.
 const waitPollInterval = 250 * time.Millisecond
 
+// captureGraceWindow bounds how long after a job completes WaitTerminal keeps
+// polling a done, id-less job for a waiter that does not own the in-process
+// capture state (a cross-process hook-wait or wait-job, whose pending/settled
+// maps are empty). It must comfortably exceed the manager's captureBudget (2s)
+// so such a waiter outlasts the owning server's capture retry, and it bounds the
+// extra polling a genuinely id-less fresh run can cost that waiter.
+const captureGraceWindow = 5 * time.Second
+
 // WaitTerminal polls the job until it reaches a terminal state, the deadline
 // passes, or ctx is cancelled. It returns the latest observed Status and
 // whether the job was terminal when the wait ended. The deadline is observed
@@ -19,14 +27,15 @@ const waitPollInterval = 250 * time.Millisecond
 // while the job is still running; it must not block longer than the poll
 // interval (it is for progress reporting, not work).
 //
-// One refinement carried over from the original agy_run_sync loop: when the
-// job is done but its conversation id is still being captured in this process
-// (CapturePending), WaitTerminal keeps polling until the capture settles or
-// the deadline passes, so a caller that will never poll again does not lose
-// the id to agy's cache-flush lag. If ctx is cancelled during that grace the
-// job is already terminal, so the status is returned with a nil error.
-// Cross-process callers always observe CapturePending == false; for them
-// Status lazy-captures on read instead and no grace applies.
+// One refinement carried over from the original agy_run_sync loop: when the job
+// is done but its conversation id is still being captured (see inCaptureGrace),
+// WaitTerminal keeps polling until the capture concludes or the deadline passes,
+// so a caller that will never poll again does not lose the id to agy's
+// cache-flush lag. If ctx is cancelled during that grace the job is already
+// terminal, so the status is returned with a nil error. The grace also covers a
+// cross-process waiter (which never observes CapturePending) via a
+// completion-recency window; for such a waiter Status's lazy capture, which
+// reads agy's cache directly, is what actually delivers the id.
 func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Time, onTick func(Status)) (Status, bool, error) {
 	ticker := time.NewTicker(waitPollInterval)
 	defer ticker.Stop()
@@ -37,7 +46,7 @@ func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Tim
 		}
 		if st.State != StateRunning {
 			if st.State == StateDone && st.ConversationID == "" && time.Now().Before(deadline) {
-				if m.CapturePending(id) {
+				if m.inCaptureGrace(id) {
 					select {
 					case <-ctx.Done():
 						return st, true, nil
@@ -45,11 +54,12 @@ func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Tim
 					}
 					continue
 				}
-				// CapturePending went false between the Status read above and this
-				// check: the completion goroutine persists the captured id and only
-				// then clears pendingCaptures, so the st we hold can predate a
-				// just-settled id. Re-read once so that id is delivered instead of a
-				// stale empty one; keep the original st if the re-read fails.
+				// The grace no longer applies. CapturePending may have flipped false
+				// between the Status read above and this check: the completion
+				// goroutine persists the captured id and only then clears
+				// pendingCaptures, so the st we hold can predate a just-settled id.
+				// Re-read once so that id is delivered instead of a stale empty one;
+				// keep the original st if the re-read fails.
 				if fresh, ferr := m.Status(id); ferr == nil {
 					return fresh, true, nil
 				}
@@ -68,4 +78,24 @@ func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Tim
 		case <-ticker.C:
 		}
 	}
+}
+
+// inCaptureGrace reports whether a done, id-less job should keep being polled so
+// a late-flushed conversation id is not missed. For the process that owns the
+// capture, CapturePending is the precise signal while the eager attempt runs, and
+// captureConcluded marks it finished, so an in-process waiter stops as soon as the
+// eager attempt concludes. A cross-process waiter has neither (its maps are
+// empty), so it falls back to a completion-recency window: while the job finished
+// within captureGraceWindow and no local eager attempt concluded it, keep waiting
+// for Status's lazy capture (which keeps retrying past the eager attempt) to
+// deliver the id.
+func (m *Manager) inCaptureGrace(id string) bool {
+	if m.CapturePending(id) {
+		return true
+	}
+	if m.captureConcluded(id) {
+		return false
+	}
+	end, ok := m.store.CompletedAt(id)
+	return ok && time.Since(end) < captureGraceWindow
 }

--- a/internal/manager/wait.go
+++ b/internal/manager/wait.go
@@ -96,6 +96,14 @@ func (m *Manager) inCaptureGrace(id string) bool {
 	if m.captureConcluded(id) {
 		return false
 	}
+	// A capture disabled at start (a torn pre-run snapshot) can never produce an
+	// id, so no grace is owed: a cross-process waiter would only be stalled for the
+	// whole recency window for an id that is not coming. The meta read is an
+	// optimization, not a correctness gate, so a read error falls through to the
+	// recency window rather than erroring.
+	if meta, err := m.store.Load(id); err == nil && meta.CaptureDisabled {
+		return false
+	}
 	end, ok := m.store.CompletedAt(id)
 	return ok && time.Since(end) < captureGraceWindow
 }

--- a/internal/manager/wait.go
+++ b/internal/manager/wait.go
@@ -5,10 +5,11 @@ import (
 	"time"
 )
 
-// waitPollInterval is how often WaitTerminal re-reads job status and invokes
-// onTick. Status reads a few small files, so this is cheap. agy_run_sync's
-// wait loop used the same 250ms cadence before it moved here.
-const waitPollInterval = 250 * time.Millisecond
+// WaitPollInterval is how often WaitTerminal re-reads job status and invokes
+// onTick. Status reads a few small files, so this is cheap. It is exported so
+// callers that bound per-tick work (mcptools' progress-notification send) share
+// the one cadence rather than hard-coding a matching literal.
+const WaitPollInterval = 250 * time.Millisecond
 
 // captureGraceWindow bounds how long after a job completes WaitTerminal keeps
 // polling a done, id-less job for a waiter that does not own the in-process
@@ -37,7 +38,7 @@ const captureGraceWindow = 5 * time.Second
 // completion-recency window; for such a waiter Status's lazy capture, which
 // reads agy's cache directly, is what actually delivers the id.
 func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Time, onTick func(Status)) (Status, bool, error) {
-	ticker := time.NewTicker(waitPollInterval)
+	ticker := time.NewTicker(WaitPollInterval)
 	defer ticker.Stop()
 	for {
 		st, err := m.Status(id)

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tphakala/agy-mcp/internal/jobstore"
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
@@ -324,5 +325,63 @@ func TestWaitTerminalCrossProcessGraceDeliversLateID(t *testing.T) {
 	}
 	if st.ConversationID != uuid {
 		t.Fatalf("conversation_id = %q, want %q (cross-process grace must hold until the late capture lands)", st.ConversationID, uuid)
+	}
+}
+
+// A fresh run whose capture was disabled at start (a torn pre-run snapshot) can
+// never produce a conversation id, so the recency grace must be skipped: a
+// cross-process waiter must return at once rather than stall for the full
+// captureGraceWindow waiting for an id that is not coming.
+func TestWaitTerminalNoGraceForDisabledCapture(t *testing.T) {
+	stateDir := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A completed fresh run left on disk with capture disabled and a clean exit.
+	m := newManager(t, managerOpts{
+		agyPath: "/usr/bin/agy", supervisorExe: "/bin/true", stateDir: stateDir,
+		defaultTimeout: time.Minute, maxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+	meta := jobstore.Meta{
+		ID:              "job-disabled",
+		Cwd:             t.TempDir(),
+		CaptureDisabled: true,
+		StartedAt:       time.Now().Add(-time.Second),
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("OK"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(meta.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// A distinct process's view: fresh maps, so CapturePending and captureConcluded
+	// are both false. Only the CaptureDisabled short-circuit keeps this from polling
+	// the full captureGraceWindow.
+	mB := newManager(t, managerOpts{
+		agyPath: "/usr/bin/agy", supervisorExe: "/bin/true", stateDir: stateDir,
+		defaultTimeout: time.Minute, maxConcurrency: 4,
+	})
+	mB.cacheFile = cachePath
+
+	start := time.Now()
+	st, terminal, err := mB.WaitTerminal(t.Context(), meta.ID, time.Now().Add(15*time.Second), nil)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if !terminal || st.State != StateDone {
+		t.Fatalf("state = %q terminal = %v, want done/true", st.State, terminal)
+	}
+	// Well under captureGraceWindow (5s): a disabled capture owes no grace.
+	if elapsed > 2*time.Second {
+		t.Fatalf("WaitTerminal took %s for a capture-disabled job; grace must be skipped", elapsed)
 	}
 }

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -73,7 +73,7 @@ func TestWaitTerminalReturnsDoneJob(t *testing.T) {
 		return st.State == StateDone && !m.CapturePending(job.ID)
 	}, "job never settled done")
 
-	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(5*time.Second), nil)
+	st, terminal, err := m.WaitTerminal(t.Context(), job.ID, time.Now().Add(5*time.Second), nil)
 	if err != nil {
 		t.Fatalf("WaitTerminal: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestWaitTerminalBlocksUntilDone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(15*time.Second), nil)
+	st, terminal, err := m.WaitTerminal(t.Context(), job.ID, time.Now().Add(15*time.Second), nil)
 	if err != nil {
 		t.Fatalf("WaitTerminal: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestWaitTerminalDeadlineOverrun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(100*time.Millisecond), nil)
+	st, terminal, err := m.WaitTerminal(t.Context(), job.ID, time.Now().Add(100*time.Millisecond), nil)
 	if err != nil {
 		t.Fatalf("WaitTerminal: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestWaitTerminalContextCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	// Cancel only once WaitTerminal is observably polling, so the cancellation
 	// races the running-state select rather than the first status read.
@@ -156,7 +156,7 @@ func TestWaitTerminalContextCancel(t *testing.T) {
 // An unknown job id must surface the store load failure, not a terminal result.
 func TestWaitTerminalUnknownJob(t *testing.T) {
 	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
-	_, terminal, err := m.WaitTerminal(context.Background(), "nonexistent-id", time.Now().Add(5*time.Second), nil)
+	_, terminal, err := m.WaitTerminal(t.Context(), "nonexistent-id", time.Now().Add(5*time.Second), nil)
 	if err == nil {
 		t.Fatal("err = nil, want a store load failure for an unknown job")
 	}
@@ -183,7 +183,7 @@ func TestWaitTerminalOnTick(t *testing.T) {
 			sawNonRunning = true
 		}
 	}
-	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(15*time.Second), onTick)
+	st, terminal, err := m.WaitTerminal(t.Context(), job.ID, time.Now().Add(15*time.Second), onTick)
 	if err != nil {
 		t.Fatalf("WaitTerminal: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestWaitTerminalGraceDeliversLateCapturedID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(15*time.Second), nil)
+	st, terminal, err := m.WaitTerminal(t.Context(), job.ID, time.Now().Add(15*time.Second), nil)
 	if err != nil {
 		t.Fatalf("WaitTerminal: %v", err)
 	}

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -328,6 +328,45 @@ func TestWaitTerminalCrossProcessGraceDeliversLateID(t *testing.T) {
 	}
 }
 
+// concludeCapture marks the eager capture concluded BEFORE it clears
+// pendingCaptures, so !CapturePending must always imply captureConcluded. A
+// waiter that observed pending=false && concluded=false would wrongly treat a
+// still-in-flight capture as "no grace owed" and could return a done job with an
+// empty id. Poll tightly across the completion window and assert the ordering
+// never inverts.
+func TestConcludeBeforePendingCleared(t *testing.T) {
+	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	// Precondition: this fresh run arms the capture, so pending starts true and the
+	// invariant below is meaningful (a never-armed job would be pending=false from
+	// the start with nothing concluded, a different, legitimate state).
+	if !m.CapturePending(job.ID) {
+		t.Fatal("expected a fresh run's capture to be armed (CapturePending true)")
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		// Read pending first: conclude happens before the pending clear, so if
+		// pending is observed false the conclusion must already be visible.
+		pending := m.CapturePending(job.ID)
+		if !pending && !m.captureConcluded(job.ID) {
+			t.Fatal("observed !CapturePending with !captureConcluded; conclude must precede the pending clear")
+		}
+		st, err := m.Status(job.ID)
+		if err != nil {
+			t.Fatalf("Status: %v", err)
+		}
+		if st.State == StateDone && !pending {
+			break // job settled and the eager capture attempt has concluded
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("job never settled done with a concluded capture")
+		}
+	}
+}
+
 // A fresh run whose capture was disabled at start (a torn pre-run snapshot) can
 // never produce a conversation id, so the recency grace must be skipped: a
 // cross-process waiter must return at once rather than stall for the full

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -252,3 +252,77 @@ func TestWaitTerminalGraceDeliversLateCapturedID(t *testing.T) {
 		t.Fatalf("conversation_id = %q, want %q (grace must hold until the late capture lands)", st.ConversationID, uuid)
 	}
 }
+
+// A waiter in a DIFFERENT process than the server that owns the job (hook-wait,
+// wait-job) never sees CapturePending, so without the completion-recency grace it
+// would return done with an empty id the instant the exit sentinel appears, while
+// the owning server is still inside its capture retry. The cross-process grace
+// must hold such a waiter until the late cache flush lands, at which point its own
+// Status lazy-captures the id.
+func TestWaitTerminalCrossProcessGraceDeliversLateID(t *testing.T) {
+	// See TestFreshRunCapturesConversationID: the cache key must match the
+	// symlink-resolved path StartJob persists as meta.Cwd.
+	cwd, err := normalizeCwd(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateDir := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const uuid = "24242424-3535-4646-5757-686868686868"
+
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	// The cache lands ~700ms after the exit sentinel. B must begin waiting inside
+	// that gap, with the job done but no id yet, to prove its grace holds until the
+	// late capture arrives rather than returning done with an empty id.
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:    agy,
+		CachePath:  cachePath,
+		CacheJSON:  fmt.Sprintf(`{%q:%q}`, cwd, uuid),
+		CacheDelay: 700 * time.Millisecond,
+	})
+
+	// Manager A owns and runs the job (the MCP server process).
+	mA := newManager(t, managerOpts{
+		agyPath: agy, supervisorExe: sup, stateDir: stateDir,
+		defaultTimeout: time.Minute, maxConcurrency: 4,
+	})
+	mA.cacheFile = cachePath
+
+	job, err := mA.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+
+	// Wait only for the exit sentinel, NOT for A's capture: B must start waiting
+	// while the job is done but the cache has not yet landed.
+	testutil.WaitFor(t, 3*time.Second, func() bool {
+		_, ok := mA.store.ExitCode(job.ID)
+		return ok
+	}, "job never wrote its exit sentinel")
+
+	// Manager B is a distinct process's view: same state dir and cache file, fresh
+	// in-memory maps, so CapturePending and captureSettled are always false for this
+	// job. Its grace rests entirely on the completion-recency window.
+	mB := newManager(t, managerOpts{
+		agyPath: agy, supervisorExe: sup, stateDir: stateDir,
+		defaultTimeout: time.Minute, maxConcurrency: 4,
+	})
+	mB.cacheFile = cachePath
+	if mB.CapturePending(job.ID) {
+		t.Fatal("cross-process manager must not see the job as capture-pending")
+	}
+
+	st, terminal, err := mB.WaitTerminal(t.Context(), job.ID, time.Now().Add(15*time.Second), nil)
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if !terminal || st.State != StateDone {
+		t.Fatalf("state = %q terminal = %v, want done/true", st.State, terminal)
+	}
+	if st.ConversationID != uuid {
+		t.Fatalf("conversation_id = %q, want %q (cross-process grace must hold until the late capture lands)", st.ConversationID, uuid)
+	}
+}

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -328,6 +328,64 @@ func TestWaitTerminalCrossProcessGraceDeliversLateID(t *testing.T) {
 	}
 }
 
+// TestWaitTerminalGraceCancelReturnsTerminal covers the grace-window cancel
+// branch: when a done, id-less job is still inside the capture grace and ctx is
+// cancelled, WaitTerminal returns the terminal status with a nil error, because
+// the job is already done, so the cancellation is not a wait failure.
+func TestWaitTerminalGraceCancelReturnsTerminal(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	// The supervisor writes no conversation cache, so this fresh run stays id-less
+	// and its capture stays pending for the whole default budget after the exit
+	// sentinel: exactly the done + id-less + in-grace window the cancel branch
+	// handles. The default captureBudget (2s, via New) keeps that window wide
+	// enough to enter reliably.
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy})
+	m := newManager(t, managerOpts{
+		agyPath:        agy,
+		supervisorExe:  sup,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	// Wait until the job is done on disk with its capture still pending: the exact
+	// state the grace-cancel branch handles.
+	testutil.WaitFor(t, 3*time.Second, func() bool {
+		_, done := m.store.ExitCode(job.ID)
+		return done && m.CapturePending(job.ID)
+	}, "job never reached done with a pending capture")
+
+	// A context already cancelled when WaitTerminal enters the grace select makes
+	// the ctx.Done() branch fire deterministically, without racing the poll cadence.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	st, terminal, err := m.WaitTerminal(ctx, job.ID, time.Now().Add(15*time.Second), nil)
+	if err != nil {
+		t.Fatalf("WaitTerminal err = %v, want nil (a done job's grace cancel is not a failure)", err)
+	}
+	if !terminal {
+		t.Fatal("terminal = false, want true")
+	}
+	if st.State != StateDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	// Drain the completion goroutine so the capture bookkeeping settles before the
+	// test dir is removed.
+	testutil.WaitFor(t, 5*time.Second, func() bool {
+		return !m.CapturePending(job.ID)
+	}, "capture never concluded")
+}
+
 // concludeCapture marks the eager capture concluded BEFORE it clears
 // pendingCaptures, so !CapturePending must always imply captureConcluded. A
 // waiter that observed pending=false && concluded=false would wrongly treat a

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -1,0 +1,198 @@
+//go:build linux || darwin
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// waitManager builds a Manager whose jobs run the given fake agy under a fake
+// supervisor. The supervisor writes no conversation cache and the cache file is
+// an empty object, so a fresh run's id capture arms and then settles empty
+// within a short capture budget. That keeps WaitTerminal's capture-grace path
+// (done + CapturePending) from stalling the tests that do not target it.
+func waitManager(t *testing.T, fake testutil.FakeAgy) *Manager {
+	t.Helper()
+	agy := testutil.WriteFakeAgy(t, fake)
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{AgyPath: agy})
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newManager(t, managerOpts{
+		agyPath:        agy,
+		supervisorExe:  sup,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+	m.captureBudget = 50 * time.Millisecond
+	m.capturePoll = 10 * time.Millisecond
+	return m
+}
+
+// drainJob waits for a still-running job to finish, so the test's TempDir
+// StateDir is not removed out from under a supervisor still writing into it.
+func drainJob(t *testing.T, m *Manager, id string) {
+	t.Helper()
+	testutil.WaitFor(t, 5*time.Second, func() bool {
+		st, err := m.Status(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return st.State == StateDone
+	}, "job never finished")
+}
+
+// A job that is already done when WaitTerminal is called must return its
+// terminal status without waiting.
+func TestWaitTerminalReturnsDoneJob(t *testing.T) {
+	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	// Poll until the job is done and its id capture has settled, so the call
+	// below does not enter the capture-grace path and can return at once.
+	testutil.WaitFor(t, 3*time.Second, func() bool {
+		st, err := m.Status(job.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.State != StateRunning && st.State != StateDone {
+			t.Fatalf("job reached %q, want running or done", st.State)
+		}
+		return st.State == StateDone && !m.CapturePending(job.ID)
+	}, "job never settled done")
+
+	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(5*time.Second), nil)
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if st.State != StateDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if !terminal {
+		t.Fatal("terminal = false, want true")
+	}
+	if st.Result != "OK" {
+		t.Fatalf("result = %q, want OK", st.Result)
+	}
+}
+
+// WaitTerminal must block until a running job reaches a terminal state, then
+// report its captured result.
+func TestWaitTerminalBlocksUntilDone(t *testing.T) {
+	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0, Sleep: 1 * time.Second})
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(15*time.Second), nil)
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if !terminal || st.State != StateDone {
+		t.Fatalf("state = %q terminal = %v, want done/true", st.State, terminal)
+	}
+	if st.Result != "OK" {
+		t.Fatalf("result = %q, want OK", st.Result)
+	}
+}
+
+// A deadline that passes while the job is still running must end the wait with a
+// non-terminal running status and no error.
+func TestWaitTerminalDeadlineOverrun(t *testing.T) {
+	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0, Sleep: 2 * time.Second})
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(100*time.Millisecond), nil)
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if terminal {
+		t.Fatal("terminal = true, want false on deadline overrun")
+	}
+	if st.State != StateRunning {
+		t.Fatalf("state = %q, want running", st.State)
+	}
+	drainJob(t, m, job.ID)
+}
+
+// A cancelled context must end the wait with context.Canceled and a
+// non-terminal result, without touching the still-running job.
+func TestWaitTerminalContextCancel(t *testing.T) {
+	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0, Sleep: 2 * time.Second})
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Cancel only once WaitTerminal is observably polling, so the cancellation
+	// races the running-state select rather than the first status read.
+	time.AfterFunc(300*time.Millisecond, cancel)
+
+	_, terminal, err := m.WaitTerminal(ctx, job.ID, time.Now().Add(15*time.Second), nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if terminal {
+		t.Fatal("terminal = true, want false on cancel")
+	}
+	drainJob(t, m, job.ID)
+}
+
+// An unknown job id must surface the store load failure, not a terminal result.
+func TestWaitTerminalUnknownJob(t *testing.T) {
+	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	_, terminal, err := m.WaitTerminal(context.Background(), "nonexistent-id", time.Now().Add(5*time.Second), nil)
+	if err == nil {
+		t.Fatal("err = nil, want a store load failure for an unknown job")
+	}
+	if terminal {
+		t.Fatal("terminal = true, want false for an unknown job")
+	}
+}
+
+// onTick must fire at least once while the job runs, and every status it
+// observes must be running.
+func TestWaitTerminalOnTick(t *testing.T) {
+	m := waitManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0, Sleep: 1 * time.Second})
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	// onTick is documented to run only from WaitTerminal's own goroutine, so these
+	// need no synchronization.
+	var ticks int
+	var sawNonRunning bool
+	onTick := func(st Status) {
+		ticks++
+		if st.State != StateRunning {
+			sawNonRunning = true
+		}
+	}
+	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(15*time.Second), onTick)
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if !terminal || st.State != StateDone {
+		t.Fatalf("state = %q terminal = %v, want done/true", st.State, terminal)
+	}
+	if ticks < 1 {
+		t.Fatalf("onTick fired %d times, want >= 1", ticks)
+	}
+	if sawNonRunning {
+		t.Fatal("onTick observed a non-running status; it must only fire while running")
+	}
+}

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -5,6 +5,7 @@ package manager
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -194,5 +195,60 @@ func TestWaitTerminalOnTick(t *testing.T) {
 	}
 	if sawNonRunning {
 		t.Fatal("onTick observed a non-running status; it must only fire while running")
+	}
+}
+
+// A fresh run whose conversation cache lands only after the exit sentinel (agy's
+// cache daemon flushes after the process exits) must still return its id from
+// WaitTerminal: the capture grace must hold until the late capture settles
+// rather than returning done with an empty id. This mirrors
+// TestAgyRunSyncReturnsLateCapturedConversationID at the manager level.
+func TestWaitTerminalGraceDeliversLateCapturedID(t *testing.T) {
+	// See TestFreshRunCapturesConversationID: the cache key must match the
+	// symlink-resolved path StartJob persists as meta.Cwd, or the fake
+	// supervisor's cache write is never attributed to this run.
+	cwd, err := normalizeCwd(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const uuid = "13131313-2424-3535-4646-575757575757"
+
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	// The cache lands ~600ms after the exit sentinel, mimicking agy's cache-daemon
+	// lag. The manager's default captureBudget (2s) stays comfortably larger, so
+	// the completion goroutine is still retrying the capture when the cache write
+	// arrives; WaitTerminal's grace must span that window. Using the default
+	// budget (not the short waitManager one) is what exercises the grace path.
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:    agy,
+		CachePath:  cachePath,
+		CacheJSON:  fmt.Sprintf(`{%q:%q}`, cwd, uuid),
+		CacheDelay: 600 * time.Millisecond,
+	})
+	m := newManager(t, managerOpts{
+		agyPath:        agy,
+		supervisorExe:  sup,
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	st, terminal, err := m.WaitTerminal(context.Background(), job.ID, time.Now().Add(15*time.Second), nil)
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if !terminal || st.State != StateDone {
+		t.Fatalf("state = %q terminal = %v, want done/true", st.State, terminal)
+	}
+	if st.ConversationID != uuid {
+		t.Fatalf("conversation_id = %q, want %q (grace must hold until the late capture lands)", st.ConversationID, uuid)
 	}
 }

--- a/internal/mcptools/await.go
+++ b/internal/mcptools/await.go
@@ -1,0 +1,77 @@
+package mcptools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// notifyTimeout bounds each progress-notification send so a client that
+// stopped draining the stream cannot park the wait loop past its cap. It
+// matches the manager's poll cadence, which is what the send used to be
+// bounded by when the loop lived in run_sync.
+const notifyTimeout = 250 * time.Millisecond
+
+// parseWait validates a caller-supplied inline wait, applying the shared
+// default and cap. agy_run_sync and agy_wait use it so the two cannot drift.
+func parseWait(s string) (time.Duration, error) {
+	if s == "" {
+		return defaultSyncWait, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, fmt.Errorf("invalid wait %q: want a positive Go duration like 90s", s)
+	}
+	return min(d, maxSyncWait), nil
+}
+
+// awaitJob blocks until the job is terminal or the deadline passes, emitting
+// once-per-second MCP progress notifications when the client supplied a
+// progress token. It is the wait phase shared by agy_run_sync and agy_wait,
+// so their semantics cannot drift. On a wait-cap overrun the returned output
+// carries the standard poll-with-agy_status note.
+func awaitJob(ctx context.Context, req *mcp.CallToolRequest, mgr *manager.Manager, jobID string, deadline time.Time) (runSyncOutput, error) {
+	token := req.Params.GetProgressToken()
+	// Notify once per elapsed second, not per poll tick: the message has
+	// whole-second granularity, so finer cadence is pure stream noise.
+	lastNotified := time.Duration(-1)
+	onTick := func(st manager.Status) {
+		sec := st.Elapsed.Truncate(time.Second)
+		if token == nil || sec == lastNotified {
+			return
+		}
+		lastNotified = sec
+		// Best effort: the result, not the notifications, is the contract.
+		nctx, ncancel := context.WithTimeout(ctx, notifyTimeout)
+		_ = req.Session.NotifyProgress(nctx, &mcp.ProgressNotificationParams{
+			ProgressToken: token,
+			Progress:      st.Elapsed.Seconds(),
+			Message:       fmt.Sprintf("job %s running (%s)", jobID, sec),
+		})
+		ncancel()
+	}
+	st, terminal, err := mgr.WaitTerminal(ctx, jobID, deadline, onTick)
+	if err != nil {
+		// Classify by error identity, not context state: ctx can already be
+		// Done() in the same poll tick as an unrelated Status() read failure,
+		// so checking ctx.Err() != nil alone would mislabel that failure as a
+		// cancellation. Only report cancellation when WaitTerminal's error is
+		// actually the context error.
+		if cerr := ctx.Err(); cerr != nil && errors.Is(err, cerr) {
+			// The client gave up on the call; the job stays alive under its
+			// detached supervisor. Carry the job id in the error so a
+			// gracefully-cancelling client can still find the job.
+			return runSyncOutput{}, fmt.Errorf("wait cancelled; job %s is still running, poll it with agy_status: %w", jobID, err)
+		}
+		return runSyncOutput{}, fmt.Errorf("job %s status read failed: %w", jobID, err)
+	}
+	out := runSyncOutput{JobID: jobID, statusOutput: toStatusOutput(st)}
+	if !terminal {
+		out.Note = "wait cap reached; the job is still running, poll it with agy_status"
+	}
+	return out, nil
+}

--- a/internal/mcptools/await.go
+++ b/internal/mcptools/await.go
@@ -10,12 +10,6 @@ import (
 	"github.com/tphakala/agy-mcp/internal/manager"
 )
 
-// notifyTimeout bounds each progress-notification send so a client that
-// stopped draining the stream cannot park the wait loop past its cap. It
-// matches the manager's poll cadence, which is what the send used to be
-// bounded by when the loop lived in run_sync.
-const notifyTimeout = 250 * time.Millisecond
-
 // parseWait validates a caller-supplied inline wait, applying the shared
 // default and cap. agy_run_sync and agy_wait use it so the two cannot drift.
 func parseWait(s string) (time.Duration, error) {
@@ -45,8 +39,10 @@ func awaitJob(ctx context.Context, req *mcp.CallToolRequest, mgr *manager.Manage
 			return
 		}
 		lastNotified = sec
-		// Best effort: the result, not the notifications, is the contract.
-		nctx, ncancel := context.WithTimeout(ctx, notifyTimeout)
+		// Best effort: the result, not the notifications, is the contract. Bound
+		// each send to one poll tick so a client that stopped draining the stream
+		// cannot park the wait loop past its cap.
+		nctx, ncancel := context.WithTimeout(ctx, manager.WaitPollInterval)
 		_ = req.Session.NotifyProgress(nctx, &mcp.ProgressNotificationParams{
 			ProgressToken: token,
 			Progress:      st.Elapsed.Seconds(),

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -2,7 +2,6 @@ package mcptools
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -16,10 +15,6 @@ const (
 	// maxSyncWait caps caller-supplied waits so a tool call cannot park a
 	// session indefinitely; longer runs are for agy_run + agy_status.
 	maxSyncWait = 10 * time.Minute
-	// syncPollInterval is how often the wait loop re-reads job status and
-	// emits a progress notification. Status reads a few small files, so
-	// this is cheap.
-	syncPollInterval = 250 * time.Millisecond
 )
 
 // runSyncInput is runInput plus the inline wait cap.
@@ -43,13 +38,9 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 			"Sends MCP progress notifications while waiting. If the job outlives the wait cap " +
 			"it keeps running and the returned job_id can be polled with agy_status.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in runSyncInput) (*mcp.CallToolResult, runSyncOutput, error) {
-		wait := defaultSyncWait
-		if in.Wait != "" {
-			d, err := time.ParseDuration(in.Wait)
-			if err != nil || d <= 0 {
-				return nil, runSyncOutput{}, fmt.Errorf("invalid wait %q: want a positive Go duration like 90s", in.Wait)
-			}
-			wait = min(d, maxSyncWait)
+		wait, err := parseWait(in.Wait)
+		if err != nil {
+			return nil, runSyncOutput{}, err
 		}
 		startReq, err := in.toStartRequest()
 		if err != nil {
@@ -59,67 +50,10 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 		if err != nil {
 			return nil, runSyncOutput{}, err
 		}
-
-		token := req.Params.GetProgressToken()
-		deadline := time.Now().Add(wait)
-		ticker := time.NewTicker(syncPollInterval)
-		defer ticker.Stop()
-		lastNotified := time.Duration(-1)
-		for {
-			st, err := mgr.Status(job.ID)
-			if err != nil {
-				return nil, runSyncOutput{}, fmt.Errorf("job %s started but status read failed: %w", job.ID, err)
-			}
-			out := runSyncOutput{JobID: job.ID, statusOutput: toStatusOutput(st)}
-			if st.State != manager.StateRunning {
-				// A fresh run's conversation id can lag the exit sentinel: agy's
-				// cache daemon flushes after the process exits, and the manager's
-				// completion goroutine captures the id with a bounded retry. While
-				// that capture is still pending, keep polling instead of returning
-				// done with no id: a sync caller has no reason to poll again after
-				// a terminal result, so an id missing here is lost to the caller.
-				if st.State == manager.StateDone && st.ConversationID == "" &&
-					job.ConversationID == "" && time.Now().Before(deadline) &&
-					mgr.CapturePending(job.ID) {
-					select {
-					case <-ctx.Done():
-						return nil, out, nil
-					case <-ticker.C:
-					}
-					continue
-				}
-				return nil, out, nil
-			}
-			// The cap is approximate: the loop only observes the deadline on a
-			// poll tick, so a call can overshoot wait by up to syncPollInterval.
-			if time.Now().After(deadline) {
-				out.Note = "wait cap reached; the job is still running, poll it with agy_status"
-				return nil, out, nil
-			}
-			// Notify once per elapsed second, not per poll tick: the message has
-			// whole-second granularity, so finer cadence is pure stream noise.
-			if sec := st.Elapsed.Truncate(time.Second); token != nil && sec != lastNotified {
-				lastNotified = sec
-				// Best effort: the result, not the notifications, is the
-				// contract. The bounded context keeps a client that stopped
-				// draining the stream from parking the loop past the wait cap.
-				nctx, ncancel := context.WithTimeout(ctx, syncPollInterval)
-				_ = req.Session.NotifyProgress(nctx, &mcp.ProgressNotificationParams{
-					ProgressToken: token,
-					Progress:      st.Elapsed.Seconds(),
-					Message:       fmt.Sprintf("job %s running (%s)", job.ID, sec),
-				})
-				ncancel()
-			}
-			select {
-			case <-ctx.Done():
-				// The client gave up on the call; the job stays alive under
-				// its detached supervisor for agy_status polling. Carry the
-				// job id in the error so a gracefully-cancelling client can
-				// still find the job.
-				return nil, runSyncOutput{}, fmt.Errorf("wait cancelled; job %s is still running, poll it with agy_status: %w", job.ID, ctx.Err())
-			case <-ticker.C:
-			}
+		out, err := awaitJob(ctx, req, mgr, job.ID, time.Now().Add(wait))
+		if err != nil {
+			return nil, runSyncOutput{}, err
 		}
+		return nil, out, nil
 	})
 }

--- a/internal/mcptools/run_sync_posix_test.go
+++ b/internal/mcptools/run_sync_posix_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -187,20 +188,48 @@ func TestAgyRunSyncOverrunReturnsJobID(t *testing.T) {
 	waitForDone(t, mgr, jobID, "LATE OK", 15*time.Second)
 }
 
-func TestAgyRunSyncSendsProgress(t *testing.T) {
-	// One second spans several 250ms poll ticks, so at least one progress
-	// notification fires while the job runs.
-	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "SLOW OK", Exit: 0, Sleep: 1 * time.Second})
-
+// progressCollector returns client options whose progress handler records every
+// progress token received, plus a snapshot accessor. Shared by the two
+// SendsProgress tests, which differ only in which tool drives the wait.
+func progressCollector() (opts *mcp.ClientOptions, snapshot func() []any) {
 	var mu sync.Mutex
 	var tokens []any
-	opts := &mcp.ClientOptions{
+	opts = &mcp.ClientOptions{
 		ProgressNotificationHandler: func(_ context.Context, r *mcp.ProgressNotificationClientRequest) {
 			mu.Lock()
 			tokens = append(tokens, r.Params.ProgressToken)
 			mu.Unlock()
 		},
 	}
+	snapshot = func() []any {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(tokens)
+	}
+	return opts, snapshot
+}
+
+// assertProgressToken waits briefly for at least one progress notification to
+// land (they are one-way, so they can arrive after the call returns) and asserts
+// every token received equals want. Shared by the two SendsProgress tests.
+func assertProgressToken(t *testing.T, tokens func() []any, want any) {
+	t.Helper()
+	testutil.WaitFor(t, 2*time.Second, func() bool {
+		return len(tokens()) > 0
+	}, "no progress notifications received")
+	for _, tok := range tokens() {
+		if tok != want {
+			t.Fatalf("progress token = %v, want %v", tok, want)
+		}
+	}
+}
+
+func TestAgyRunSyncSendsProgress(t *testing.T) {
+	// One second spans several 250ms poll ticks, so at least one progress
+	// notification fires while the job runs.
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "SLOW OK", Exit: 0, Sleep: 1 * time.Second})
+
+	opts, tokens := progressCollector()
 	cs := connect(t, mgr, opts)
 
 	params := &mcp.CallToolParams{
@@ -216,27 +245,7 @@ func TestAgyRunSyncSendsProgress(t *testing.T) {
 		t.Fatalf("state = %v, want done", sc["state"])
 	}
 
-	// Notifications are one-way; give in-flight ones a moment to land.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(tokens)
-		mu.Unlock()
-		if n > 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	if len(tokens) == 0 {
-		t.Fatal("no progress notifications received")
-	}
-	for _, tok := range tokens {
-		if tok != "tok-7" {
-			t.Fatalf("progress token = %v, want tok-7", tok)
-		}
-	}
+	assertProgressToken(t, tokens, "tok-7")
 }
 
 func TestAgyRunSyncClientCancelKeepsJobAlive(t *testing.T) {

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -162,7 +162,7 @@ func TestHTTPServeListsTools(t *testing.T) {
 	for _, tool := range tools.Tools {
 		got[tool.Name] = true
 	}
-	want := []string{"agy_run", "agy_status", "agy_cancel", "agy_run_sync", "list_models", "list_sessions"}
+	want := []string{"agy_run", "agy_status", "agy_cancel", "agy_run_sync", "agy_wait", "list_models", "list_sessions"}
 	if len(tools.Tools) != len(want) {
 		t.Fatalf("registered %d tools, want %d (%v)", len(tools.Tools), len(want), want)
 	}

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -35,6 +35,7 @@ const (
 	toolAgyStatus    = "agy_status"
 	toolAgyCancel    = "agy_cancel"
 	toolAgyRunSync   = "agy_run_sync"
+	toolAgyWait      = "agy_wait"
 	toolListModels   = "list_models"
 	toolListSessions = "list_sessions"
 )
@@ -174,6 +175,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 	})
 
 	registerRunSync(s, mgr)
+	registerWait(s, mgr)
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name: toolListModels, Description: "List available agy models.",

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -28,13 +28,18 @@ type runInput struct {
 // cannot leave a hung job uncollectable for weeks.
 const maxJobTimeout = 24 * time.Hour
 
+// ToolAgyRunSync is the agy_run_sync tool name, exported so out-of-package
+// callers (the hook-wait suppression gate) can match it against a hook payload's
+// recorded tool name with a compile-time link instead of a duplicated literal.
+const ToolAgyRunSync = "agy_run_sync"
+
 // Tool names, shared between registration (here and run_sync.go) and tests so
 // the two cannot drift.
 const (
 	toolAgyRun       = "agy_run"
 	toolAgyStatus    = "agy_status"
 	toolAgyCancel    = "agy_cancel"
-	toolAgyRunSync   = "agy_run_sync"
+	toolAgyRunSync   = ToolAgyRunSync
 	toolAgyWait      = "agy_wait"
 	toolListModels   = "list_models"
 	toolListSessions = "list_sessions"

--- a/internal/mcptools/wait.go
+++ b/internal/mcptools/wait.go
@@ -1,0 +1,45 @@
+package mcptools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// waitInput is the input for agy_wait.
+type waitInput struct {
+	JobID string `json:"job_id" jsonschema:"the job id to wait for"`
+	Wait  string `json:"wait,omitempty" jsonschema:"max time to wait inline (Go duration, default 2m, max 10m); on overrun the job keeps running and can be waited on again or polled with agy_status"`
+}
+
+// registerWait adds the agy_wait tool: block on an existing job until it
+// finishes (bounded), streaming progress notifications when the client asked
+// for them. It shares agy_run_sync's wait phase, so one agy_wait call
+// replaces an agy_status poll loop.
+func registerWait(s *mcp.Server, mgr *manager.Manager) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name: toolAgyWait,
+		Description: "Block until an agy_run job finishes (bounded by wait, default 2m, max 10m). " +
+			"Sends MCP progress notifications while waiting. Prefer one agy_wait over repeated " +
+			"agy_status polling when the next step depends on the job's result. If the job " +
+			"outlives the wait cap it keeps running; call agy_wait again or poll agy_status.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in waitInput) (*mcp.CallToolResult, runSyncOutput, error) {
+		wait, err := parseWait(in.Wait)
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		// Reject an unknown job before entering the wait loop, so a typo'd id
+		// fails fast instead of polling a job that can never appear.
+		if _, err := mgr.Status(in.JobID); err != nil {
+			return nil, runSyncOutput{}, fmt.Errorf("job %s: %w", in.JobID, err)
+		}
+		out, err := awaitJob(ctx, req, mgr, in.JobID, time.Now().Add(wait))
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		return nil, out, nil
+	})
+}

--- a/internal/mcptools/wait.go
+++ b/internal/mcptools/wait.go
@@ -2,7 +2,6 @@ package mcptools
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -31,11 +30,11 @@ func registerWait(s *mcp.Server, mgr *manager.Manager) {
 		if err != nil {
 			return nil, runSyncOutput{}, err
 		}
-		// Reject an unknown job before entering the wait loop, so a typo'd id
-		// fails fast instead of polling a job that can never appear.
-		if _, err := mgr.Status(in.JobID); err != nil {
-			return nil, runSyncOutput{}, fmt.Errorf("job %s: %w", in.JobID, err)
-		}
+		// An unknown job needs no separate pre-check: WaitTerminal's first action is
+		// the same Status read, and it returns before any polling, so awaitJob's
+		// "status read failed" path already fails a typo'd id fast. The pre-check only
+		// duplicated a potentially large out-file read on every wait against a
+		// terminal job.
 		out, err := awaitJob(ctx, req, mgr, in.JobID, time.Now().Add(wait))
 		if err != nil {
 			return nil, runSyncOutput{}, err

--- a/internal/mcptools/wait_posix_test.go
+++ b/internal/mcptools/wait_posix_test.go
@@ -4,6 +4,7 @@ package mcptools
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -61,19 +62,64 @@ func TestAgyWaitUnknownJob(t *testing.T) {
 	}
 }
 
+// TestAgyWaitInvalidWait proves the invalid-wait error comes from parseWait,
+// not from an unknown job id. It targets a real, observably running job with
+// each invalid wait: if the implementation looked the job up before
+// validating wait, a real job id would let the call through, so this only
+// passes when wait is rejected first.
 func TestAgyWaitInvalidWait(t *testing.T) {
-	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "x", Exit: 0})
+	mgr, stateDir := newTestManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0, Sleep: 2 * time.Second})
 	cs := connect(t, mgr, nil)
+
+	runRes, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run",
+		Arguments: map[string]any{"prompt": "review"},
+	})
+	if err != nil || runRes.IsError {
+		t.Fatalf("agy_run: err=%v res=%+v", err, runRes)
+	}
+	jobID, _ := structMap(t, runRes.StructuredContent)["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+	// Confirm the job is actually running before probing it, so a pass here
+	// cannot be explained by the job not existing yet either.
+	waitForRunningJob(t, mgr, stateDir, 5*time.Second)
 
 	for _, wait := range []string{"nope", "-1s", "0"} {
 		res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
 			Name:      "agy_wait",
-			Arguments: map[string]any{"job_id": "x", "wait": wait},
+			Arguments: map[string]any{"job_id": jobID, "wait": wait},
 		})
 		if err == nil && !res.IsError {
 			t.Errorf("wait %q: expected an error, got %+v", wait, res.StructuredContent)
+			continue
+		}
+		text := callToolErrorText(err, res)
+		if !strings.Contains(text, "invalid wait") {
+			t.Errorf("wait %q: error = %q, want it to contain %q", wait, text, "invalid wait")
 		}
 	}
+
+	waitForDone(t, mgr, jobID, "OK", 15*time.Second)
+}
+
+// callToolErrorText extracts the human-readable error message from a failed
+// CallTool response, whichever of the two error surfaces the SDK used: a
+// transport-level err (context or protocol failure), or a tool-level error
+// result whose message lands in the first text content block.
+func callToolErrorText(err error, res *mcp.CallToolResult) string {
+	if err != nil {
+		return err.Error()
+	}
+	if res != nil {
+		for _, c := range res.Content {
+			if tc, ok := c.(*mcp.TextContent); ok {
+				return tc.Text
+			}
+		}
+	}
+	return ""
 }
 
 func TestAgyWaitOverrunReturnsNote(t *testing.T) {

--- a/internal/mcptools/wait_posix_test.go
+++ b/internal/mcptools/wait_posix_test.go
@@ -3,9 +3,7 @@
 package mcptools
 
 import (
-	"context"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -165,15 +163,7 @@ func TestAgyWaitSendsProgress(t *testing.T) {
 	// notification fires while the job runs.
 	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0, Sleep: 1 * time.Second})
 
-	var mu sync.Mutex
-	var tokens []any
-	opts := &mcp.ClientOptions{
-		ProgressNotificationHandler: func(_ context.Context, r *mcp.ProgressNotificationClientRequest) {
-			mu.Lock()
-			tokens = append(tokens, r.Params.ProgressToken)
-			mu.Unlock()
-		},
-	}
+	opts, tokens := progressCollector()
 	cs := connect(t, mgr, opts)
 
 	runRes, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
@@ -201,25 +191,5 @@ func TestAgyWaitSendsProgress(t *testing.T) {
 		t.Fatalf("state = %v, want done", sc["state"])
 	}
 
-	// Notifications are one-way; give in-flight ones a moment to land.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(tokens)
-		mu.Unlock()
-		if n > 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	if len(tokens) == 0 {
-		t.Fatal("no progress notifications received")
-	}
-	for _, tok := range tokens {
-		if tok != "tok-9" {
-			t.Fatalf("progress token = %v, want tok-9", tok)
-		}
-	}
+	assertProgressToken(t, tokens, "tok-9")
 }

--- a/internal/mcptools/wait_posix_test.go
+++ b/internal/mcptools/wait_posix_test.go
@@ -1,0 +1,179 @@
+//go:build linux || darwin
+
+package mcptools
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+func TestAgyWaitReturnsResult(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "WAITED OK", Exit: 0, Sleep: 500 * time.Millisecond})
+	cs := connect(t, mgr, nil)
+
+	runRes, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run",
+		Arguments: map[string]any{"prompt": "review"},
+	})
+	if err != nil || runRes.IsError {
+		t.Fatalf("agy_run: err=%v res=%+v", err, runRes)
+	}
+	jobID, _ := structMap(t, runRes.StructuredContent)["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_wait",
+		Arguments: map[string]any{"job_id": jobID, "wait": "30s"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_wait: err=%v res=%+v", err, res)
+	}
+	sc := structMap(t, res.StructuredContent)
+	if sc["state"] != manager.StateDone {
+		t.Fatalf("state = %v, want done", sc["state"])
+	}
+	if sc["result"] != "WAITED OK" {
+		t.Fatalf("result = %v, want WAITED OK", sc["result"])
+	}
+	if sc["job_id"] != jobID {
+		t.Fatalf("job_id = %v, want %q", sc["job_id"], jobID)
+	}
+}
+
+func TestAgyWaitUnknownJob(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "x", Exit: 0})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_wait",
+		Arguments: map[string]any{"job_id": "no-such-job"},
+	})
+	if err == nil && !res.IsError {
+		t.Fatalf("expected an error for an unknown job, got %+v", res)
+	}
+}
+
+func TestAgyWaitInvalidWait(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "x", Exit: 0})
+	cs := connect(t, mgr, nil)
+
+	for _, wait := range []string{"nope", "-1s", "0"} {
+		res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+			Name:      "agy_wait",
+			Arguments: map[string]any{"job_id": "x", "wait": wait},
+		})
+		if err == nil && !res.IsError {
+			t.Errorf("wait %q: expected an error, got %+v", wait, res.StructuredContent)
+		}
+	}
+}
+
+func TestAgyWaitOverrunReturnsNote(t *testing.T) {
+	// The sleep must comfortably outlast the 100ms wait cap even on a stalled
+	// CI runner, or the job finishes before the cap and the running assertion
+	// flakes.
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "LATE OK", Exit: 0, Sleep: 2 * time.Second})
+	cs := connect(t, mgr, nil)
+
+	runRes, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run",
+		Arguments: map[string]any{"prompt": "review"},
+	})
+	if err != nil || runRes.IsError {
+		t.Fatalf("agy_run: err=%v res=%+v", err, runRes)
+	}
+	jobID, _ := structMap(t, runRes.StructuredContent)["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_wait",
+		Arguments: map[string]any{"job_id": jobID, "wait": "100ms"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_wait: err=%v res=%+v", err, res)
+	}
+	sc := structMap(t, res.StructuredContent)
+	if sc["state"] != manager.StateRunning {
+		t.Fatalf("state = %v, want running", sc["state"])
+	}
+	if note, _ := sc["note"].(string); note == "" {
+		t.Fatal("expected an overrun note")
+	}
+
+	// The overrun must not have cancelled the job: it finishes on its own.
+	waitForDone(t, mgr, jobID, "LATE OK", 15*time.Second)
+}
+
+func TestAgyWaitSendsProgress(t *testing.T) {
+	// One second spans several 250ms poll ticks, so at least one progress
+	// notification fires while the job runs.
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "OK", Exit: 0, Sleep: 1 * time.Second})
+
+	var mu sync.Mutex
+	var tokens []any
+	opts := &mcp.ClientOptions{
+		ProgressNotificationHandler: func(_ context.Context, r *mcp.ProgressNotificationClientRequest) {
+			mu.Lock()
+			tokens = append(tokens, r.Params.ProgressToken)
+			mu.Unlock()
+		},
+	}
+	cs := connect(t, mgr, opts)
+
+	runRes, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run",
+		Arguments: map[string]any{"prompt": "review"},
+	})
+	if err != nil || runRes.IsError {
+		t.Fatalf("agy_run: err=%v res=%+v", err, runRes)
+	}
+	jobID, _ := structMap(t, runRes.StructuredContent)["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+
+	params := &mcp.CallToolParams{
+		Name:      "agy_wait",
+		Arguments: map[string]any{"job_id": jobID, "wait": "30s"},
+	}
+	params.SetProgressToken("tok-9")
+	res, err := cs.CallTool(t.Context(), params)
+	if err != nil || res.IsError {
+		t.Fatalf("agy_wait: err=%v res=%+v", err, res)
+	}
+	if sc := structMap(t, res.StructuredContent); sc["state"] != manager.StateDone {
+		t.Fatalf("state = %v, want done", sc["state"])
+	}
+
+	// Notifications are one-way; give in-flight ones a moment to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(tokens)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(tokens) == 0 {
+		t.Fatal("no progress notifications received")
+	}
+	for _, tok := range tokens {
+		if tok != "tok-9" {
+			t.Fatalf("progress token = %v, want tok-9", tok)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,10 @@ func main() {
 		return
 	}
 
+	if len(os.Args) >= 2 && os.Args[1] == "wait-job" {
+		os.Exit(waitJobMain(os.Args[2:], os.Stdout, os.Stderr))
+	}
+
 	if err := serve(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,10 @@ func main() {
 		os.Exit(waitJobMain(os.Args[2:], os.Stdout, os.Stderr))
 	}
 
+	if len(os.Args) >= 2 && os.Args[1] == "hook-wait" {
+		os.Exit(hookWaitMain(os.Args[2:], os.Stdin, os.Stderr))
+	}
+
 	if err := serve(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/waitcmd.go
+++ b/waitcmd.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// waitJobMain implements "agy-mcp wait-job [-timeout 1h] <job_id>": block
+// until the job reaches a terminal state, print that state word to stdout,
+// and exit 0. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout. It is the
+// scriptable face of manager.WaitTerminal for shell automation that would
+// otherwise poll agy_status.
+func waitJobMain(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("wait-job", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	timeout := fs.Duration("timeout", time.Hour, "max time to wait for the job")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: agy-mcp wait-job [-timeout 1h] <job_id>")
+		return 2
+	}
+	id := fs.Arg(0)
+	st, terminal, err := waitForJob(id, *timeout)
+	if err != nil {
+		fmt.Fprintf(stderr, "wait-job: %v\n", err)
+		return 1
+	}
+	if !terminal {
+		fmt.Fprintf(stderr, "wait-job: job %s still running after %s\n", id, *timeout)
+		return 3
+	}
+	fmt.Fprintln(stdout, st.State)
+	return 0
+}
+
+// waitForJob resolves the wait-only config and blocks on the job. Shared by
+// wait-job and hook-wait so the two subcommands cannot diverge on how a wait
+// manager is built. The job itself is never signalled: SIGINT/SIGTERM cancel
+// only this observer's wait.
+func waitForJob(id string, timeout time.Duration) (manager.Status, bool, error) {
+	cfg, err := config.ResolveWait()
+	if err != nil {
+		return manager.Status{}, false, err
+	}
+	mgr := manager.New(cfg)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	return mgr.WaitTerminal(ctx, id, time.Now().Add(timeout), nil)
+}

--- a/waitcmd.go
+++ b/waitcmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -15,9 +16,9 @@ import (
 
 // waitJobMain implements "agy-mcp wait-job [-timeout 1h] <job_id>": block
 // until the job reaches a terminal state, print that state word to stdout,
-// and exit 0. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout. It is the
-// scriptable face of manager.WaitTerminal for shell automation that would
-// otherwise poll agy_status.
+// and exit 0. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout, 130
+// interrupted. It is the scriptable face of manager.WaitTerminal for shell
+// automation that would otherwise poll agy_status.
 func waitJobMain(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("wait-job", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -32,6 +33,16 @@ func waitJobMain(args []string, stdout, stderr io.Writer) int {
 	id := fs.Arg(0)
 	st, terminal, err := waitForJob(id, *timeout)
 	if err != nil {
+		// signal.NotifyContext cancels the wait's ctx on SIGINT or SIGTERM, which
+		// WaitTerminal surfaces as context.Canceled; report that as the POSIX
+		// 128+SIGINT interrupt code (130) rather than a generic error, so a script
+		// can tell "the user hit Ctrl-C" apart from a real failure. NotifyContext
+		// covers SIGTERM too, but one code keeps the contract simple and 130 is the
+		// widely understood interrupt exit status.
+		if errors.Is(err, context.Canceled) {
+			_, _ = fmt.Fprintln(stderr, "wait-job: interrupted")
+			return 130
+		}
 		_, _ = fmt.Fprintf(stderr, "wait-job: %v\n", err)
 		return 1
 	}

--- a/waitcmd.go
+++ b/waitcmd.go
@@ -26,20 +26,20 @@ func waitJobMain(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if fs.NArg() != 1 {
-		fmt.Fprintln(stderr, "usage: agy-mcp wait-job [-timeout 1h] <job_id>")
+		_, _ = fmt.Fprintln(stderr, "usage: agy-mcp wait-job [-timeout 1h] <job_id>")
 		return 2
 	}
 	id := fs.Arg(0)
 	st, terminal, err := waitForJob(id, *timeout)
 	if err != nil {
-		fmt.Fprintf(stderr, "wait-job: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "wait-job: %v\n", err)
 		return 1
 	}
 	if !terminal {
-		fmt.Fprintf(stderr, "wait-job: job %s still running after %s\n", id, *timeout)
+		_, _ = fmt.Fprintf(stderr, "wait-job: job %s still running after %s\n", id, *timeout)
 		return 3
 	}
-	fmt.Fprintln(stdout, st.State)
+	_, _ = fmt.Fprintln(stdout, st.State)
 	return 0
 }
 

--- a/waitcmd.go
+++ b/waitcmd.go
@@ -54,16 +54,35 @@ func waitJobMain(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-// waitForJob resolves the wait-only config and blocks on the job. Shared by
+// resolveWaitManager builds the wait-only manager (the lighter ResolveWait
+// config plus manager.New) shared by the wait subcommands. Both wait-job and
+// hook-wait observe the job store without ever execing agy, so they resolve the
+// wait config rather than the full one.
+func resolveWaitManager() (*manager.Manager, error) {
+	cfg, err := config.ResolveWait()
+	if err != nil {
+		return nil, err
+	}
+	return manager.New(cfg), nil
+}
+
+// waitForJob resolves the wait-only manager and blocks on the job. Shared by
 // wait-job and hook-wait so the two subcommands cannot diverge on how a wait
 // manager is built. The job itself is never signalled: SIGINT/SIGTERM cancel
 // only this observer's wait.
 func waitForJob(id string, timeout time.Duration) (manager.Status, bool, error) {
-	cfg, err := config.ResolveWait()
+	mgr, err := resolveWaitManager()
 	if err != nil {
 		return manager.Status{}, false, err
 	}
-	mgr := manager.New(cfg)
+	return waitForJobWith(mgr, id, timeout)
+}
+
+// waitForJobWith blocks on the job using an already-resolved manager, so a
+// caller that needs the manager for more than the wait (hook-wait reuses it for
+// its run_sync short-circuit Status read) resolves it once and reuses it here.
+// SIGINT/SIGTERM cancel only this observer's wait, never the job.
+func waitForJobWith(mgr *manager.Manager, id string, timeout time.Duration) (manager.Status, bool, error) {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 	return mgr.WaitTerminal(ctx, id, time.Now().Add(timeout), nil)

--- a/waitcmd_posix_test.go
+++ b/waitcmd_posix_test.go
@@ -1,0 +1,131 @@
+//go:build linux || darwin
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// writeTerminalJob creates <stateDir>/jobs/<id> holding a done job: meta.json
+// (CaptureDisabled: true so the wait manager never reads the host's real agy
+// conversation cache), an out file "RESULT", and an exit_code sentinel "0".
+func writeTerminalJob(t *testing.T, stateDir, id string) {
+	t.Helper()
+	dir := filepath.Join(stateDir, "jobs", id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := jobstore.Meta{ID: id, StartedAt: time.Now(), CaptureDisabled: true}
+	b, err := jsonMarshalForTest(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobstore.MetaPath(dir), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobstore.OutPath(dir), []byte("RESULT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobstore.ExitCodePath(dir), []byte("0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitJobDoneJob(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-done-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var out, errb bytes.Buffer
+	code := waitJobMain([]string{"job-done-1"}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if out.String() != "done\n" {
+		t.Fatalf("stdout = %q, want %q", out.String(), "done\n")
+	}
+}
+
+func TestWaitJobUnknownJob(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := t.TempDir()
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var out, errb bytes.Buffer
+	code := waitJobMain([]string{"nope"}, &out, &errb)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr: %s)", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "nope") {
+		t.Fatalf("stderr = %q, want it to mention the failing job", errb.String())
+	}
+}
+
+func TestWaitJobUsage(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := waitJobMain(nil, &out, &errb); code != 2 {
+		t.Fatalf("waitJobMain(nil) = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	out.Reset()
+	errb.Reset()
+	if code := waitJobMain([]string{"a", "b"}, &out, &errb); code != 2 {
+		t.Fatalf("waitJobMain(a, b) = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+}
+
+func TestWaitJobTimeout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 2 * time.Second})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:   agy,
+		CachePath: cachePath,
+		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-timeout-test"),
+	})
+	stateDir := t.TempDir()
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	mgr := manager.New(c)
+
+	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain the started job once the test is done polling waitJobMain, so a
+	// slow fake agy never outlives the test.
+	t.Cleanup(func() {
+		testutil.WaitFor(t, 5*time.Second, func() bool {
+			st, err := mgr.State(job.ID)
+			return err == nil && st != manager.StateRunning
+		}, "job did not finish before test cleanup")
+	})
+
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var out, errb bytes.Buffer
+	code := waitJobMain([]string{"-timeout", "100ms", job.ID}, &out, &errb)
+	if code != 3 {
+		t.Fatalf("exit code = %d, want 3 (stdout: %s, stderr: %s)", code, out.String(), errb.String())
+	}
+}

--- a/waitcmd_posix_test.go
+++ b/waitcmd_posix_test.go
@@ -5,130 +5,18 @@ package main
 import (
 	"bytes"
 	"errors"
-	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/tphakala/agy-mcp/internal/config"
-	"github.com/tphakala/agy-mcp/internal/jobstore"
-	"github.com/tphakala/agy-mcp/internal/manager"
-	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
-// writeTerminalJob creates <stateDir>/jobs/<id> holding a done job: meta.json
-// (CaptureDisabled: true so the wait manager never reads the host's real agy
-// conversation cache), an out file "RESULT", and an exit_code sentinel "0".
-func writeTerminalJob(t *testing.T, stateDir, id string) {
-	t.Helper()
-	dir := filepath.Join(stateDir, "jobs", id)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	meta := jobstore.Meta{ID: id, StartedAt: time.Now(), CaptureDisabled: true}
-	b, err := jsonMarshalForTest(meta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(jobstore.MetaPath(dir), b, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(jobstore.OutPath(dir), []byte("RESULT"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(jobstore.ExitCodePath(dir), []byte("0"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestWaitJobDoneJob(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	writeTerminalJob(t, stateDir, "job-done-1")
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	var out, errb bytes.Buffer
-	code := waitJobMain([]string{"job-done-1"}, &out, &errb)
-	if code != 0 {
-		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
-	}
-	if out.String() != "done\n" {
-		t.Fatalf("stdout = %q, want %q", out.String(), "done\n")
-	}
-}
-
-func TestWaitJobUnknownJob(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := t.TempDir()
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	var out, errb bytes.Buffer
-	code := waitJobMain([]string{"nope"}, &out, &errb)
-	if code != 1 {
-		t.Fatalf("exit code = %d, want 1 (stderr: %s)", code, errb.String())
-	}
-	if !strings.Contains(errb.String(), "nope") {
-		t.Fatalf("stderr = %q, want it to mention the failing job", errb.String())
-	}
-}
-
-func TestWaitJobUsage(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	var out, errb bytes.Buffer
-	if code := waitJobMain(nil, &out, &errb); code != 2 {
-		t.Fatalf("waitJobMain(nil) = %d, want 2 (stderr: %s)", code, errb.String())
-	}
-	out.Reset()
-	errb.Reset()
-	if code := waitJobMain([]string{"a", "b"}, &out, &errb); code != 2 {
-		t.Fatalf("waitJobMain(a, b) = %d, want 2 (stderr: %s)", code, errb.String())
-	}
-}
-
 func TestWaitJobTimeout(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 2 * time.Second})
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
-	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
-		AgyPath:   agy,
-		CachePath: cachePath,
-		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-timeout-test"),
-	})
-	stateDir := t.TempDir()
-	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
-		DefaultTimeout: time.Minute, MaxConcurrency: 4,
-		ConversationCacheFile: cachePath}
-	mgr := manager.New(c)
-
-	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Drain the started job once the test is done polling waitJobMain, so a
-	// slow fake agy never outlives the test.
-	t.Cleanup(func() {
-		testutil.WaitFor(t, 5*time.Second, func() bool {
-			st, err := mgr.State(job.ID)
-			return err == nil && st != manager.StateRunning
-		}, "job did not finish before test cleanup")
-	})
-
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+	setFakeHome(t)
+	jobID := startRunningJobForWait(t, 2*time.Second, "conv-timeout-test", 5*time.Second)
 
 	var out, errb bytes.Buffer
-	code := waitJobMain([]string{"-timeout", "100ms", job.ID}, &out, &errb)
+	code := waitJobMain([]string{"-timeout", "100ms", jobID}, &out, &errb)
 	if code != 3 {
 		t.Fatalf("exit code = %d, want 3 (stdout: %s, stderr: %s)", code, out.String(), errb.String())
 	}
@@ -145,60 +33,36 @@ func TestWaitJobInterrupted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", t.TempDir())
+	setFakeHome(t)
+	jobID := startRunningJobForWait(t, 5*time.Second, "conv-interrupt-test", 10*time.Second)
 
-	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 5 * time.Second})
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
-	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
-		AgyPath:   agy,
-		CachePath: cachePath,
-		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-interrupt-test"),
-	})
-	stateDir := t.TempDir()
-	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
-		DefaultTimeout: time.Minute, MaxConcurrency: 4,
-		ConversationCacheFile: cachePath}
-	mgr := manager.New(c)
-
-	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Drain the started job once the test is done, so the 5s fake agy never
-	// outlives the test.
-	t.Cleanup(func() {
-		testutil.WaitFor(t, 10*time.Second, func() bool {
-			st, err := mgr.State(job.ID)
-			return err == nil && st != manager.StateRunning
-		}, "job did not finish before test cleanup")
-	})
-
-	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
-
-	cmd := exec.Command(bin, "wait-job", "-timeout", "1h", job.ID)
+	cmd := exec.Command(bin, "wait-job", "-timeout", "1h", jobID)
 	var out, errb bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errb
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	// Give the child a moment to run signal.NotifyContext (the first thing
-	// waitForJob does) before signalling it. wait-job produces no observable
-	// side effect until it goes terminal, so there is no file or output to poll
-	// for readiness the way TestRunJobCancelViaSignal polls for the supervisor's
-	// out/err files; the job itself sleeps 5s, leaving ample margin either way.
+	// Kill and reap the child if the test aborts before the happy-path Wait below,
+	// so neither it nor its fake agy leaks.
+	reaped := false
+	t.Cleanup(func() {
+		if !reaped {
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+			_ = cmd.Wait()
+		}
+	})
+	// waitForJob resolves the wait config and constructs the manager before
+	// waitForJobWith installs the signal.NotifyContext handler, so this margin
+	// covers that whole pre-handler window. wait-job produces no observable side
+	// effect until it goes terminal, so there is nothing to poll for readiness; the
+	// job sleeps 5s, leaving ample margin either way.
 	time.Sleep(300 * time.Millisecond)
 	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
 		t.Fatal(err)
 	}
 	waitErr := cmd.Wait()
+	reaped = true
 	exitErr, ok := errors.AsType[*exec.ExitError](waitErr)
 	if !ok {
 		t.Fatalf("wait-job did not exit with an error after SIGINT: %v (stdout=%q stderr=%q)", waitErr, out.String(), errb.String())

--- a/waitcmd_posix_test.go
+++ b/waitcmd_posix_test.go
@@ -4,10 +4,13 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -128,5 +131,79 @@ func TestWaitJobTimeout(t *testing.T) {
 	code := waitJobMain([]string{"-timeout", "100ms", job.ID}, &out, &errb)
 	if code != 3 {
 		t.Fatalf("exit code = %d, want 3 (stdout: %s, stderr: %s)", code, out.String(), errb.String())
+	}
+}
+
+// TestWaitJobInterrupted proves SIGINT during a wait maps to exit 130
+// (128+SIGINT, the POSIX interrupt convention), not the generic error exit 1.
+// waitJobMain runs in-process for the other tests, but a SIGINT sent to the
+// test binary itself would kill the whole test run, so this execs the real
+// binary as a child and signals that instead, mirroring
+// TestRunJobCancelViaSignal's approach for run-job.
+func TestWaitJobInterrupted(t *testing.T) {
+	bin, err := buildBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: 5 * time.Second})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:   agy,
+		CachePath: cachePath,
+		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, "conv-interrupt-test"),
+	})
+	stateDir := t.TempDir()
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	mgr := manager.New(c)
+
+	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain the started job once the test is done, so the 5s fake agy never
+	// outlives the test.
+	t.Cleanup(func() {
+		testutil.WaitFor(t, 10*time.Second, func() bool {
+			st, err := mgr.State(job.ID)
+			return err == nil && st != manager.StateRunning
+		}, "job did not finish before test cleanup")
+	})
+
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	cmd := exec.Command(bin, "wait-job", "-timeout", "1h", job.ID)
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Give the child a moment to run signal.NotifyContext (the first thing
+	// waitForJob does) before signalling it. wait-job produces no observable
+	// side effect until it goes terminal, so there is no file or output to poll
+	// for readiness the way TestRunJobCancelViaSignal polls for the supervisor's
+	// out/err files; the job itself sleeps 5s, leaving ample margin either way.
+	time.Sleep(300 * time.Millisecond)
+	if err := cmd.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatal(err)
+	}
+	waitErr := cmd.Wait()
+	exitErr, ok := errors.AsType[*exec.ExitError](waitErr)
+	if !ok {
+		t.Fatalf("wait-job did not exit with an error after SIGINT: %v (stdout=%q stderr=%q)", waitErr, out.String(), errb.String())
+	}
+	if code := exitErr.ExitCode(); code != 130 {
+		t.Fatalf("exit code = %d, want 130 (stdout=%q stderr=%q)", code, out.String(), errb.String())
 	}
 }

--- a/waitcmd_posix_test.go
+++ b/waitcmd_posix_test.go
@@ -74,6 +74,7 @@ func TestWaitJobUnknownJob(t *testing.T) {
 }
 
 func TestWaitJobUsage(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	var out, errb bytes.Buffer
 	if code := waitJobMain(nil, &out, &errb); code != 2 {
 		t.Fatalf("waitJobMain(nil) = %d, want 2 (stderr: %s)", code, errb.String())

--- a/waitcmd_shared_test.go
+++ b/waitcmd_shared_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/jobstore"
+)
+
+// setFakeHome points the home-directory lookup at a fresh temp dir on both Unix
+// (HOME) and Windows (USERPROFILE, which os.UserHomeDir reads there), so a test
+// that resolves the wait config stays hermetic and never touches the real user's
+// agy conversation cache on either platform.
+func setFakeHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
+// writeTerminalJob creates <stateDir>/jobs/<id> holding a done job: meta.json
+// (CaptureDisabled: true so the wait manager never reads the host's real agy
+// conversation cache), an out file "RESULT", and an exit_code sentinel "0". It
+// writes only files, so it and the tests that use it run on Windows too.
+func writeTerminalJob(t *testing.T, stateDir, id string) {
+	t.Helper()
+	dir := filepath.Join(stateDir, "jobs", id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := jobstore.Meta{ID: id, StartedAt: time.Now(), CaptureDisabled: true}
+	b, err := jsonMarshalForTest(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobstore.MetaPath(dir), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobstore.OutPath(dir), []byte("RESULT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobstore.ExitCodePath(dir), []byte("0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// hookPayload builds the stdin JSON hook-wait expects from a PostToolUse hook,
+// with the given state carried in the tool response (the state the tool call
+// itself observed, distinct from whatever the job's state is on disk by the time
+// the hook runs).
+func hookPayload(tool, id, state string) string {
+	return fmt.Sprintf(`{"tool_name":%q,"tool_response":{"job_id":%q,"state":%q}}`, tool, id, state)
+}

--- a/waitcmd_test.go
+++ b/waitcmd_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The file-based wait-job tests live in this untagged file (not the posix one)
+// so they run on Windows CI too; they only read and write files and never exec a
+// shell fake or send a signal.
+
+func TestWaitJobDoneJob(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	writeTerminalJob(t, stateDir, "job-done-1")
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var out, errb bytes.Buffer
+	code := waitJobMain([]string{"job-done-1"}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errb.String())
+	}
+	if out.String() != "done\n" {
+		t.Fatalf("stdout = %q, want %q", out.String(), "done\n")
+	}
+}
+
+func TestWaitJobUnknownJob(t *testing.T) {
+	setFakeHome(t)
+	stateDir := t.TempDir()
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+
+	var out, errb bytes.Buffer
+	code := waitJobMain([]string{"nope"}, &out, &errb)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (stderr: %s)", code, errb.String())
+	}
+	if !strings.Contains(errb.String(), "nope") {
+		t.Fatalf("stderr = %q, want it to mention the failing job", errb.String())
+	}
+}
+
+func TestWaitJobUsage(t *testing.T) {
+	setFakeHome(t)
+	var out, errb bytes.Buffer
+	if code := waitJobMain(nil, &out, &errb); code != 2 {
+		t.Fatalf("waitJobMain(nil) = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+	out.Reset()
+	errb.Reset()
+	if code := waitJobMain([]string{"a", "b"}, &out, &errb); code != 2 {
+		t.Fatalf("waitJobMain(a, b) = %d, want 2 (stderr: %s)", code, errb.String())
+	}
+}

--- a/waitfixtures_posix_test.go
+++ b/waitfixtures_posix_test.go
@@ -1,0 +1,63 @@
+//go:build linux || darwin
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+	"github.com/tphakala/agy-mcp/internal/testutil"
+)
+
+// startRunningJobForWait starts a real job under a fake agy that sleeps for the
+// given duration and a fake supervisor that records convLabel in the agy
+// conversation cache. It points AGY_MCP_STATE_DIR at the job's state dir and
+// registers a cleanup that drains the job (within drainTimeout) so the slow fake
+// agy never outlives the test. It returns the job id. Shared by the wait-job and
+// hook-wait tests that need an observably-running job (the timeout and
+// signal-interrupt paths), which is why the fixture writes shell-script fakes and
+// stays posix-tagged. It assumes the caller already set a fake home (setFakeHome)
+// for the wait manager the subcommand under test resolves.
+func startRunningJobForWait(t *testing.T, sleep time.Duration, convLabel string, drainTimeout time.Duration) string {
+	t.Helper()
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0, Sleep: sleep})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:   agy,
+		CachePath: cachePath,
+		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, convLabel),
+	})
+	stateDir := t.TempDir()
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	mgr := manager.New(c)
+
+	job, err := mgr.StartJob(manager.StartRequest{Prompt: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain the started job once the test is done, so the slow fake agy never
+	// outlives the test.
+	t.Cleanup(func() {
+		testutil.WaitFor(t, drainTimeout, func() bool {
+			st, err := mgr.State(job.ID)
+			return err == nil && st != manager.StateRunning
+		}, "job did not finish before test cleanup")
+	})
+
+	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
+	return job.ID
+}


### PR DESCRIPTION
## Summary

MCP clients cannot be woken by server-side notifications when an async agy job finishes, so callers had to poll agy_status. This PR adds push-style completion waking built on a shared blocking-wait primitive: manager.WaitTerminal polls job state with the same semantics the agy_run_sync loop used (250ms cadence, terminal detection, conversation-id capture grace) and now also covers cross-process waiters via a completion-recency window backed by a concluded-capture marker, so an id captured moments after completion is not lost to a waiting process.

On top of it: the agy_run_sync tool is refactored onto shared helpers with wire behavior preserved; a new `agy_wait` MCP tool blocks on an already-started job (one call replaces an agy_status poll loop); `agy-mcp wait-job` gives shell scripts a blocking wait with exit codes 0/1/2/3/130; and `agy-mcp hook-wait` bridges completion into Claude Code's asyncRewake hook mechanism: it reads the PostToolUse payload from stdin, waits for the referenced job, and exits 2 with a one-line stderr message to wake the model, exiting 0 silently otherwise so a hook failure can never disrupt the tool flow. An interrupted wait also wakes rather than dying silently. The hook payload parser probes structuredContent before content deterministically, bounds stdin and its walk, and never panics on adversarial shapes (fuzz-tested).

Config gains ResolveWait, an agy-free resolver for the wait-only subcommands (state dir plus its own executable for the liveness fallback; the state dir is now absolutized so a relative override cannot split the job store across processes). The README documents the hook setup, timeout margins, and the state-dir environment caveat.

## Test Plan

- [x] Full suite green under -race on Linux; golangci-lint 0 issues
- [x] New coverage: 10 WaitTerminal tests including cross-process grace and capture-disabled discriminators and grace-cancel; 5 agy_wait tests; hookinput table tests, depth guard, and FuzzParse; hook-wait wake/quiet/overrun/interrupt tests (interrupt via exec + real SIGINT); wait-job exit-code tests including SIGINT to 130; file-based tests untagged so they run on Windows CI
- [x] End-to-end dogfood: wait-job built from this branch blocked on a live job in the real state dir and woke on completion