### PR TITLE
hookwait: frame completion wake as a notification, not an error

### DIFF
--- a/docs/superpowers/plans/2026-06-11-conversation-id-capture.md
+++ b/docs/superpowers/plans/2026-06-11-conversation-id-capture.md
@@ -1,0 +1,1350 @@
+# Conversation ID Capture Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix GitHub issue tphakala/agy-mcp#23: agy_run_sync must not return `done` without a conversation id for a fresh run, lazy capture must not misattribute another run's conversation, restored jobs must capture like normal ones, and torn cache reads must be detected instead of swallowed.
+
+**Architecture:** agy-mcp captures conversation ids by diffing agy's `last_conversations.json` cache (keyed by cwd) against a pre-run snapshot, because agy mints its own UUID for fresh runs. The cache is flushed by a separate agy daemon that can lag the process exit, so the manager's completion goroutine retries the diff for a bounded budget while holding the run's gate key. This plan (a) makes the test fixture reproduce the real-world ordering (exit sentinel first, cache later), (b) introduces an explicit "capture pending" state on the Manager that agy_run_sync polls through instead of returning early, (c) mirrors the capture in the restored-job watcher, (d) makes cache reads error-aware with a per-run `CaptureDisabled` flag when the pre-run snapshot is unreadable, and (e) guards the lazy (post-restart) capture against attributing a later same-cwd run's id, with a permanent "settled" memo once a capture can no longer succeed.
+
+**Tech Stack:** Go 1.26, stdlib only (`sync`, `time`, `encoding/json`), MCP go-sdk for the tool layer, bash-script test fakes in `internal/testutil`. Job supervision tests are Linux-only (the suite already assumes this).
+
+**Branch:** create `fix/conversation-id-capture` off `main` before Task 1:
+
+```bash
+git -C /home/thakala/src/agy-mcp switch -c fix/conversation-id-capture
+```
+
+All paths below are relative to `/home/thakala/src/agy-mcp`.
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `internal/testutil/fakesupervisor.go` | Write `exit_code` before the cache; new `CacheDelay` field to simulate the cache-daemon lag |
+| `internal/manager/conversation.go` | `loadCache` returns errors; `snapshotCwd` gains an ok result; retry helper |
+| `internal/jobstore/store.go` | New `Meta.CaptureDisabled` field |
+| `internal/config/config.go` | New `Config.ConversationCacheFile` override (test seam) |
+| `internal/manager/manager.go` | Pending-capture tracking, `CapturePending`, `CaptureDisabled` handling in StartJob, watchRestored capture, lazy-capture guards + settle memo |
+| `internal/mcptools/run_sync.go` | Poll through a pending capture instead of returning done-with-no-id |
+| `internal/manager/conversation_test.go` | Update for new signatures; new loadCache unit tests |
+| `internal/manager/capture_linux_test.go` | New tests: CaptureDisabled, CapturePending lifecycle, later-run guard, settle horizon |
+| `internal/manager/restore_linux_test.go` | New test: watcher captures id for restored fresh run |
+| `internal/mcptools/run_sync_test.go` | newTestManager gets a real cache; new late-cache regression test |
+
+---
+
+### Task 1: Test fixture realism: exit sentinel before cache, optional cache lag
+
+The fake supervisor currently writes the cache payload BEFORE `exit_code`, the inverse of reality (the supervisor writes `exit_code` the moment agy exits; agy's cache daemon flushes the cache around or after that). This ordering is what masks the run_sync bug. Flip it, and add a `CacheDelay` knob that writes the cache from a backgrounded subshell after the script exits, which is exactly the real daemon-lag shape.
+
+**Files:**
+- Modify: `internal/testutil/fakesupervisor.go`
+
+- [ ] **Step 1: Update the FakeSupervisor struct and doc comments**
+
+In `internal/testutil/fakesupervisor.go`, replace the `CachePath`/`CacheJSON` field comments and add `CacheDelay`. Replace:
+
+```go
+	// CachePath, when set, makes the script write CacheJSON to that path
+	// before exit_code, mimicking agy persisting its conversation cache.
+	CachePath string
+	// CacheJSON is the cache payload to write; requires CachePath.
+	CacheJSON string
+}
+```
+
+with:
+
+```go
+	// CachePath, when set, makes the script write CacheJSON to that path
+	// after exit_code, mimicking the real ordering: the supervisor writes the
+	// exit sentinel at process exit, and agy's cache daemon flushes the
+	// conversation cache around or after that moment.
+	CachePath string
+	// CacheJSON is the cache payload to write; requires CachePath.
+	CacheJSON string
+	// CacheDelay, when positive, writes the cache from a backgrounded subshell
+	// that sleeps this long first, so the cache lands only after the script
+	// (and its exit_code) is gone. This reproduces the cache-daemon lag that
+	// the manager's capture retry exists for. Requires CachePath.
+	CacheDelay time.Duration
+}
+```
+
+Add `"time"` to the imports.
+
+Then update the WriteFakeSupervisor doc comment: replace the sentence
+
+```go
+// shell quoting. exit_code is always written last because the manager treats
+// its presence as job completion.
+```
+
+with:
+
+```go
+// shell quoting. exit_code is written before the cache payload, matching the
+// real ordering the manager must tolerate: job completion (the sentinel) can
+// be observable before the conversation cache has been flushed.
+```
+
+- [ ] **Step 2: Reorder the script generation and implement CacheDelay**
+
+In `WriteFakeSupervisor`, add the validation right after the existing CacheJSON check:
+
+```go
+	if cfg.CacheDelay > 0 && cfg.CachePath == "" {
+		t.Fatal("FakeSupervisor: CacheDelay requires CachePath")
+	}
+```
+
+Then replace the script-assembly block:
+
+```go
+	if cfg.CachePath != "" {
+		cachePayload := filepath.Join(dir, "cache-payload.json")
+		if err := os.WriteFile(cachePayload, []byte(cfg.CacheJSON), 0o644); err != nil {
+			t.Fatalf("write fake supervisor cache payload: %v", err)
+		}
+		fmt.Fprintf(&sb, "cat %q > %q\n", cachePayload, cfg.CachePath)
+	}
+	sb.WriteString("printf '%s' \"$code\" > \"$dir/exit_code\"\n")
+```
+
+with:
+
+```go
+	sb.WriteString("printf '%s' \"$code\" > \"$dir/exit_code\"\n")
+	if cfg.CachePath != "" {
+		cachePayload := filepath.Join(dir, "cache-payload.json")
+		if err := os.WriteFile(cachePayload, []byte(cfg.CacheJSON), 0o644); err != nil {
+			t.Fatalf("write fake supervisor cache payload: %v", err)
+		}
+		if cfg.CacheDelay > 0 {
+			// Backgrounded so the script (the fake supervisor process) exits
+			// first and the cache lands later, like agy's real cache daemon.
+			fmt.Fprintf(&sb, "( sleep %.3f; cat %q > %q ) &\n",
+				cfg.CacheDelay.Seconds(), cachePayload, cfg.CachePath)
+		} else {
+			fmt.Fprintf(&sb, "cat %q > %q\n", cachePayload, cfg.CachePath)
+		}
+	}
+```
+
+- [ ] **Step 3: Run the affected packages**
+
+Run: `go test ./internal/testutil/... ./internal/manager/... ./internal/mcptools/... 2>&1 | tail -20`
+Expected: all PASS. `TestFreshRunCapturesConversationID` still passes because the manager's completion goroutine retries the capture for its 2s budget, which now genuinely exercises the retry. `TestFakeSupervisorWritesCache` still passes because it inspects files only after the script has exited, when both exist regardless of order.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/testutil/fakesupervisor.go
+git commit -m "test: fake supervisor writes exit_code before the conversation cache
+
+Matches the real ordering (sentinel at process exit, cache flushed by agy's
+daemon afterwards) and adds CacheDelay to simulate the daemon lag. The old
+inverted ordering masked the agy_run_sync done-without-id bug."
+```
+
+---
+
+### Task 2: Error-aware cache reads and CaptureDisabled
+
+`loadCache` currently swallows read and parse errors, so a torn read (agy rewrites the file with O_TRUNC and no lock) looks identical to "no entry". That silently degrades `continue_latest` and, when it hits the pre-run snapshot, sets up a misattribution: a snapshot that reads as "" makes a pre-existing conversation look newly created. Make errors visible, retry once (torn reads are transient), and when the snapshot still cannot be read, disable capture for that run via a persisted meta flag.
+
+**Files:**
+- Modify: `internal/manager/conversation.go` (full rewrite below)
+- Modify: `internal/jobstore/store.go` (one field)
+- Modify: `internal/manager/manager.go` (StartJob snapshot block, captureFreshConversationID guard, lazyCaptureConversationID guard)
+- Modify: `internal/manager/conversation_test.go`
+- Test: `internal/manager/conversation_test.go`, `internal/manager/capture_linux_test.go`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Append to `internal/manager/conversation_test.go`:
+
+```go
+func TestLoadCacheMissingFileIsEmptyNotError(t *testing.T) {
+	cache, err := loadCache(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Fatalf("a missing cache is a normal empty cache, got error: %v", err)
+	}
+	if len(cache) != 0 {
+		t.Fatalf("want empty cache, got %v", cache)
+	}
+}
+
+func TestLoadCacheTornReadIsError(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last_conversations.json")
+	if err := os.WriteFile(p, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadCache(p); err == nil {
+		t.Fatal("a torn/unparsable cache read must surface an error")
+	}
+}
+
+func TestResolveLatestNotFoundOnTornCache(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last_conversations.json")
+	if err := os.WriteFile(p, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resolveLatest(p, "/w"); ok {
+		t.Fatal("a torn cache must resolve to not-found, not to a bogus id")
+	}
+}
+
+func TestSnapshotCwdUnknownOnTornCache(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "last_conversations.json")
+	if err := os.WriteFile(p, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := snapshotCwd(p, "/w"); ok {
+		t.Fatal("a torn cache must report the snapshot as unknown")
+	}
+}
+
+func TestSnapshotCwdOkOnMissingCache(t *testing.T) {
+	before, ok := snapshotCwd(filepath.Join(t.TempDir(), "absent.json"), "/w")
+	if !ok || before != "" {
+		t.Fatalf("missing cache = valid empty snapshot, got %q,%v", before, ok)
+	}
+}
+```
+
+Also update the existing `TestCaptureNewUUIDByDiff` for the new two-value `snapshotCwd`:
+
+```go
+	before, ok := snapshotCwd(cache, "/w") // "old"
+	if !ok {
+		t.Fatal("snapshot should be readable")
+	}
+```
+
+(and keep using `before` below it as today).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/manager/ -run 'TestLoadCache|TestResolveLatest|TestSnapshotCwd|TestCaptureNewUUID' 2>&1 | tail -5`
+Expected: FAIL (compile errors: `loadCache` returns one value, `snapshotCwd` returns one value).
+
+- [ ] **Step 3: Rewrite conversation.go**
+
+Replace the entire content of `internal/manager/conversation.go` with:
+
+```go
+package manager
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// loadCache reads agy's conversation cache. A missing file is a normal empty
+// cache (fresh agy install, no conversations yet). A read or parse failure is
+// reported: agy rewrites the file in place (O_TRUNC, no lock), so a concurrent
+// read can be torn, and callers must not mistake a torn read for "no entry"
+// when the difference matters.
+func loadCache(cacheFile string) (map[string]string, error) {
+	b, err := os.ReadFile(cacheFile)
+	if errors.Is(err, fs.ErrNotExist) {
+		return map[string]string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var raw map[string]string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return nil, fmt.Errorf("parse conversation cache %s: %w", cacheFile, err)
+	}
+	return raw, nil
+}
+
+// loadCacheRetry reads the cache, retrying once on failure: torn reads are
+// transient (agy's rewrite completes in microseconds), so an immediate re-read
+// usually observes a complete file.
+func loadCacheRetry(cacheFile string) (map[string]string, error) {
+	cache, err := loadCache(cacheFile)
+	if err == nil {
+		return cache, nil
+	}
+	return loadCache(cacheFile)
+}
+
+// resolveLatest returns the most recent conversation UUID for cwd, if any. An
+// unreadable cache resolves to not-found: continue_latest then starts a fresh
+// conversation, the documented fallback for "no prior conversation".
+func resolveLatest(cacheFile, cwd string) (string, bool) {
+	cache, err := loadCacheRetry(cacheFile)
+	if err != nil {
+		return "", false
+	}
+	id, ok := cache[cwd]
+	return id, ok && id != ""
+}
+
+// snapshotCwd records the cwd's UUID before a run. ok=false means the snapshot
+// could not be taken (torn or corrupt cache even after a retry); the caller
+// must disable capture for the run rather than guess, because an empty-by-error
+// snapshot would make a pre-existing conversation look newly created.
+func snapshotCwd(cacheFile, cwd string) (string, bool) {
+	cache, err := loadCacheRetry(cacheFile)
+	if err != nil {
+		return "", false
+	}
+	return cache[cwd], true
+}
+
+// captureNewUUID returns the cwd's UUID after a run, but only if it changed
+// from the pre-run snapshot. A failed run leaves the cache untouched, and a
+// torn read yields no capture, so a single call never misattributes an old
+// conversation to this run. Both call sites sit in retry loops, so no internal
+// retry is needed here.
+func captureNewUUID(cacheFile, cwd, before string) (string, bool) {
+	cache, err := loadCache(cacheFile)
+	if err != nil {
+		return "", false
+	}
+	after := cache[cwd]
+	if after != "" && after != before {
+		return after, true
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 4: Add the Meta field**
+
+In `internal/jobstore/store.go`, after the `CwdUUIDBefore` field, add:
+
+```go
+	// CaptureDisabled marks a fresh run whose pre-run cache snapshot could not
+	// be read: without a trustworthy snapshot a post-run cache diff cannot be
+	// attributed safely, so conversation-id capture is skipped for this job.
+	CaptureDisabled bool `json:"capture_disabled,omitempty"`
+```
+
+- [ ] **Step 5: Wire CaptureDisabled through the manager**
+
+In `internal/manager/manager.go`:
+
+(a) Replace the StartJob snapshot block:
+
+```go
+	if req.ConversationID == "" {
+		meta.CwdUUIDBefore = snapshotCwd(m.cacheFile, cwd)
+	}
+```
+
+with:
+
+```go
+	if req.ConversationID == "" {
+		if before, ok := snapshotCwd(m.cacheFile, cwd); ok {
+			meta.CwdUUIDBefore = before
+		} else {
+			// No trustworthy pre-run snapshot: a post-run diff could attribute
+			// a pre-existing conversation to this run. Report no id instead.
+			meta.CaptureDisabled = true
+			log.Printf("agy-mcp: job %s: conversation cache unreadable; id capture disabled for this run", id)
+		}
+	}
+```
+
+(b) In `captureFreshConversationID`, replace the first guard:
+
+```go
+	if meta.ConversationID != "" {
+		return
+	}
+```
+
+with:
+
+```go
+	if meta.ConversationID != "" || meta.CaptureDisabled {
+		return
+	}
+```
+
+(c) In `lazyCaptureConversationID`, after the known-id guard, add:
+
+```go
+	if meta.CaptureDisabled {
+		return ""
+	}
+```
+
+- [ ] **Step 6: Run unit tests**
+
+Run: `go test ./internal/manager/ -run 'TestLoadCache|TestResolveLatest|TestSnapshotCwd|TestCaptureNewUUID|TestCaptureNoChange' -v 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 7: Write the failing end-to-end CaptureDisabled test**
+
+Append to `internal/manager/capture_linux_test.go`:
+
+```go
+// A fresh run started while the conversation cache is unreadable must disable
+// capture for that run: even when the cache later becomes readable with a new
+// entry, the id cannot be attributed to this run.
+func TestFreshRunWithCorruptCacheDisablesCapture(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{"torn`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := t.TempDir()
+
+	c := config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = cachePath
+	m.captureBudget = 50 * time.Millisecond
+	m.capturePoll = 10 * time.Millisecond
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	meta, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !meta.CaptureDisabled {
+		t.Fatal("expected CaptureDisabled for a run started with an unreadable cache")
+	}
+	waitForExitCode(t, m, job.ID)
+
+	// The cache "recovers" with an entry for this cwd; it must not be captured.
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, "aaaa1111-2222-3333-4444-555566667777")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st, err := m.Status(job.ID)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.ConversationID != "" {
+		t.Fatalf("capture-disabled run must report no id, got %q", st.ConversationID)
+	}
+}
+```
+
+- [ ] **Step 8: Run it (it should already pass; verify it tests the right thing)**
+
+Run: `go test ./internal/manager/ -run TestFreshRunWithCorruptCacheDisablesCapture -v 2>&1 | tail -5`
+Expected: PASS. To prove the test bites, temporarily revert step 5(c) (remove the `meta.CaptureDisabled` guard in lazyCaptureConversationID), rerun, and confirm it FAILS with `capture-disabled run must report no id`; then restore the guard.
+
+- [ ] **Step 9: Run the full suite and commit**
+
+Run: `go test ./... 2>&1 | tail -10`
+Expected: all PASS.
+
+```bash
+git add internal/manager/conversation.go internal/manager/conversation_test.go internal/manager/manager.go internal/manager/capture_linux_test.go internal/jobstore/store.go
+git commit -m "fix: detect torn conversation-cache reads instead of swallowing them
+
+loadCache now reports read/parse errors (a missing file stays a normal empty
+cache), resolveLatest retries once and falls through to fresh-run semantics,
+and an unreadable pre-run snapshot disables capture for that run via a new
+Meta.CaptureDisabled flag, closing the torn-snapshot misattribution edge."
+```
+
+---
+
+### Task 3: Config.ConversationCacheFile
+
+The mcptools tests construct managers via `manager.New(config.Config{...})` and cannot reach the unexported `cacheFile` field, so today they silently read the real `~/.gemini` cache. A config override fixes that and is the seam Task 4's tests need.
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/manager/manager.go` (New)
+- Test: `internal/manager/conversation_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/manager/conversation_test.go`:
+
+```go
+func TestNewUsesConfiguredCacheFile(t *testing.T) {
+	m := New(config.Config{StateDir: t.TempDir(), MaxConcurrency: 1,
+		ConversationCacheFile: "/tmp/agy-test-cache.json"})
+	if m.cacheFile != "/tmp/agy-test-cache.json" {
+		t.Fatalf("cacheFile = %q, want the configured override", m.cacheFile)
+	}
+}
+```
+
+Add `"github.com/tphakala/agy-mcp/internal/config"` to that file's imports.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./internal/manager/ -run TestNewUsesConfiguredCacheFile 2>&1 | tail -5`
+Expected: FAIL (compile error: unknown field ConversationCacheFile).
+
+- [ ] **Step 3: Add the config field**
+
+In `internal/config/config.go`, add to the `Config` struct (after the existing fields):
+
+```go
+	// ConversationCacheFile overrides where agy's conversation cache
+	// (last_conversations.json) is read from. Empty means agy's default
+	// location under the user's home. Primarily a test seam.
+	ConversationCacheFile string
+```
+
+`Resolve()` is unchanged (the zero value selects the default).
+
+- [ ] **Step 4: Use it in manager.New**
+
+In `internal/manager/manager.go`, replace inside `New`:
+
+```go
+		cacheFile:            agyCachePath(),
+```
+
+with:
+
+```go
+		cacheFile:            cmp.Or(c.ConversationCacheFile, agyCachePath()),
+```
+
+and add `"cmp"` to the imports.
+
+- [ ] **Step 5: Run and commit**
+
+Run: `go test ./internal/manager/ ./internal/config/ 2>&1 | tail -5`
+Expected: PASS.
+
+```bash
+git add internal/config/config.go internal/manager/manager.go internal/manager/conversation_test.go
+git commit -m "feat: allow overriding the agy conversation cache path via config"
+```
+
+---
+
+### Task 4: CapturePending and the agy_run_sync grace
+
+The core fix. The Manager tracks which jobs have a fresh-run capture "armed but not settled"; agy_run_sync keeps polling while a done job's capture is still pending instead of returning done-with-no-id. The bound is the manager's own captureBudget (the completion goroutine always clears the pending mark), so no new timeout constant is needed in mcptools.
+
+**Files:**
+- Modify: `internal/manager/manager.go`
+- Modify: `internal/mcptools/run_sync.go`
+- Modify: `internal/mcptools/run_sync_test.go`
+- Test: `internal/manager/capture_linux_test.go`, `internal/mcptools/run_sync_test.go`
+
+- [ ] **Step 1: Write the failing mcptools regression test**
+
+First rewire `newTestManager` in `internal/mcptools/run_sync_test.go` so fake runs produce a conversation id through a test-owned cache (this also stops these tests from reading the real `~/.gemini` cache). Replace the whole function with:
+
+```go
+// testConversationID is the id the fake supervisor's cache write attributes to
+// fresh runs started by newTestManager.
+const testConversationID = "abcdabcd-1234-5678-9abc-def012345678"
+
+// newTestManager builds a manager around a fake agy and fake supervisor. The
+// fake supervisor writes a conversation cache entry for the test's cwd after
+// the exit sentinel, so fresh runs capture an id the way real runs do, against
+// a test-owned cache file rather than the real agy cache.
+func newTestManager(t *testing.T, fake testutil.FakeAgy) (mgr *manager.Manager, stateDir string) {
+	t.Helper()
+	agy := testutil.WriteFakeAgy(t, fake)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:   agy,
+		CachePath: cachePath,
+		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, testConversationID),
+	})
+	stateDir = t.TempDir()
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	return manager.New(c), stateDir
+}
+```
+
+Add `"fmt"` to the file's imports. Then append the regression test:
+
+```go
+// A fresh run whose conversation cache lands only after the exit sentinel (the
+// real-world ordering: agy's cache daemon flushes after the process exits) must
+// still return its conversation id from agy_run_sync. Returning done with no id
+// loses the id for good, because a sync caller has no reason to poll again.
+func TestAgyRunSyncReturnsLateCapturedConversationID(t *testing.T) {
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "OK", Exit: 0})
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const uuid = "12121212-3434-5656-7878-909090909090"
+	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+		AgyPath:    agy,
+		CachePath:  cachePath,
+		CacheJSON:  fmt.Sprintf(`{%q:%q}`, cwd, uuid),
+		CacheDelay: 700 * time.Millisecond,
+	})
+	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: t.TempDir(),
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationCacheFile: cachePath}
+	mgr := manager.New(c)
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run_sync",
+		Arguments: map[string]any{"prompt": "review", "wait": "30s"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
+	}
+	sc := res.StructuredContent.(map[string]any)
+	if sc["state"] != manager.StateDone {
+		t.Fatalf("state = %v, want done", sc["state"])
+	}
+	if sc["conversation_id"] != uuid {
+		t.Fatalf("conversation_id = %v, want %q (the id must not be lost to cache-flush lag)",
+			sc["conversation_id"], uuid)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./internal/mcptools/ -run TestAgyRunSyncReturnsLateCapturedConversationID -v 2>&1 | tail -5`
+Expected: FAIL on the conversation_id assertion (`conversation_id = <nil>, want "12121212-..."`). The exit sentinel appears immediately, run_sync's first poll returns done with no id, and the cache lands 700ms too late. (It fails to compile until CapturePending exists only if you wrote the run_sync change first; at this point nothing references it yet, so it fails at the assertion.)
+
+- [ ] **Step 3: Add pending-capture tracking to the Manager**
+
+In `internal/manager/manager.go`:
+
+(a) Add to the Manager struct, after `cacheFile`:
+
+```go
+	// pendingCaptures holds the job ids of fresh runs whose conversation-id
+	// capture is armed but not yet settled (the post-exit capture attempt has
+	// not finished). Keyed by job id; values are struct{}.
+	pendingCaptures sync.Map
+```
+
+Add `"sync"` to the imports.
+
+(b) In StartJob, arm the capture in the snapshot-ok branch (final form of the Task 2 block):
+
+```go
+	if req.ConversationID == "" {
+		if before, ok := snapshotCwd(m.cacheFile, cwd); ok {
+			meta.CwdUUIDBefore = before
+			m.pendingCaptures.Store(id, struct{}{})
+		} else {
+			// No trustworthy pre-run snapshot: a post-run diff could attribute
+			// a pre-existing conversation to this run. Report no id instead.
+			meta.CaptureDisabled = true
+			log.Printf("agy-mcp: job %s: conversation cache unreadable; id capture disabled for this run", id)
+		}
+	}
+```
+
+(c) Disarm on every StartJob failure path. After `m.store.Create` fails:
+
+```go
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		m.pendingCaptures.Delete(id)
+		m.gate.release(key)
+		return Job{}, err
+	}
+```
+
+After `cmd.Start()` fails (inside that error branch, before the return):
+
+```go
+		_ = m.store.Remove(id)
+		m.pendingCaptures.Delete(id)
+		m.gate.release(key)
+		return Job{}, fmt.Errorf("spawn supervisor: %w", err)
+```
+
+In the UpdateMeta-failure goroutine:
+
+```go
+		go func() {
+			_ = cmd.Wait()
+			_ = m.store.Remove(id)
+			m.pendingCaptures.Delete(id)
+			m.gate.release(key)
+		}()
+```
+
+(d) Replace the completion goroutine:
+
+```go
+	go func() {
+		_ = cmd.Wait()
+		// For a successful fresh run, capture the conversation id agy created
+		// while the gate key is still held, then release. Gating on exit 0 avoids
+		// waiting out the capture budget for a run that created no conversation.
+		if code, ok := m.store.ExitCode(id); ok && code == 0 {
+			m.captureFreshConversationID(&meta)
+		}
+		m.gate.release(key)
+	}()
+```
+
+with:
+
+```go
+	go func() {
+		_ = cmd.Wait()
+		// For a successful fresh run, capture the conversation id agy created
+		// while the gate key is still held, then release. Gating on exit 0 avoids
+		// waiting out the capture budget for a run that created no conversation.
+		if code, ok := m.store.ExitCode(id); ok && code == 0 {
+			m.captureFreshConversationID(&meta)
+		}
+		// Settle the capture (success or give-up) before releasing the key, so
+		// CapturePending=false means the reported status is final.
+		m.pendingCaptures.Delete(id)
+		m.gate.release(key)
+	}()
+```
+
+(e) Add the accessor, after `lazyCaptureConversationID`:
+
+```go
+// CapturePending reports whether a fresh run's conversation-id capture has not
+// yet settled in this process: capture was armed at start (or restore) and the
+// post-exit capture attempt has not finished. Pollers use it to distinguish
+// "done, id still being captured" from "done, no id is coming".
+func (m *Manager) CapturePending(id string) bool {
+	_, ok := m.pendingCaptures.Load(id)
+	return ok
+}
+```
+
+- [ ] **Step 4: Make agy_run_sync poll through a pending capture**
+
+In `internal/mcptools/run_sync.go`, replace:
+
+```go
+			out := runSyncOutput{JobID: job.ID, statusOutput: toStatusOutput(st)}
+			if st.State != manager.StateRunning {
+				return nil, out, nil
+			}
+```
+
+with:
+
+```go
+			out := runSyncOutput{JobID: job.ID, statusOutput: toStatusOutput(st)}
+			if st.State != manager.StateRunning {
+				// A fresh run's conversation id can lag the exit sentinel: agy's
+				// cache daemon flushes after the process exits, and the manager's
+				// completion goroutine captures the id with a bounded retry. While
+				// that capture is still pending, keep polling instead of returning
+				// done with no id: a sync caller has no reason to poll again after
+				// a terminal result, so an id missing here is lost to the caller.
+				if st.State == manager.StateDone && st.ConversationID == "" &&
+					job.ConversationID == "" && time.Now().Before(deadline) &&
+					mgr.CapturePending(job.ID) {
+					select {
+					case <-ctx.Done():
+						return nil, out, nil
+					case <-ticker.C:
+					}
+					continue
+				}
+				return nil, out, nil
+			}
+```
+
+- [ ] **Step 5: Run the regression test**
+
+Run: `go test ./internal/mcptools/ -run TestAgyRunSyncReturnsLateCapturedConversationID -v 2>&1 | tail -5`
+Expected: PASS in roughly 1s (the 700ms cache lag plus a poll tick).
+
+- [ ] **Step 6: Write the manager-level pending-lifecycle test**
+
+Append to `internal/manager/capture_linux_test.go`:
+
+```go
+// CapturePending must be armed synchronously by a fresh StartJob and settle
+// once the completion goroutine has captured (or given up on) the id.
+func TestCapturePendingSettles(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := t.TempDir()
+	const newUUID = "55556666-7777-8888-9999-000011112222"
+
+	c := config.Config{
+		AgyPath: "/usr/bin/agy",
+		SupervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{
+			Out: "done", CachePath: cachePath, CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, newUUID),
+		}),
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	}
+	m := New(c)
+	m.cacheFile = cachePath
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	if !m.CapturePending(job.ID) {
+		t.Fatal("capture must be pending right after a fresh StartJob")
+	}
+
+	st := waitForCapturedID(t, m, job.ID, 3*time.Second)
+	if st.ConversationID != newUUID {
+		t.Fatalf("captured id = %q, want %q", st.ConversationID, newUUID)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for m.CapturePending(job.ID) {
+		if time.Now().After(deadline) {
+			t.Fatal("capture never settled after the id was captured")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+```
+
+- [ ] **Step 7: Run the affected packages, then the full suite**
+
+Run: `go test ./internal/manager/ ./internal/mcptools/ 2>&1 | tail -5` then `go test ./... 2>&1 | tail -10`
+Expected: all PASS. The existing run_sync tests now also flow through a real cache and settle quickly because the fake supervisor's cache write (no delay) lands before the completion goroutine's first capture attempt.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/manager/manager.go internal/manager/capture_linux_test.go internal/mcptools/run_sync.go internal/mcptools/run_sync_test.go
+git commit -m "fix: agy_run_sync waits for a pending conversation-id capture
+
+The manager tracks fresh runs whose capture has not settled (CapturePending);
+agy_run_sync keeps polling a done job while its capture is pending instead of
+returning done with an empty conversation_id, which lost the id for sync
+callers whenever agy's cache flush lagged the exit sentinel."
+```
+
+---
+
+### Task 5: Capture for restored jobs (watchRestored parity)
+
+The StartJob completion goroutine captures while holding the gate key. The restored-job watcher releases the key with no capture attempt, so a fresh run that outlives a manager restart loses its id to the first same-cwd run that grabs the freed key. Mirror the completion path.
+
+**Files:**
+- Modify: `internal/manager/manager.go` (RestoreGate, watchRestored)
+- Test: `internal/manager/restore_linux_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/manager/restore_linux_test.go`. Before writing, confirm `createLiveJob` (restore_linux_test.go:48) leaves `ConversationID` empty in the meta it writes (it must, since the restore tests exercise cwd-keyed conflicts); if it sets other fields like `CwdUUIDBefore`, leave them as it does.
+
+```go
+// A restored fresh run must have its conversation id captured by the watcher
+// when its supervisor finishes, exactly like the StartJob completion path, and
+// the id must land on disk without any Status call (the watcher, not a poller,
+// owns the capture while the gate key is held).
+func TestRestoreGateCapturesConversationIDOnExit(t *testing.T) {
+	pid, exePath := startFakeLiveSupervisor(t)
+	m := newManagerForRestore(t, exePath, 4)
+	m.restoredPollInterval = 20 * time.Millisecond
+
+	cwd := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.cacheFile = cachePath
+
+	createLiveJob(t, m, "restored-fresh", cwd, pid)
+
+	if err := m.RestoreGate(); err != nil {
+		t.Fatalf("RestoreGate: %v", err)
+	}
+	if !m.CapturePending("restored-fresh") {
+		t.Fatal("a restored fresh run must have its capture armed")
+	}
+
+	// The job "finishes": agy's cache gains the new conversation, then the
+	// supervisor records exit 0 (the watcher treats the sentinel as terminal
+	// even while the fake supervisor process lingers).
+	const uuid = "deadbeef-1111-2222-3333-444455556666"
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, uuid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("restored-fresh", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		meta, err := m.store.Load("restored-fresh")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if meta.ConversationID == uuid {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("watcher never captured the id; meta.ConversationID = %q", meta.ConversationID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+```
+
+Add `"fmt"` and `"os"`/`"path/filepath"` to the file's imports if not already present.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./internal/manager/ -run TestRestoreGateCapturesConversationIDOnExit -v 2>&1 | tail -5`
+Expected: FAIL at `a restored fresh run must have its capture armed` (RestoreGate does not arm) or, if arming alone were added, at the capture wait.
+
+- [ ] **Step 3: Arm in RestoreGate and capture in watchRestored**
+
+In `internal/manager/manager.go`:
+
+(a) In `RestoreGate`, replace:
+
+```go
+		key := keyFor(reqFromMeta(meta))
+		if m.gate.forceAcquire(key) {
+			m.watchRestored(meta, key)
+		}
+```
+
+with:
+
+```go
+		key := keyFor(reqFromMeta(meta))
+		if m.gate.forceAcquire(key) {
+			if meta.ConversationID == "" && !meta.CaptureDisabled {
+				// Mirror StartJob: arm the capture so pollers can tell this
+				// restored fresh run's id is still being settled.
+				m.pendingCaptures.Store(meta.ID, struct{}{})
+			}
+			m.watchRestored(meta, key)
+		}
+```
+
+(b) In `watchRestored`, replace the goroutine body:
+
+```go
+	go func() {
+		// Check once before waiting a full interval, so a supervisor that exits
+		// right after startup does not hold its slot for a whole poll period.
+		if !dead() {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for range t.C {
+				if dead() {
+					break
+				}
+			}
+		}
+		m.gate.release(key)
+	}()
+```
+
+with:
+
+```go
+	go func() {
+		// Check once before waiting a full interval, so a supervisor that exits
+		// right after startup does not hold its slot for a whole poll period.
+		if !dead() {
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for range t.C {
+				if dead() {
+					break
+				}
+			}
+		}
+		// Mirror the StartJob completion path: a restored fresh run that exited 0
+		// still needs its conversation id captured, and like there the capture
+		// must happen while the gate key is held, so a new same-cwd run cannot
+		// overwrite the cache entry first.
+		if code, ok := m.store.ExitCode(meta.ID); ok && code == 0 {
+			m.captureFreshConversationID(&meta)
+		}
+		m.pendingCaptures.Delete(meta.ID)
+		m.gate.release(key)
+	}()
+```
+
+- [ ] **Step 4: Run the test and the restore suite**
+
+Run: `go test ./internal/manager/ -run 'TestRestoreGate' -v 2>&1 | tail -12`
+Expected: all restore tests PASS, including the new one. The pre-existing release tests still pass: for their jobs the sentinel is absent or nonzero, so the new capture call is a no-op before release.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/manager/manager.go internal/manager/restore_linux_test.go
+git commit -m "fix: capture conversation ids for restored jobs before releasing the gate
+
+watchRestored now mirrors the StartJob completion path: when a restored fresh
+run's supervisor exits 0, the watcher captures the id while still holding the
+cwd gate key, instead of releasing immediately and leaving the id to a lazy
+single-shot Status capture that a new same-cwd run can spoil."
+```
+
+---
+
+### Task 6: Lazy-capture guards: later-run check and settle memo
+
+`lazyCaptureConversationID` (the post-restart fallback inside Status) holds no gate key, so a cache change since the snapshot may belong to a later same-cwd run; today it captures and persists it anyway, permanently mislabeling the job. Two guards: skip (permanently) when a later same-cwd job exists in the store, and settle permanently once the run is so long over that no attributable change can still appear. The settle memo also kills the per-poll cache re-read churn for id-less done jobs.
+
+**Files:**
+- Modify: `internal/manager/manager.go`
+- Test: `internal/manager/capture_linux_test.go`
+
+- [ ] **Step 1: Write the failing misattribution test**
+
+Append to `internal/manager/capture_linux_test.go`:
+
+```go
+// A lazily captured id must not be stolen from a later same-cwd run: when
+// another job started in this cwd after this one, a changed cache entry cannot
+// be attributed to this job.
+func TestStatusLazyCaptureSkipsWhenLaterRunExists(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	const laterUUID = "99998888-7777-6666-5555-444433332222"
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, laterUUID)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	// Job A: a completed fresh run from a previous manager, id never captured.
+	metaA := jobstore.Meta{
+		ID:            "job-a",
+		Cwd:           cwd,
+		CwdUUIDBefore: "",
+		StartedAt:     time.Now().Add(-2 * time.Minute),
+		Timeout:       time.Hour,
+	}
+	dirA, err := m.store.Create(metaA)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dirA, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(metaA.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Job B: a later run in the same cwd; the cache entry is (or may be) B's.
+	metaB := jobstore.Meta{ID: "job-b", Cwd: cwd, StartedAt: time.Now().Add(-time.Minute)}
+	if _, err := m.store.Create(metaB); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	st, err := m.Status(metaA.ID)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.ConversationID != "" {
+		t.Fatalf("must not attribute the later run's id, got %q", st.ConversationID)
+	}
+	reloaded, err := m.store.Load(metaA.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.ConversationID != "" {
+		t.Fatalf("misattributed id was persisted: %q", reloaded.ConversationID)
+	}
+}
+
+// Once a job is long past its timeout with no cache change, lazy capture must
+// settle permanently: a cache change appearing afterward belongs to some other
+// (possibly out-of-store) run and must not be captured, and settled jobs must
+// stop re-reading the cache on every poll.
+func TestStatusLazyCaptureSettlesAfterHorizon(t *testing.T) {
+	state := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "last_conversations.json")
+	cwd := t.TempDir()
+	if err := os.WriteFile(cachePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(config.Config{
+		AgyPath:        "/usr/bin/agy",
+		SupervisorExe:  "/bin/true",
+		StateDir:       state,
+		DefaultTimeout: time.Minute,
+		MaxConcurrency: 4,
+	})
+	m.cacheFile = cachePath
+
+	// Done long ago: StartedAt is far past Timeout + captureBudget.
+	meta := jobstore.Meta{
+		ID:            "job-old",
+		Cwd:           cwd,
+		CwdUUIDBefore: "",
+		StartedAt:     time.Now().Add(-time.Hour),
+		Timeout:       time.Minute,
+	}
+	dir, err := m.store.Create(meta)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("done"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode(meta.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// First Status: no cache change, and the job is long over, so the capture settles.
+	if st, err := m.Status(meta.ID); err != nil || st.ConversationID != "" {
+		t.Fatalf("first Status: id=%q err=%v", st.ConversationID, err)
+	}
+	// A cache entry appears later (some unrelated run); it must not be captured.
+	if err := os.WriteFile(cachePath, []byte(fmt.Sprintf(`{%q:%q}`, cwd, "abcdef00-1111-2222-3333-444455556666")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if st, err := m.Status(meta.ID); err != nil || st.ConversationID != "" {
+		t.Fatalf("settled job captured a late id: id=%q err=%v", st.ConversationID, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `go test ./internal/manager/ -run 'TestStatusLazyCaptureSkipsWhenLaterRunExists|TestStatusLazyCaptureSettlesAfterHorizon' -v 2>&1 | tail -8`
+Expected: both FAIL: the first captures `laterUUID`, the second captures the late id on the second Status.
+
+- [ ] **Step 3: Implement the guards**
+
+In `internal/manager/manager.go`:
+
+(a) Add to the Manager struct, after `pendingCaptures`:
+
+```go
+	// settledCapture memoizes job ids whose lazy capture is permanently over
+	// (no id is coming): either the run is long past its timeout with no cache
+	// change, or a later same-cwd run made attribution unsafe. Settled jobs
+	// stop re-reading the cache on every Status poll.
+	settledMu      sync.Mutex
+	settledCapture map[string]struct{}
+```
+
+(b) In `New`, add to the struct literal:
+
+```go
+		settledCapture:       make(map[string]struct{}),
+```
+
+(c) Add the helpers, after `CapturePending`:
+
+```go
+func (m *Manager) captureSettled(id string) bool {
+	m.settledMu.Lock()
+	defer m.settledMu.Unlock()
+	_, ok := m.settledCapture[id]
+	return ok
+}
+
+func (m *Manager) settleCapture(id string) {
+	m.settledMu.Lock()
+	defer m.settledMu.Unlock()
+	m.settledCapture[id] = struct{}{}
+}
+
+// maybeSettleCapture marks a job's lazy capture as permanently over once the
+// run is certainly long finished: the supervisor's hard timeout bounds the run
+// and agy's cache daemon flushes within moments of the exit, so past
+// StartedAt+Timeout+captureBudget no attributable cache change can still
+// appear. Settling stops later polls from re-reading the cache for a job that
+// will never get an id, and keeps a much-later unrelated cache write from
+// being misattributed to this job.
+func (m *Manager) maybeSettleCapture(meta jobstore.Meta) {
+	horizon := meta.Timeout
+	if horizon <= 0 {
+		horizon = time.Hour // old metas without a recorded timeout: stay conservative
+	}
+	if time.Since(meta.StartedAt) > horizon+m.captureBudget {
+		m.settleCapture(meta.ID)
+	}
+}
+
+// hasLaterSameCwdRun reports whether any other stored job shares meta's cwd and
+// started after it. When one exists, a changed cache entry cannot be attributed
+// to meta's run: the later run may be the one that wrote it.
+func (m *Manager) hasLaterSameCwdRun(meta jobstore.Meta) bool {
+	ids, err := m.store.List()
+	if err != nil {
+		return true // cannot prove safety: skip the capture rather than risk misattribution
+	}
+	for _, id := range ids {
+		if id == meta.ID {
+			continue
+		}
+		other, err := m.store.Load(id)
+		if err != nil {
+			continue
+		}
+		if other.Cwd == meta.Cwd && other.StartedAt.After(meta.StartedAt) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+(d) Replace `lazyCaptureConversationID` (body and doc comment, which currently makes a false safety claim):
+
+```go
+// lazyCaptureConversationID best-effort captures a fresh run's conversation id
+// from the cache when no in-process watcher captured it (the manager was
+// restarted after the job ended). It returns an already-known id unchanged.
+//
+// No gate key is held here, so a cache change since the snapshot is not
+// necessarily this job's: a later same-cwd run may have written it. Two guards
+// keep that from becoming a persisted misattribution: a changed entry is not
+// captured while any later same-cwd job exists in the store, and once the run
+// is long enough over that no attributable change can still appear, the
+// capture settles permanently as empty.
+func (m *Manager) lazyCaptureConversationID(meta jobstore.Meta) string {
+	if meta.ConversationID != "" {
+		return meta.ConversationID
+	}
+	if meta.CaptureDisabled || m.captureSettled(meta.ID) {
+		return ""
+	}
+	id, ok := captureNewUUID(m.cacheFile, meta.Cwd, meta.CwdUUIDBefore)
+	if !ok {
+		m.maybeSettleCapture(meta)
+		return ""
+	}
+	if m.hasLaterSameCwdRun(meta) {
+		m.settleCapture(meta.ID)
+		return ""
+	}
+	final, err := m.store.SetConversationID(meta.ID, id)
+	if err != nil {
+		log.Printf("agy-mcp: persist captured conversation id for job %s: %v", meta.ID, err)
+		return id // best-effort: report what we captured even if the persist failed
+	}
+	return final
+}
+```
+
+- [ ] **Step 4: Run the lazy-capture tests, old and new**
+
+Run: `go test ./internal/manager/ -run 'TestStatusLazy' -v 2>&1 | tail -10`
+Expected: all four PASS (`LazilyCaptures`, `NoOpWhenCacheUnchanged`, `SkipsWhenLaterRunExists`, `SettlesAfterHorizon`). The first two stay green: their metas are 1 minute old with no recorded Timeout, so the 1-hour conservative horizon does not settle them, and no later same-cwd job exists.
+
+- [ ] **Step 5: Full suite and commit**
+
+Run: `go test ./... 2>&1 | tail -10`
+Expected: all PASS.
+
+```bash
+git add internal/manager/manager.go internal/manager/capture_linux_test.go
+git commit -m "fix: lazy conversation-id capture cannot steal a later run's id
+
+Status's post-restart lazy capture now skips (and permanently settles) when a
+later same-cwd job exists, and settles once the run is long past its timeout,
+so a cache change from another run is never persisted as this job's id. The
+settle memo also stops id-less done jobs from re-reading the cache per poll."
+```
+
+---
+
+### Task 7: Documentation truth-up and final sweep
+
+**Files:**
+- Modify: `internal/manager/manager.go` (struct comment)
+- Modify: `internal/manager/capture_linux_test.go` (gofmt drift at line 27)
+
+- [ ] **Step 1: Fix the stale concurrency claim in the Manager struct comment**
+
+In `internal/manager/manager.go`, in the comment block above `captureBudget`, replace the sentence:
+
+```
+// file lock), so a concurrent read can be torn; loadCache tolerates that (an
+// unparsable read yields no capture) and this retry loop re-reads, so no mutex
+// is needed.
+```
+
+with:
+
+```
+// file lock), so a concurrent read can be torn; loadCache reports torn reads
+// as errors, capture treats them as "no capture yet" and this retry loop
+// re-reads, and StartJob disables capture when the pre-run snapshot itself is
+// unreadable, so no mutex is needed.
+```
+
+- [ ] **Step 2: Format, vet, lint**
+
+Run: `gofmt -l . && go vet ./...`
+Expected: no gofmt output (the pre-existing drift in `internal/manager/capture_linux_test.go:27` is fixed by `gofmt -w internal/manager/capture_linux_test.go` if it appears), no vet errors.
+
+Run: `golangci-lint run 2>&1 | tail -5`
+Expected: `0 issues`.
+
+- [ ] **Step 3: Full suite, race detector**
+
+Run: `go test -race ./... 2>&1 | tail -10`
+Expected: all PASS. The race detector matters here: this change adds a sync.Map and a mutex-guarded map touched from the completion goroutine, the restored watcher, and Status callers.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "docs: align cache-concurrency comments with error-aware loadCache"
+```
+
+- [ ] **Step 5: Pre-push gate**
+
+Per the repo workflow (recon, design, implement, gate, push), run the `gate` skill over the branch before pushing, then push and open a PR referencing issue #23 (`Fixes #23`).
+
+---
+
+## Self-Review Notes
+
+- Issue #23 checkbox coverage: sync done-without-id (Task 4), fixture ordering (Task 1), lazy misattribution (Task 6), watchRestored (Task 5), loadCache errors + snapshot edge (Task 2), per-poll cache churn (Task 6 settle memo), wrong comments (Tasks 2, 6, 7).
+- Type consistency: `snapshotCwd(cacheFile, cwd) (string, bool)` defined in Task 2 and consumed in Tasks 2 and 4's StartJob block; `pendingCaptures sync.Map` defined in Task 4, used in Task 5; `CapturePending` defined in Task 4, used in Tasks 4 and 5's tests; `ConversationCacheFile` defined in Task 3, used in Task 4's tests; `CacheDelay time.Duration` defined in Task 1, used in Task 4's regression test.
+- Known interactions verified against current sources: `statusOutput` serializes the id as `conversation_id` (tools.go:57); `FakeAgy{Stdout, Stderr, Exit, SleepSecs}` (fakeagy.go:12); `SetConversationID` is first-write-wins under the store mutex, so concurrent lazy and goroutine captures stay benign.
+- Deliberate non-goals (tracked in other issues): cwd normalization (#24), cross-process gate (#25), Status output polish (#29), test-suite hygiene (#34).

--- a/docs/superpowers/plans/2026-07-17-job-completion-wake.md
+++ b/docs/superpowers/plans/2026-07-17-job-completion-wake.md
@@ -1,0 +1,1024 @@
+# Job Completion Wake Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let callers block on an agy job with one call (`agy_wait` tool, `wait-job` CLI) and let Claude Code be woken on job completion with zero polling (`hook-wait` CLI driven by an asyncRewake PostToolUse hook).
+
+**Architecture:** One shared wait primitive, `manager.WaitTerminal`, carries the proven `agy_run_sync` polling semantics (250ms Status polls, terminal detection, conversation-id capture grace). `agy_run_sync` is refactored onto it, `agy_wait` reuses the same mcptools wait helper, and two new positional CLI subcommands (`wait-job`, `hook-wait`) call it through a new agy-free config resolver.
+
+**Tech Stack:** Go 1.26, github.com/modelcontextprotocol/go-sdk/mcp, stdlib only otherwise.
+
+**Spec:** `specs/2026-07-17-job-completion-wake-design.md` (local, gitignored; read it first).
+
+## Global Constraints
+
+- Em dashes and en dashes are banned in every file, comment, string, and commit message; use `-`, `,`, `:`, or `;`.
+- `agy_run_sync` wire behavior (outputs, notes, wait cap, capture grace, client-cancel error) must not change; its existing tests pass unmodified.
+- Tests that exec the bash fake agy need build tag `//go:build linux || darwin` (repo convention: `*_posix_test.go`).
+- Verification for every task: `go build ./...`, `go test ./... -race` (from repo root), and the task's focused test command.
+- Commit style: `<package>: <imperative summary>` (see `git log --oneline`).
+- specs/ and docs/ are gitignored; never `git add -f` them.
+- Comments explain constraints and reasoning, not narration; match existing density.
+
+---
+
+### Task 1: manager.WaitTerminal shared wait primitive
+
+**Files:**
+- Create: `internal/manager/wait.go`
+- Create: `internal/manager/wait_posix_test.go`
+
+**Interfaces:**
+- Consumes: `(*Manager).Status`, `(*Manager).CapturePending`, `StateRunning`/`StateDone` (all existing, `internal/manager/status.go`, `manager.go`).
+- Produces: `func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Time, onTick func(Status)) (Status, bool, error)` and const `waitPollInterval = 250 * time.Millisecond`. Tasks 2, 3, 5, 6 rely on exactly this signature.
+
+- [ ] **Step 1: Write failing tests**
+
+`internal/manager/wait_posix_test.go`. Look at `internal/manager/capture_posix_test.go` first and reuse its existing helpers for building a Manager around `testutil.WriteFakeAgy` / `testutil.WriteFakeSupervisor` (do not invent a parallel helper if one exists; the mcptools variant to mirror is `newTestManager` in `internal/mcptools/run_sync_posix_test.go:47`).
+
+```go
+//go:build linux || darwin
+
+package manager_test // or package manager, matching the existing test files' choice
+
+// Test list (each is a separate func; use the package's existing manager-builder helper):
+//
+// TestWaitTerminalReturnsDoneJob: start a job with a fast fake agy
+// (Stdout "OK", Exit 0), poll Status until done (existing waitForDone-style
+// loop), then call WaitTerminal with a 5s deadline: it must return
+// (st.State == StateDone, terminal == true, err == nil) immediately.
+//
+// TestWaitTerminalBlocksUntilDone: fake agy with Sleep: 1 * time.Second,
+// call WaitTerminal right after StartJob with a 15s deadline: returns
+// done/terminal, and st.Result == "OK".
+//
+// TestWaitTerminalDeadlineOverrun: fake agy with Sleep: 2 * time.Second,
+// WaitTerminal with deadline time.Now().Add(100 * time.Millisecond):
+// returns (st.State == StateRunning, terminal == false, err == nil).
+// Then wait for the job to finish (waitForDone-style) so cleanup is quiet.
+//
+// TestWaitTerminalContextCancel: fake agy with Sleep: 2 * time.Second,
+// ctx with cancel; cancel after WaitTerminal is observably polling (cancel
+// from a time.AfterFunc(300*time.Millisecond, cancel)): returns
+// errors.Is(err, context.Canceled), terminal == false.
+//
+// TestWaitTerminalUnknownJob: WaitTerminal(ctx, "nonexistent-id", ...)
+// returns a non-nil error (store load failure), terminal == false.
+//
+// TestWaitTerminalOnTick: fake agy with Sleep: 1 * time.Second; onTick
+// increments an int (no mutex needed: onTick is documented single-goroutine).
+// After WaitTerminal returns done, the count must be >= 1 and every observed
+// Status passed to onTick had State == StateRunning.
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/manager/ -run TestWaitTerminal -v`
+Expected: FAIL, `undefined: ... WaitTerminal` (compile error).
+
+- [ ] **Step 3: Implement WaitTerminal**
+
+`internal/manager/wait.go`:
+
+```go
+package manager
+
+import (
+	"context"
+	"time"
+)
+
+// waitPollInterval is how often WaitTerminal re-reads job status and invokes
+// onTick. Status reads a few small files, so this is cheap. agy_run_sync's
+// wait loop used the same 250ms cadence before it moved here.
+const waitPollInterval = 250 * time.Millisecond
+
+// WaitTerminal polls the job until it reaches a terminal state, the deadline
+// passes, or ctx is cancelled. It returns the latest observed Status and
+// whether the job was terminal when the wait ended. The deadline is observed
+// on poll ticks only, so a wait can overshoot it by up to one poll interval.
+//
+// onTick, if non-nil, is invoked once per poll from the calling goroutine
+// while the job is still running; it must not block longer than the poll
+// interval (it is for progress reporting, not work).
+//
+// One refinement carried over from the original agy_run_sync loop: when the
+// job is done but its conversation id is still being captured in this process
+// (CapturePending), WaitTerminal keeps polling until the capture settles or
+// the deadline passes, so a caller that will never poll again does not lose
+// the id to agy's cache-flush lag. If ctx is cancelled during that grace the
+// job is already terminal, so the status is returned with a nil error.
+// Cross-process callers always observe CapturePending == false; for them
+// Status lazy-captures on read instead and no grace applies.
+func (m *Manager) WaitTerminal(ctx context.Context, id string, deadline time.Time, onTick func(Status)) (Status, bool, error) {
+	ticker := time.NewTicker(waitPollInterval)
+	defer ticker.Stop()
+	for {
+		st, err := m.Status(id)
+		if err != nil {
+			return Status{}, false, err
+		}
+		if st.State != StateRunning {
+			if st.State == StateDone && st.ConversationID == "" &&
+				time.Now().Before(deadline) && m.CapturePending(id) {
+				select {
+				case <-ctx.Done():
+					return st, true, nil
+				case <-ticker.C:
+				}
+				continue
+			}
+			return st, true, nil
+		}
+		if time.Now().After(deadline) {
+			return st, false, nil
+		}
+		if onTick != nil {
+			onTick(st)
+		}
+		select {
+		case <-ctx.Done():
+			return st, false, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/manager/ -run TestWaitTerminal -race -v`
+Expected: PASS (all six).
+
+- [ ] **Step 5: Full package check and commit**
+
+Run: `go build ./... && go test ./internal/manager/ -race`
+Expected: PASS.
+
+```bash
+git add internal/manager/wait.go internal/manager/wait_posix_test.go
+git commit -m "manager: add WaitTerminal shared wait primitive"
+```
+
+---
+
+### Task 2: route agy_run_sync through a shared awaitJob helper
+
+**Files:**
+- Create: `internal/mcptools/await.go`
+- Modify: `internal/mcptools/run_sync.go`
+
+**Interfaces:**
+- Consumes: `manager.WaitTerminal` (Task 1, exact signature above); existing `runSyncOutput`, `toStatusOutput`, `defaultSyncWait`, `maxSyncWait` in `internal/mcptools`.
+- Produces: `func awaitJob(ctx context.Context, req *mcp.CallToolRequest, mgr *manager.Manager, jobID string, deadline time.Time) (runSyncOutput, error)` and `func parseWait(s string) (time.Duration, error)`. Task 3 relies on both.
+
+- [ ] **Step 1: Write awaitJob and parseWait**
+
+`internal/mcptools/await.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// notifyTimeout bounds each progress-notification send so a client that
+// stopped draining the stream cannot park the wait loop past its cap. It
+// matches the manager's poll cadence, which is what the send used to be
+// bounded by when the loop lived in run_sync.
+const notifyTimeout = 250 * time.Millisecond
+
+// parseWait validates a caller-supplied inline wait, applying the shared
+// default and cap. agy_run_sync and agy_wait use it so the two cannot drift.
+func parseWait(s string) (time.Duration, error) {
+	if s == "" {
+		return defaultSyncWait, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, fmt.Errorf("invalid wait %q: want a positive Go duration like 90s", s)
+	}
+	return min(d, maxSyncWait), nil
+}
+
+// awaitJob blocks until the job is terminal or the deadline passes, emitting
+// once-per-second MCP progress notifications when the client supplied a
+// progress token. It is the wait phase shared by agy_run_sync and agy_wait,
+// so their semantics cannot drift. On a wait-cap overrun the returned output
+// carries the standard poll-with-agy_status note.
+func awaitJob(ctx context.Context, req *mcp.CallToolRequest, mgr *manager.Manager, jobID string, deadline time.Time) (runSyncOutput, error) {
+	token := req.Params.GetProgressToken()
+	// Notify once per elapsed second, not per poll tick: the message has
+	// whole-second granularity, so finer cadence is pure stream noise.
+	lastNotified := time.Duration(-1)
+	onTick := func(st manager.Status) {
+		sec := st.Elapsed.Truncate(time.Second)
+		if token == nil || sec == lastNotified {
+			return
+		}
+		lastNotified = sec
+		// Best effort: the result, not the notifications, is the contract.
+		nctx, ncancel := context.WithTimeout(ctx, notifyTimeout)
+		_ = req.Session.NotifyProgress(nctx, &mcp.ProgressNotificationParams{
+			ProgressToken: token,
+			Progress:      st.Elapsed.Seconds(),
+			Message:       fmt.Sprintf("job %s running (%s)", jobID, sec),
+		})
+		ncancel()
+	}
+	st, terminal, err := mgr.WaitTerminal(ctx, jobID, deadline, onTick)
+	if err != nil {
+		if ctx.Err() != nil {
+			// The client gave up on the call; the job stays alive under its
+			// detached supervisor. Carry the job id in the error so a
+			// gracefully-cancelling client can still find the job.
+			return runSyncOutput{}, fmt.Errorf("wait cancelled; job %s is still running, poll it with agy_status: %w", jobID, err)
+		}
+		return runSyncOutput{}, fmt.Errorf("job %s status read failed: %w", jobID, err)
+	}
+	out := runSyncOutput{JobID: jobID, statusOutput: toStatusOutput(st)}
+	if !terminal {
+		out.Note = "wait cap reached; the job is still running, poll it with agy_status"
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 2: Refactor registerRunSync onto it**
+
+Replace the body of the `mcp.AddTool` handler in `internal/mcptools/run_sync.go` (keep the tool name and Description unchanged; delete the now-dead loop, the `syncPollInterval` constant, and unused imports):
+
+```go
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in runSyncInput) (*mcp.CallToolResult, runSyncOutput, error) {
+		wait, err := parseWait(in.Wait)
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		startReq, err := in.toStartRequest()
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		job, err := mgr.StartJob(startReq)
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		out, err := awaitJob(ctx, req, mgr, job.ID, time.Now().Add(wait))
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		return nil, out, nil
+	})
+```
+
+Note the one accepted wire delta (spec-approved): the mid-wait status-read error text becomes `job <id> status read failed: ...` instead of `job <id> started but status read failed: ...`. No test asserts the old text; do not preserve it.
+
+- [ ] **Step 3: Run the full existing run_sync suite**
+
+Run: `go test ./internal/mcptools/ -race -v -run TestAgyRunSync`
+Expected: PASS with zero test-file edits. If any of these tests needed changing, the refactor is wrong; fix the code, not the tests.
+
+- [ ] **Step 4: Full build, vet, and commit**
+
+Run: `go build ./... && go vet ./... && go test ./internal/mcptools/ ./internal/manager/ -race`
+Expected: PASS.
+
+```bash
+git add internal/mcptools/await.go internal/mcptools/run_sync.go
+git commit -m "mcptools: route agy_run_sync wait through manager.WaitTerminal"
+```
+
+---
+
+### Task 3: agy_wait MCP tool
+
+**Files:**
+- Create: `internal/mcptools/wait.go`
+- Create: `internal/mcptools/wait_posix_test.go`
+- Modify: `internal/mcptools/tools.go` (const block at line 33)
+- Modify: the server tool registration list (find it: `grep -n registerRunSync internal/mcptools/*.go`; add `registerWait(s, mgr)` beside it)
+
+**Interfaces:**
+- Consumes: `awaitJob`, `parseWait` (Task 2), `runSyncOutput`, `manager.Status`.
+- Produces: MCP tool `agy_wait` with input `{ job_id, wait? }` and the `agy_run_sync` output shape `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`. Task 7 documents it.
+
+- [ ] **Step 1: Write failing tests**
+
+`internal/mcptools/wait_posix_test.go` (`//go:build linux || darwin`), reusing `connect`, `newTestManager`, `structMap`, `waitForDone`, `waitForRunningJob` from `run_sync_posix_test.go`:
+
+```go
+// TestAgyWaitReturnsResult: newTestManager with FakeAgy{Stdout: "WAITED OK",
+// Exit: 0, Sleep: 500 * time.Millisecond}. CallTool agy_run (prompt "review"),
+// take job_id from structMap. CallTool agy_wait {job_id, wait: "30s"}:
+// state done, result "WAITED OK", job_id echoed back.
+//
+// TestAgyWaitUnknownJob: CallTool agy_wait {job_id: "no-such-job"}:
+// err != nil || res.IsError must hold.
+//
+// TestAgyWaitInvalidWait: for each wait in "nope", "-1s", "0": CallTool
+// agy_wait {job_id: "x", wait: wait} must error (wait is validated before
+// the job id is looked up, mirroring run_sync's precedence).
+//
+// TestAgyWaitOverrunReturnsNote: FakeAgy{Stdout: "LATE OK", Exit: 0,
+// Sleep: 2 * time.Second}; agy_run, then agy_wait {job_id, wait: "100ms"}:
+// state running, note non-empty, and the job must NOT be cancelled:
+// waitForDone(t, mgr, jobID, "LATE OK", 15*time.Second).
+//
+// TestAgyWaitSendsProgress: FakeAgy{Stdout: "OK", Exit: 0, Sleep: 1 * time.Second};
+// agy_run, then agy_wait with params.SetProgressToken("tok-9") and wait "30s":
+// completes done and at least one notification with token "tok-9" arrives
+// (copy the deadline-drain pattern from TestAgyRunSyncSendsProgress).
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/mcptools/ -run TestAgyWait -v`
+Expected: FAIL, tool `agy_wait` not found (CallTool error).
+
+- [ ] **Step 3: Implement the tool**
+
+Add to the const block in `internal/mcptools/tools.go`:
+
+```go
+	toolAgyWait      = "agy_wait"
+```
+
+`internal/mcptools/wait.go`:
+
+```go
+package mcptools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// waitInput is the input for agy_wait.
+type waitInput struct {
+	JobID string `json:"job_id" jsonschema:"the job id to wait for"`
+	Wait  string `json:"wait,omitempty" jsonschema:"max time to wait inline (Go duration, default 2m, max 10m); on overrun the job keeps running and can be waited on again or polled with agy_status"`
+}
+
+// registerWait adds the agy_wait tool: block on an existing job until it
+// finishes (bounded), streaming progress notifications when the client asked
+// for them. It shares agy_run_sync's wait phase, so one agy_wait call
+// replaces an agy_status poll loop.
+func registerWait(s *mcp.Server, mgr *manager.Manager) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name: toolAgyWait,
+		Description: "Block until an agy_run job finishes (bounded by wait, default 2m, max 10m). " +
+			"Sends MCP progress notifications while waiting. Prefer one agy_wait over repeated " +
+			"agy_status polling when the next step depends on the job's result. If the job " +
+			"outlives the wait cap it keeps running; call agy_wait again or poll agy_status.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in waitInput) (*mcp.CallToolResult, runSyncOutput, error) {
+		wait, err := parseWait(in.Wait)
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		// Reject an unknown job before entering the wait loop, so a typo'd id
+		// fails fast instead of polling a job that can never appear.
+		if _, err := mgr.Status(in.JobID); err != nil {
+			return nil, runSyncOutput{}, fmt.Errorf("job %s: %w", in.JobID, err)
+		}
+		out, err := awaitJob(ctx, req, mgr, in.JobID, time.Now().Add(wait))
+		if err != nil {
+			return nil, runSyncOutput{}, err
+		}
+		return nil, out, nil
+	})
+}
+```
+
+Register it beside the other tools (same registration site as `registerRunSync`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/mcptools/ -run TestAgyWait -race -v`
+Expected: PASS (all five).
+
+- [ ] **Step 5: Full check and commit**
+
+Run: `go build ./... && go test ./internal/mcptools/ -race`
+Expected: PASS.
+
+```bash
+git add internal/mcptools/wait.go internal/mcptools/wait_posix_test.go internal/mcptools/tools.go internal/mcptools/serve.go
+git commit -m "mcptools: add agy_wait tool for blocking on an existing job"
+```
+
+(If registration lives somewhere other than serve.go, add that file instead.)
+
+---
+
+### Task 4: config.ResolveWait, an agy-free resolver
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/config_test.go`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `func ResolveWait() (Config, error)` returning a Config with StateDir plus defaults (`DefaultTimeout: 30 * time.Minute`, `MaxConcurrency: 4`, `JobTTL: 24 * time.Hour`) and empty AgyPath/SupervisorExe. Tasks 5 and 6 call it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/config/config_test.go`:
+
+```go
+// TestResolveWaitNeedsNoAgy: ResolveWait must succeed with no agy anywhere on
+// PATH (the wait-only subcommands are pure observers of the job store), while
+// Resolve fails in the same environment, proving the seam matters.
+func TestResolveWaitNeedsNoAgy(t *testing.T) {
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	t.Setenv("PATH", t.TempDir()) // empty dir: no agy
+	t.Setenv("AGY_MCP_STATE_DIR", "/custom/state")
+
+	if _, err := Resolve(); err == nil {
+		t.Fatal("Resolve succeeded without agy on PATH; the control condition is broken")
+	}
+	c, err := ResolveWait()
+	if err != nil {
+		t.Fatalf("ResolveWait: %v", err)
+	}
+	if c.StateDir != "/custom/state" {
+		t.Fatalf("StateDir = %q, want /custom/state", c.StateDir)
+	}
+	if c.AgyPath != "" || c.SupervisorExe != "" {
+		t.Fatalf("wait config resolved binaries it must not need: agy=%q supervisor=%q", c.AgyPath, c.SupervisorExe)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestResolveWaitNeedsNoAgy -v`
+Expected: FAIL, `undefined: ResolveWait`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/config/config.go`, extract the state-dir block of `Resolve` (the `stateRoot := os.Getenv("AGY_MCP_STATE_DIR")` paragraph) into a helper, call it from `Resolve`, and add `ResolveWait`:
+
+```go
+// resolveStateDir returns the job-state root: AGY_MCP_STATE_DIR verbatim, or
+// the XDG state-home fallback. Shared by Resolve and ResolveWait so the two
+// cannot drift.
+func resolveStateDir() (string, error) {
+	if stateRoot := os.Getenv("AGY_MCP_STATE_DIR"); stateRoot != "" {
+		return stateRoot, nil
+	}
+	xdg := os.Getenv("XDG_STATE_HOME")
+	if xdg == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home: %w", err)
+		}
+		xdg = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(xdg, "agy-mcp"), nil
+}
+
+// ResolveWait builds the minimal Config the wait-only subcommands (wait-job,
+// hook-wait) need: the state dir and defaults, with no agy binary lookup and
+// no supervisor path. Reading job status never execs agy, so requiring it on
+// PATH would be an artificial failure for a pure observer.
+func ResolveWait() (Config, error) {
+	stateDir, err := resolveStateDir()
+	if err != nil {
+		return Config{}, err
+	}
+	return Config{
+		StateDir:       stateDir,
+		DefaultTimeout: 30 * time.Minute,
+		MaxConcurrency: 4,
+		JobTTL:         24 * time.Hour,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -race -v`
+Expected: PASS, including all pre-existing Resolve tests (the extraction must not change Resolve's behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "config: add ResolveWait for wait-only subcommands"
+```
+
+---
+
+### Task 5: wait-job CLI subcommand
+
+**Files:**
+- Create: `waitcmd.go` (package main)
+- Create: `waitcmd_posix_test.go` (package main)
+- Modify: `main.go:33-43` (subcommand dispatch)
+
+**Interfaces:**
+- Consumes: `config.ResolveWait` (Task 4), `manager.New`, `manager.WaitTerminal` (Task 1), `manager.Status`.
+- Produces: `func waitJobMain(args []string, stdout, stderr io.Writer) int` and `func waitForJob(id string, timeout time.Duration) (manager.Status, bool, error)`; Task 6 reuses `waitForJob`. CLI contract (documented in Task 7): exit 0 terminal (state word on stdout: `done`, `failed`, or `cancelled`), 1 error, 2 usage, 3 timeout.
+
+- [ ] **Step 1: Write failing tests**
+
+`waitcmd_posix_test.go` (`//go:build linux || darwin`, package main). Two fixtures:
+
+```go
+// writeTerminalJob creates <stateDir>/jobs/<id> holding a done job: meta.json
+// (jobstore.Meta{ID: id, StartedAt: time.Now(), CaptureDisabled: true}),
+// out file "RESULT", exit_code "0". CaptureDisabled stops the wait manager
+// from reading the host's real agy conversation cache during the test.
+// Write files with jsonMarshalForTest + jobstore.MetaPath / jobstore.OutPath /
+// jobstore.ExitCodePath (see TestRunJobSubcommandEndToEnd in main_test.go for
+// the meta-writing pattern). Also t.Setenv("HOME", t.TempDir()) in every test
+// so the manager's default cache path can never touch the real user cache.
+//
+// TestWaitJobDoneJob: fixture job "job-done-1"; t.Setenv AGY_MCP_STATE_DIR to
+// the fixture stateDir; waitJobMain([]string{"job-done-1"}, &out, &errb)
+// returns 0 and out.String() == "done\n".
+//
+// TestWaitJobUnknownJob: same env, waitJobMain([]string{"nope"}, ...) returns 1
+// and stderr mentions the failure.
+//
+// TestWaitJobUsage: waitJobMain(nil, ...) returns 2. waitJobMain
+// ([]string{"a", "b"}, ...) returns 2.
+//
+// TestWaitJobTimeout: start a real slow job: build a manager the way
+// internal/mcptools' newTestManager does (testutil.WriteFakeAgy with
+// Sleep: 2 * time.Second, testutil.WriteFakeSupervisor, config.Config with
+// ConversationCacheFile pointing at a temp cache) over a temp stateDir;
+// StartJob; t.Setenv AGY_MCP_STATE_DIR to that stateDir; waitJobMain
+// ([]string{"-timeout", "100ms", job.ID}, ...) returns 3. Then poll the
+// starting manager until the job is done so nothing leaks past the test.
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test . -run TestWaitJob -v`
+Expected: FAIL, `undefined: waitJobMain`.
+
+- [ ] **Step 3: Implement**
+
+`waitcmd.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// waitJobMain implements "agy-mcp wait-job [-timeout 1h] <job_id>": block
+// until the job reaches a terminal state, print that state word to stdout,
+// and exit 0. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout. It is the
+// scriptable face of manager.WaitTerminal for shell automation that would
+// otherwise poll agy_status.
+func waitJobMain(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("wait-job", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	timeout := fs.Duration("timeout", time.Hour, "max time to wait for the job")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "usage: agy-mcp wait-job [-timeout 1h] <job_id>")
+		return 2
+	}
+	id := fs.Arg(0)
+	st, terminal, err := waitForJob(id, *timeout)
+	if err != nil {
+		fmt.Fprintf(stderr, "wait-job: %v\n", err)
+		return 1
+	}
+	if !terminal {
+		fmt.Fprintf(stderr, "wait-job: job %s still running after %s\n", id, *timeout)
+		return 3
+	}
+	fmt.Fprintln(stdout, st.State)
+	return 0
+}
+
+// waitForJob resolves the wait-only config and blocks on the job. Shared by
+// wait-job and hook-wait so the two subcommands cannot diverge on how a wait
+// manager is built. The job itself is never signalled: SIGINT/SIGTERM cancel
+// only this observer's wait.
+func waitForJob(id string, timeout time.Duration) (manager.Status, bool, error) {
+	cfg, err := config.ResolveWait()
+	if err != nil {
+		return manager.Status{}, false, err
+	}
+	mgr := manager.New(cfg)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	return mgr.WaitTerminal(ctx, id, time.Now().Add(timeout), nil)
+}
+```
+
+In `main.go`, after the existing `run-job` block (keep its shape):
+
+```go
+	if len(os.Args) >= 2 && os.Args[1] == "wait-job" {
+		os.Exit(waitJobMain(os.Args[2:], os.Stdout, os.Stderr))
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test . -run TestWaitJob -race -v`
+Expected: PASS (all four).
+
+- [ ] **Step 5: Full check and commit**
+
+Run: `go build ./... && go test . -race`
+Expected: PASS (including the pre-existing main tests).
+
+```bash
+git add waitcmd.go waitcmd_posix_test.go main.go
+git commit -m "main: add wait-job subcommand"
+```
+
+---
+
+### Task 6: hook-wait CLI subcommand and hookinput parser
+
+**Files:**
+- Create: `internal/hookinput/hookinput.go`
+- Create: `internal/hookinput/hookinput_test.go`
+- Create: `hookwait.go` (package main)
+- Create: `hookwait_posix_test.go` (package main)
+- Modify: `main.go` (dispatch, beside Task 5's block)
+
+**Interfaces:**
+- Consumes: `waitForJob` (Task 5), `config.ResolveWait` (Task 4), `manager.New`, `manager.Status`, `manager.StateRunning`.
+- Produces: `func hookinput.Parse(r io.Reader) (jobID, toolName string, ok bool)`; `func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int`. CLI contract: exit 2 wakes Claude (terminal or timeout, message on stderr); every other outcome exits 0 silently.
+
+- [ ] **Step 1: Write failing parser tests**
+
+`internal/hookinput/hookinput_test.go`, table-driven over realistic Claude Code PostToolUse payloads:
+
+```go
+package hookinput
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name, in           string
+		wantID, wantTool   string
+		wantOK             bool
+	}{
+		{
+			name: "structured job_id",
+			in: `{"hook_event_name":"PostToolUse","tool_name":"mcp__agy__agy_run",
+			      "tool_input":{"prompt":"review"},
+			      "tool_response":{"job_id":"job-abc-123","state":"running"}}`,
+			wantID: "job-abc-123", wantTool: "mcp__agy__agy_run", wantOK: true,
+		},
+		{
+			name: "job_id nested in MCP content list",
+			in: `{"tool_name":"mcp__agy__agy_run",
+			      "tool_response":{"content":[{"type":"text","text":"{\"job_id\":\"job-xyz-9\",\"state\":\"running\"}"}]}}`,
+			wantID: "job-xyz-9", wantTool: "mcp__agy__agy_run", wantOK: true,
+		},
+		{
+			name:   "no job id",
+			in:     `{"tool_name":"mcp__agy__agy_run","tool_response":{"error":"conflict"}}`,
+			wantOK: false,
+		},
+		{
+			name:   "malformed json",
+			in:     `{"tool_name": `,
+			wantOK: false,
+		},
+		{
+			name:   "empty input",
+			in:     ``,
+			wantOK: false,
+		},
+		{
+			name: "run_sync tool name carried through",
+			in: `{"tool_name":"mcp__agy__agy_run_sync",
+			      "tool_response":{"job_id":"job-s-1","state":"done"}}`,
+			wantID: "job-s-1", wantTool: "mcp__agy__agy_run_sync", wantOK: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, tool, ok := Parse(strings.NewReader(tc.in))
+			if ok != tc.wantOK || id != tc.wantID || (ok && tool != tc.wantTool) {
+				t.Fatalf("Parse = (%q, %q, %v), want (%q, %q, %v)", id, tool, ok, tc.wantID, tc.wantTool, tc.wantOK)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/hookinput/ -v`
+Expected: FAIL, package does not exist yet.
+
+- [ ] **Step 3: Implement the parser**
+
+`internal/hookinput/hookinput.go`:
+
+```go
+// Package hookinput extracts the agy job id from a Claude Code PostToolUse
+// hook payload, for the hook-wait subcommand. Parsing is deliberately loose:
+// the payload's tool_response shape depends on the MCP client version (plain
+// structured output, or a content list whose text embeds the output JSON), so
+// the job id is found by walking, not by a fixed schema.
+package hookinput
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// maxDepth bounds the recursive walk so a pathological payload cannot
+// exhaust the stack. Real payloads are a handful of levels deep.
+const maxDepth = 32
+
+// payload is the subset of the PostToolUse hook input hook-wait needs.
+type payload struct {
+	ToolName     string          `json:"tool_name"`
+	ToolResponse json.RawMessage `json:"tool_response"`
+}
+
+// Parse decodes a PostToolUse payload from r and extracts the agy job id from
+// its tool response. ok is false when no job id is present; that is not an
+// error, a failed or foreign tool call simply has no job to wait for.
+func Parse(r io.Reader) (jobID, toolName string, ok bool) {
+	var p payload
+	if err := json.NewDecoder(r).Decode(&p); err != nil {
+		return "", "", false
+	}
+	var resp any
+	if err := json.Unmarshal(p.ToolResponse, &resp); err != nil {
+		return "", p.ToolName, false
+	}
+	id := findJobID(resp, 0)
+	return id, p.ToolName, id != ""
+}
+
+// findJobID walks maps and slices for a "job_id" string field. String values
+// that look like they embed JSON with a job id (MCP text content) are parsed
+// and walked too, so the id is found regardless of which layer carries it.
+func findJobID(v any, depth int) string {
+	if depth > maxDepth {
+		return ""
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		if id, isStr := t["job_id"].(string); isStr && id != "" {
+			return id
+		}
+		for _, child := range t {
+			if id := findJobID(child, depth+1); id != "" {
+				return id
+			}
+		}
+	case []any:
+		for _, child := range t {
+			if id := findJobID(child, depth+1); id != "" {
+				return id
+			}
+		}
+	case string:
+		if strings.Contains(t, `"job_id"`) {
+			var embedded any
+			if err := json.Unmarshal([]byte(t), &embedded); err == nil {
+				return findJobID(embedded, depth+1)
+			}
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 4: Parser tests pass, then write failing subcommand tests**
+
+Run: `go test ./internal/hookinput/ -race -v` -> PASS.
+
+`hookwait_posix_test.go` (`//go:build linux || darwin`, package main), reusing Task 5's `writeTerminalJob` fixture and env pattern (AGY_MCP_STATE_DIR + HOME both pointed at test dirs):
+
+```go
+// hookPayload builds the stdin JSON: fmt.Sprintf(`{"tool_name":%q,
+// "tool_response":{"job_id":%q,"state":"running"}}`, tool, id).
+//
+// TestHookWaitWakesOnDoneJob: fixture "job-hw-1" (done). hookWaitMain(nil,
+// strings.NewReader(hookPayload("mcp__agy__agy_run", "job-hw-1")), &errb)
+// returns 2; stderr contains "job-hw-1" and "state=done" and "agy_status".
+//
+// TestHookWaitQuietWhenRunSyncAlreadyTerminal: same fixture, tool name
+// "mcp__agy__agy_run_sync": returns 0, stderr empty (the sync caller already
+// received the result inline; a wake would be noise).
+//
+// TestHookWaitQuietOnNoJobID: hookWaitMain(nil, strings.NewReader(
+// `{"tool_name":"mcp__agy__agy_run","tool_response":{"error":"x"}}`), &errb)
+// returns 0, stderr empty.
+//
+// TestHookWaitWakesOnTimeout: slow real job as in TestWaitJobTimeout
+// (Sleep 2s fake, StartJob, env pointed at its stateDir); hookWaitMain(
+// []string{"-timeout", "100ms"}, strings.NewReader(hookPayload(
+// "mcp__agy__agy_run", job.ID)), &errb) returns 2 and stderr contains
+// "still running". Drain the job afterwards.
+//
+// TestHookWaitQuietOnUnknownJob: env points at an empty state dir;
+// payload references "job-none": returns 0 (the wait errors internally,
+// and internal errors never wake or disrupt the session).
+```
+
+Run: `go test . -run TestHookWait -v` -> FAIL, `undefined: hookWaitMain`.
+
+- [ ] **Step 5: Implement the subcommand**
+
+`hookwait.go`:
+
+```go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/tphakala/agy-mcp/internal/config"
+	"github.com/tphakala/agy-mcp/internal/hookinput"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// hookWaitMain implements "agy-mcp hook-wait [-timeout 1h]": read a Claude
+// Code PostToolUse hook payload from stdin, wait for the agy job it
+// references, and exit 2 with a wake message on stderr. Exit 2 is Claude
+// Code's asyncRewake wake signal; every other outcome exits 0 with no output,
+// because a hook that fails must never disrupt the tool flow it observes.
+// A timeout also wakes (exit 2): the model should learn the job is
+// long-running rather than never hearing back.
+func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
+	fs := flag.NewFlagSet("hook-wait", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // usage noise would land in the transcript; stay quiet
+	timeout := fs.Duration("timeout", time.Hour, "max time to wait for the job")
+	if err := fs.Parse(args); err != nil {
+		return 0
+	}
+	jobID, toolName, ok := hookinput.Parse(stdin)
+	if !ok {
+		return 0
+	}
+	// A sync tool that already returned a terminal result delivered it inline;
+	// waking Claude again would be noise. agy_run never delivers inline, so
+	// for it even an already-terminal job still gets its wake.
+	if strings.HasSuffix(toolName, "agy_run_sync") {
+		if cfg, err := config.ResolveWait(); err == nil {
+			if st, err := manager.New(cfg).Status(jobID); err == nil && st.State != manager.StateRunning {
+				return 0
+			}
+		}
+	}
+	st, terminal, err := waitForJob(jobID, *timeout)
+	if err != nil {
+		return 0
+	}
+	if terminal {
+		fmt.Fprintf(stderr, "agy job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",
+			jobID, st.State, st.Elapsed.Round(time.Second))
+	} else {
+		fmt.Fprintf(stderr, "agy job %s still running after %s; poll agy_status\n", jobID, *timeout)
+	}
+	return 2
+}
+```
+
+In `main.go`, beside the Task 5 block:
+
+```go
+	if len(os.Args) >= 2 && os.Args[1] == "hook-wait" {
+		os.Exit(hookWaitMain(os.Args[2:], os.Stdin, os.Stderr))
+	}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test . ./internal/hookinput/ -race -v -run 'TestHookWait|TestParse'`
+Expected: PASS.
+
+- [ ] **Step 7: Full check and commit**
+
+Run: `go build ./... && go test ./... -race`
+Expected: PASS everywhere.
+
+```bash
+git add internal/hookinput/ hookwait.go hookwait_posix_test.go main.go
+git commit -m "main: add hook-wait subcommand for Claude Code asyncRewake"
+```
+
+---
+
+### Task 7: README documentation
+
+**Files:**
+- Modify: `README.md` (Tools list at line 75-82; new section after the Tools section, before "HTTP mode")
+
+**Interfaces:**
+- Consumes: final tool/subcommand names and semantics from Tasks 3, 5, 6 exactly as specified there.
+- Produces: user-facing docs; nothing downstream.
+
+- [ ] **Step 1: Add agy_wait to the Tools list**
+
+After the `agy_status` line in the Tools list:
+
+```markdown
+- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, note? }`
+```
+
+And in the "What it provides" bullet list near the top, extend the first bullet: `agy_run` / `agy_status` / `agy_cancel` stays, and after the `agy_run_sync` bullet add:
+
+```markdown
+- `agy_wait`: block until an already-started job finishes (bounded, with MCP progress notifications); one call replaces an `agy_status` poll loop.
+```
+
+- [ ] **Step 2: Add the completion-wake section**
+
+New section after the Tools section (heading level matches "HTTP mode"). Prose paragraphs must each be one continuous line (no hard wrapping inside paragraphs; repo README follows this for new content, and GFM rendering is the reason). No em dashes. Content to cover, in this order:
+
+```markdown
+## Completion wake for Claude Code
+
+Claude Code does not surface MCP server notifications to the model: progress notifications are UI-only, and there is no server-initiated push that can wake the model when an async job finishes. Polling `agy_status` after `agy_run` is the protocol-level baseline. agy-mcp ships a hook bridge that turns job completion into a real wake instead, built on Claude Code's `asyncRewake` hook mechanism: a background PostToolUse hook that exits with code 2 wakes the model with the hook's stderr as a system reminder.
+
+Add to your Claude Code `settings.json`:
+
+    {
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "mcp__agy__agy_run(_sync)?",
+            "hooks": [
+              { "type": "command", "command": "agy-mcp hook-wait", "asyncRewake": true, "timeout": 3600 }
+            ]
+          }
+        ]
+      }
+    }
+
+How it behaves:
+
+- After every `agy_run`, the hook waits (in the background, off the session's critical path) for the job's completion sentinel and then wakes Claude with a one-line message naming the job id and final state, so the model calls `agy_status` exactly once, when the result is actually ready.
+- `agy_run_sync` calls that returned their result inline produce no wake; a sync call that overran its wait cap (and so returned a still-running job) gets the same completion wake as `agy_run`.
+- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes.
+- The matcher entry name `agy` is the server name from `claude mcp add agy`; adjust both if you registered the server under a different name.
+
+Two related subcommands, useful beyond Claude Code:
+
+- `agy-mcp wait-job [-timeout 1h] <job_id>` blocks until the job is terminal and prints the final state word (`done`, `failed`, or `cancelled`) to stdout. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout. It needs only the job state directory, not the agy binary, so it works in minimal environments.
+- `agy-mcp hook-wait [-timeout 1h]` is the hook entrypoint described above: it reads the PostToolUse payload from stdin, so it is not useful to invoke by hand, but it is a single self-contained binary call, no shell wrapper or jq required, and it works on Linux, macOS, and Windows.
+
+MCP clients other than Claude Code get the same no-polling benefit in-protocol: call `agy_wait` with the `job_id` returned by `agy_run` and the tool blocks (bounded by `wait`, default 2m, max 10m) until the job finishes.
+```
+
+- [ ] **Step 3: Verify rendering and style**
+
+Run: `grep -nE '\x{2014}|\x{2013}' README.md || echo clean` (expect `clean`; also run the same grep over every file the branch touches).
+Read the section back for hard-wrapped paragraphs (each prose paragraph must be a single line).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "README: document completion wake, agy_wait, and wait subcommands"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- `go build ./...`
+- `go test ./... -race`
+- `golangci-lint run`
+- `git log --oneline main..HEAD` shows one commit per task, package-prefixed.

--- a/hookwait.go
+++ b/hookwait.go
@@ -22,6 +22,12 @@ import (
 // because a hook that fails must never disrupt the tool flow it observes.
 // A timeout also wakes (exit 2): the model should learn the job is
 // long-running rather than never hearing back.
+//
+// Claude Code renders any exit-2 hook under a "Stop hook blocking error from
+// command ..." wrapper it prepends itself; we cannot change that wrapper, only
+// the stderr body below. Each wake message therefore leads with an explicit
+// "(not an error)" framing so the completion signal is not misread as a
+// failure of the observed tool call. Keep that framing on every wake message.
 func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
 	// Manager internals log via the std logger on rare error paths; any stray line
 	// would land in the transcript on a non-wake exit or prepend noise to the wake
@@ -71,14 +77,14 @@ func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
 		if !errors.Is(err, context.Canceled) {
 			return 0
 		}
-		_, _ = fmt.Fprintf(stderr, "agy job %s wait interrupted; the job may still be running; poll agy_status with this job_id\n", jobID)
+		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s wait interrupted; the job may still be running; poll agy_status with this job_id\n", jobID)
 		return 2
 	}
 	if terminal {
-		_, _ = fmt.Fprintf(stderr, "agy job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",
+		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",
 			jobID, st.State, st.Elapsed.Round(time.Second))
 	} else {
-		_, _ = fmt.Fprintf(stderr, "agy job %s still running after %s; poll agy_status\n", jobID, *timeout)
+		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s still running after %s; poll agy_status\n", jobID, *timeout)
 	}
 	return 2
 }

--- a/hookwait_posix_test.go
+++ b/hookwait_posix_test.go
@@ -24,6 +24,9 @@ func TestHookWaitWakesOnTimeout(t *testing.T) {
 	if !strings.Contains(errb.String(), "still running") {
 		t.Fatalf("stderr = %q, want it to mention still running", errb.String())
 	}
+	if !strings.Contains(errb.String(), "not an error") {
+		t.Fatalf("stderr = %q, want it to frame the wake as not an error", errb.String())
+	}
 }
 
 // TestHookWaitWakesOnInterrupt proves a SIGINT delivered to a waiting hook-wait
@@ -75,5 +78,8 @@ func TestHookWaitWakesOnInterrupt(t *testing.T) {
 	}
 	if !strings.Contains(errb.String(), "wait interrupted") {
 		t.Fatalf("stderr = %q, want it to mention wait interrupted", errb.String())
+	}
+	if !strings.Contains(errb.String(), "not an error") {
+		t.Fatalf("stderr = %q, want it to frame the wake as not an error", errb.String())
 	}
 }

--- a/hookwait_test.go
+++ b/hookwait_test.go
@@ -32,6 +32,11 @@ func TestHookWaitWakesOnDoneJob(t *testing.T) {
 	if !strings.Contains(out, "agy_status") {
 		t.Fatalf("stderr = %q, want it to mention agy_status", out)
 	}
+	// The wake rides Claude Code's "Stop hook blocking error" wrapper, so the body
+	// must frame itself as a notification, not a failure. Guard that framing.
+	if !strings.Contains(out, "not an error") {
+		t.Fatalf("stderr = %q, want it to frame the wake as not an error", out)
+	}
 }
 
 func TestHookWaitQuietWhenRunSyncAlreadyTerminal(t *testing.T) {


### PR DESCRIPTION
## Motivation

Feedback from real session use of the completion-wake hook (#84): the async wake works and is genuinely useful for the fire-and-forget flow (kick off an `agy_run`, keep working, the hook guarantees you come back and collect the result). But both firings surfaced under Claude Code's `Stop hook blocking error from command PostToolUse:mcp__agy__agy_run:` wrapper, so the completion signal reads as a tool *failure* rather than a job-done notification. It re-woke the model correctly, but the framing invites a misread by a less careful reader.

## What this changes

The exit-2 asyncRewake wrapper is Claude Code's own text; we cannot change it, only the stderr body. So each of the three wake messages now leads with an explicit `agy async job notification (not an error):` prefix that directly counters the wrapper:

- finished (the common case): `... job <id> finished: state=done elapsed=4m53s; call agy_status ...`
- still running (timeout): `... job <id> still running after <t>; poll agy_status`
- wait interrupted (SIGINT/SIGTERM): `... job <id> wait interrupted; the job may still be running; poll agy_status ...`

Behavior is unchanged: same exit codes, same wake conditions, same job ids and next-action guidance. This is wording only.

## Notes

- Added a maintainer comment on `hookWaitMain` documenting why the framing exists (so it is not stripped later).
- Locked the framing in with a `not an error` assertion on each of the three wake-message tests (done, timeout, interrupt).

## Verification

- `go build ./...`
- `go test ./... -race` (all packages pass)
- `golangci-lint run` (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified asynchronous job wake-up messages so they are explicitly identified as notifications rather than errors.
  * Preserved guidance for checking job status and reporting completion details.

* **Documentation**
  * Added implementation plans for more reliable conversation ID capture and improved job-completion waiting workflows.

* **Tests**
  * Expanded coverage to verify that timeout, interruption, and completed-job notifications include the “not an error” clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->