### PR TITLE
manager: release cross-process lock before gate slot in releaseKey

### DIFF
--- a/internal/manager/admit.go
+++ b/internal/manager/admit.go
@@ -37,11 +37,27 @@ func (m *Manager) admit(key string) (acquireOutcome, error) {
 // for key. It pairs with admit and forceAdmit. The cross-process unlock is a no-op
 // for a key this process does not hold (a restored job whose lock a sibling held),
 // so it is always safe on the run's completion path.
+//
+// Release order mirrors admit's acquire order in reverse: admit takes the gate slot
+// first, then the cross-process lock, so releaseKey drops the cross-process lock
+// first, then the gate slot. Releasing the gate slot LAST is what makes the fix for
+// issue #81 correct rather than merely narrower: because admit checks the gate before
+// ever reaching xlock.tryLock, holding the gate key until the lock is already gone
+// means any concurrent same-key admit either bounces cleanly off the still-held gate
+// (acquireKeyBusy) or, once it passes the gate, is guaranteed the lock is free. The
+// gate.mu release-before-acquire edge orders this xlock.unlock ahead of that admit's
+// later xlock.tryLock. Releasing in the other order exposed a transient window where
+// the gate key was free but this process's own lock fd was still held, so a same-key
+// admit hit xlock's duplicate guard and surfaced a self-inflicted "already held by
+// this process" error instead of a clean refusal.
 func (m *Manager) releaseKey(key string) {
-	m.gate.release(key)
 	if key != "" {
 		m.xlock.unlock(key)
 	}
+	if m.testHookMidRelease != nil {
+		m.testHookMidRelease()
+	}
+	m.gate.release(key)
 }
 
 // forceAdmit tracks an already-running restored job (whose detached supervisor

--- a/internal/manager/admit_posix_test.go
+++ b/internal/manager/admit_posix_test.go
@@ -152,3 +152,45 @@ func TestForceAdmitTracksDespiteSiblingLock(t *testing.T) {
 		t.Fatalf("m3.admit while m2 still holds = (%v, %v), want (acquireKeyBusy, nil)", outcome, err)
 	}
 }
+
+// TestReleaseKeyReleasesCrossLockBeforeGate pins the release-ordering invariant from
+// issue #81: releaseKey must drop the cross-process lock BEFORE the in-process gate
+// slot, mirroring admit's acquire order (gate first, then xlock). If it releases in
+// the same order it acquires, the intermediate state "gate key free but this
+// process's own xlock fd still held" becomes observable: a concurrent same-key admit
+// passes gate.tryAcquire, then xlock.tryLock hits its own duplicate guard and returns
+// the self-inflicted error `crosslock: key %q already held by this process` instead
+// of a clean acquireKeyBusy refusal.
+//
+// The testHookMidRelease seam fires synchronously between releaseKey's two unlock
+// steps, so the concurrent admit is interposed at exactly the intermediate point with
+// no timing dependence (no goroutines, no sleeps). On the correct order the interposed
+// admit sees the gate key still held and returns (acquireKeyBusy, nil); on the buggy
+// order it sees the gate free but the lock held and returns (acquireOK, non-nil error).
+func TestReleaseKeyReleasesCrossLockBeforeGate(t *testing.T) {
+	m := newManager(t, managerOpts{maxConcurrency: 4})
+	const key = "cwd:/w"
+
+	if outcome, err := m.admit(key); err != nil || outcome != acquireOK {
+		t.Fatalf("admit = (%v, %v), want (acquireOK, nil)", outcome, err)
+	}
+
+	var midOutcome acquireOutcome
+	var midErr error
+	m.testHookMidRelease = func() {
+		m.testHookMidRelease = nil // fire once; the interposed admit must not re-enter
+		midOutcome, midErr = m.admit(key)
+	}
+
+	m.releaseKey(key)
+
+	if midErr != nil {
+		t.Fatalf("concurrent same-key admit interposed during releaseKey returned error %v; "+
+			"releaseKey must free the cross-process lock before the gate slot so the "+
+			"intermediate state is never observable", midErr)
+	}
+	if midOutcome != acquireKeyBusy {
+		t.Fatalf("concurrent same-key admit interposed during releaseKey = %v, want acquireKeyBusy "+
+			"(the gate key must stay held until the cross-process lock is released)", midOutcome)
+	}
+}

--- a/internal/manager/cleanup_posix_test.go
+++ b/internal/manager/cleanup_posix_test.go
@@ -102,17 +102,19 @@ func waitForEmptyStore(t *testing.T, m *Manager) {
 //   - "concurrency cap": admit's acquireAtCap branch, a sibling refusal for the
 //     same class of outcome (see concurrency.go's comment on why the two are
 //     reported with different text).
-//   - "already held by this process": releaseKey releases the in-process gate
-//     slot before the cross-process lock (admit.go), so a retry landing in that
-//     narrow window can observe the gate as free while xlock.tryLock still hits
-//     its own duplicate guard (keylock.go). Tracked for a real fix in #81; this
-//     is the test-side tolerance for it in the meantime.
+//
+// It deliberately does NOT tolerate "already held by this process": that was a
+// stopgap for the issue #81 self-race, where releaseKey released the in-process
+// gate slot before the cross-process lock and a same-key retry could observe the
+// gate free while xlock.tryLock still hit its own duplicate guard. releaseKey now
+// releases the cross-process lock first (admit.go), so that window is closed and
+// the error is unreachable through the admit path; a retry loop seeing it again
+// would be a real regression, not a transient to swallow.
 func isRetryableGateRefusal(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "conflicting") ||
-		strings.Contains(msg, "concurrency cap") ||
-		strings.Contains(msg, "already held by this process")
+		strings.Contains(msg, "concurrency cap")
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -81,6 +81,13 @@ type Manager struct {
 	// sysctl read failure (not reliably reproducible for a real child process)
 	// and without any risk of a package-level var leaking into another test.
 	readStartTimeTicks func(int) (uint64, bool)
+
+	// testHookMidRelease, when non-nil, is invoked by releaseKey between its two
+	// unlock steps (the cross-process xlock.unlock and the in-process gate.release).
+	// It exists only so a test can deterministically interpose a concurrent admit at
+	// that intermediate point and pin the release-ordering invariant (issue #81);
+	// production leaves it nil, so the check is a single never-taken branch.
+	testHookMidRelease func()
 }
 
 // defaultCaptureBudget bounds how long captureFreshConversationID waits for
@@ -456,12 +463,20 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	grp, err := proc.Track(cmd, false)
 	if err != nil {
 		// Started but untrackable (Track only fails before Start, which succeeded).
-		// Fail closed: kill the supervisor, reap it in the background, and clean up.
+		// Fail closed: kill the supervisor, then reap it and clean up in the
+		// background, releasing the gate key only once it has fully exited. Releasing
+		// after the supervisor is gone (rather than synchronously here) keeps a
+		// conflicting same-key run from starting while the dying agy still holds its
+		// session lock, matching abortSpawn's teardown contract. Track failed, so
+		// there is no group handle to terminate; the direct process Kill is all that
+		// is available.
 		_ = cmd.Process.Kill()
-		go func() { _ = cmd.Wait() }()
-		_ = m.store.Remove(id)
-		m.pendingCaptures.Delete(id)
-		m.releaseKey(key)
+		go func() {
+			_ = cmd.Wait()
+			_ = m.store.Remove(id)
+			m.pendingCaptures.Delete(id)
+			m.releaseKey(key)
+		}()
 		return Job{}, fmt.Errorf("track supervisor: %w", err)
 	}
 	// Record the supervisor PID (for liveness and cancel) and its start time (so a


### PR DESCRIPTION
Fixes #81.

## The bug

`admit()` reserves the in-process gate slot first, then the cross-process advisory lock (`gate.tryAcquire` then `xlock.tryLock`). `releaseKey()` released them in the *same* order (gate first), which left a transient window where the gate key was already free but this process still held its own crosslock fd. A concurrent same-key `StartJob` landing in that window passed `gate.tryAcquire`, then hit `crossLock.tryLock`'s own duplicate guard and failed with `crosslock: key "..." already held by this process`. That is a self-inflicted transient, and unlike the normal `acquireKeyBusy` refusal it does not carry "conflicting", so the same-key retry predicate did not recognize it. The window is a single uncontended mutex plus a `Close()` syscall wide, which is why 100 stress runs under `-race` never reproduced it.

## The fix

`releaseKey` now releases the cross-process lock first, then the gate slot, mirroring `admit`'s acquire order in reverse. This is provably correct, not just narrower: `admit` checks the gate before it ever reaches `xlock.tryLock`, so with the gate key released *last*, any concurrent same-key admit either bounces cleanly off the still-held gate (`acquireKeyBusy`) or, once it passes the gate, is guaranteed the lock is already free. The `gate.mu` release-before-acquire edge orders this process's `xlock.unlock` ahead of the concurrent admit's later `xlock.tryLock`, so the duplicate-guard error is unreachable through the admit path.

The new intermediate state (cross-process lock free, gate key still held) only ever produces a clean `acquireKeyBusy` refusal. Releasing the flock a hair earlier is safe with respect to sibling processes: a sibling taking it sooner is exactly what the flock is for, and for fresh runs the conversation-id capture completes before `releaseKey` runs.

## Regression test

`TestReleaseKeyReleasesCrossLockBeforeGate` pins the ordering invariant deterministically. It installs a test-only `Manager` seam that fires between `releaseKey`'s two release steps and synchronously interposes a concurrent same-key `admit` at exactly the intermediate point (no goroutines, no sleeps, nothing timing-dependent). It asserts the interposed admit returns `(acquireKeyBusy, nil)`; on the old order it returned `(acquireOK, non-nil error)`, so the test is red before the fix and green after. The seam follows the existing `readStartTimeTicks` per-instance test-seam precedent (unexported, nil in production, a single never-taken branch).

## Two related loose ends closed here

- The test retry helper `isRetryableGateRefusal` still tolerated the `already held by this process` error. That was the test-side stopgap for this issue; with the root cause fixed the error is unreachable through the admit path, so the tolerance is removed (a retry loop seeing it again would be a real regression to surface, not a transient to swallow).
- `StartJob`'s `proc.Track`-failure path released the gate key synchronously in the foreground while the killed, untrackable supervisor was still being reaped in the background. That contradicts `abortSpawn`'s documented contract ("release only after the agy process group is gone keeps a conflicting same-key run from starting while the dying agy still holds its session lock"). Its cleanup now runs inside the reap goroutine, after `cmd.Wait()`, matching that contract. This path is effectively Windows-only (on posix `Track` only fails before `Start`, which already succeeded here).

## Verification

- `go build ./...`, `go vet ./...`, and `golangci-lint run` clean.
- Full suite green under `-race`.
- The regression test confirmed red on the old release order and green on the new.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job admission reliability during concurrent starts and shutdowns.
  * Prevented resource locks from being released prematurely while a failed supervisor is still exiting.
  * Refined retry handling to avoid masking unexpected self-conflict errors.

* **Tests**
  * Added coverage for lock-release ordering and concurrent same-key admission scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->