### PR TITLE
mcptools: advertise MCP server instructions and name tool use cases

### DIFF
--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -34,9 +34,11 @@ type runSyncOutput struct {
 func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: toolAgyRunSync,
-		Description: "Start an agy prompt and wait for it inline (bounded by wait, default 2m). " +
+		Description: "Delegate a prompt to an agy model and wait for the result inline (bounded by wait, default 2m). " +
+			"Use for peer review, a second opinion, research, or any task whose answer you need before your next step. " +
 			"Sends MCP progress notifications while waiting. If the job outlives the wait cap " +
-			"it keeps running and the returned job_id can be polled with agy_status.",
+			"it keeps running and the returned job_id can be polled with agy_status or waited on with agy_wait. " +
+			"For long runs or parallel work, prefer agy_run.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in runSyncInput) (*mcp.CallToolResult, runSyncOutput, error) {
 		wait, err := parseWait(in.Wait)
 		if err != nil {

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -172,3 +172,47 @@ func TestHTTPServeListsTools(t *testing.T) {
 		}
 	}
 }
+
+// TestHTTPServeAdvertisesInstructions guards the discovery surface: the server
+// must send a non-empty MCP instructions string at initialize (a regression to
+// nil ServerOptions would silently drop it), and the entry-point tools must keep
+// naming their use cases so a client under-reaching for them is less likely.
+func TestHTTPServeAdvertisesInstructions(t *testing.T) {
+	handler := HTTPHandler(testManager(t), "")
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "t", Version: "0"}, nil)
+	ctx := t.Context()
+	cs, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: ts.URL}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	init := cs.InitializeResult()
+	if init == nil {
+		t.Fatal("no InitializeResult")
+	}
+	// Spot-check anchors, not the full text: a use-case cue, the sync entry-point
+	// tool name, and the parallelism caveat that mirrors the cwd conflict error.
+	for _, want := range []string{"Peer review", "agy_run_sync", "conflict error"} {
+		if !strings.Contains(init.Instructions, want) {
+			t.Errorf("server instructions missing %q; got:\n%s", want, init.Instructions)
+		}
+	}
+
+	tools, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	desc := make(map[string]string, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		desc[tool.Name] = tool.Description
+	}
+	for _, name := range []string{"agy_run", "agy_run_sync"} {
+		if !strings.Contains(desc[name], "peer review") {
+			t.Errorf("tool %q description no longer names a use case: %q", name, desc[name])
+		}
+	}
+}

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -131,13 +131,39 @@ var serverVersion = sync.OnceValue(func() string {
 	return "dev"
 })
 
+// serverInstructions is the MCP instructions string sent to clients at
+// initialize (injected into the client's system prompt). It is neutral
+// capability documentation: what agy is for and when a client should reach for
+// these tools. It deliberately encodes no single client's conventions or policy
+// (model choice, working-directory habits, review etiquette); those belong in
+// that client's own configuration, not in a server shared by everyone.
+const serverInstructions = `agy delegates a prompt to a background coding agent and manages the run as a restart-resilient job with output captured to disk. Use it to get an independent perspective or to offload self-contained work while you keep going:
+
+- Peer review: have another model review code, a design, or a plan for bugs, security, and correctness.
+- Rubber-duck: talk through a decision and get pushback that catches blind spots your own reasoning would skip.
+- Research: fact-check a claim or look into a topic.
+- Background delegation: fire off an independent task and reconcile the result later, so two things run at once.
+
+Choosing a tool:
+- agy_run_sync starts a run and waits inline (bounded by the wait argument). Use it when you need the answer before your next step.
+- agy_run returns a job_id immediately; poll it with agy_status or block on it with agy_wait. Use these for long runs or to fan several tasks out in parallel.
+- list_models enumerates models; call it only if you want to override the default. list_sessions lists known conversations.
+
+Notes:
+- Continue a prior thread with conversation_id or continue_latest instead of restating context.
+- Fresh runs sharing a cwd are not queued; a concurrent attempt returns a conflict error. To run tasks in parallel, continue an existing conversation or use a different directory.
+- agy runs a full agent that can edit files. For a review that must not touch the repo, say so explicitly in the prompt.
+- Always reconcile a backgrounded run: poll it to completion and fold the result back in.`
+
 // NewServer builds an MCP server with all agy tools registered.
 func NewServer(mgr *manager.Manager) *mcp.Server {
-	s := mcp.NewServer(&mcp.Implementation{Name: "agy-mcp", Version: serverVersion()}, nil)
+	s := mcp.NewServer(&mcp.Implementation{Name: "agy-mcp", Version: serverVersion()}, &mcp.ServerOptions{
+		Instructions: serverInstructions,
+	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        toolAgyRun,
-		Description: "Start an agy prompt (e.g. a peer review) as an async job. Returns a job_id to poll with agy_status.",
+		Description: "Delegate a prompt to a background agy model as an async job (peer review, research, or any self-contained task) and keep working. Returns a job_id; poll with agy_status or block with agy_wait. Prefer this over agy_run_sync for long runs or to fan several tasks out in parallel.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runInput) (*mcp.CallToolResult, runOutput, error) {
 		req, err := in.toStartRequest()
 		if err != nil {
@@ -183,7 +209,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 	registerWait(s, mgr)
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: toolListModels, Description: "List available agy models.",
+		Name: toolListModels, Description: "List available agy models. Call this to see the options if you want to override the default model for agy_run or agy_run_sync.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ emptyInput) (*mcp.CallToolResult, modelsOutput, error) {
 		models, err := mgr.ListModels(ctx)
 		if err != nil {


### PR DESCRIPTION
## Summary

agy-mcp constructed its MCP server with `nil` ServerOptions, so it advertised no `instructions` string at initialize and its tool descriptions were terse one-liners. Connecting clients (Claude Code and others) under-reached for the tools as a result.

This wires `ServerOptions.Instructions` with neutral, general-audience capability docs: what agy is for (peer review, a rubber-duck second opinion, online research, background delegation) and when to reach for sync vs async. The `agy_run`, `agy_run_sync`, and `list_models` tool descriptions are enriched to name their use cases too, so they carry discovery weight even when a client defers tool schemas until searched. The instructions are deliberately client-agnostic: any single client's own conventions (model choice, working-directory habits, review etiquette) belong in that client's config, not in a server shared by everyone.

A new test, `TestHTTPServeAdvertisesInstructions`, connects an in-memory MCP client over the Streamable HTTP transport and asserts the server advertises a non-empty instructions string and that the entry-point tool descriptions still name a use case, guarding against a regression back to `nil` ServerOptions or terse, use-case-free descriptions.

## Test Plan

- [x] `go build ./...`, `go vet ./internal/mcptools/`, `gofmt` clean, `golangci-lint` 0 issues
- [x] `go test ./internal/mcptools/` passes, including the new test
- [x] Verified the new test fails on the pre-change code (empty instructions, terse descriptions), so it is not vacuously green