### PR TITLE
mcptools: steer long work to agy_run and name agy_wait on overrun

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Driving `agy` from a shell for automation has two recurring problems:
 ## What it provides
 
 - `agy_run` / `agy_status` / `agy_cancel`: start an `agy` prompt, poll for completion, cancel if needed.
-- `agy_run_sync`: start a prompt and wait for it inline (bounded, with MCP progress notifications); returns the `job_id` to poll if it outlives the wait cap.
+- `agy_run_sync`: start a prompt and wait for it inline (bounded, with MCP progress notifications); returns the `job_id` to wait on or poll if it outlives the wait cap.
 - `agy_wait`: block until an already-started job finishes (bounded, with MCP progress notifications); one call replaces an `agy_status` poll loop.
 - `list_models`: enumerate available `agy` models.
 - `list_sessions`: list known conversations so review threads can be continued.
@@ -135,7 +135,7 @@ How it behaves:
 
 - After every `agy_run`, the hook waits (in the background, off the session's critical path) for the job's completion sentinel and then wakes Claude with a one-line message naming the `job_id` and final state, prompting the model to call `agy_status` when the result is actually ready.
 - `agy_run_sync` calls that returned their result inline produce no wake; a sync call that overran its wait cap (and so returned a still-running job) gets the same completion wake as `agy_run`.
-- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost, provided the outer hook `timeout` exceeds hook-wait's own `-timeout` (see the `settings.json` note below). An externally interrupted wait (a SIGINT or SIGTERM delivered to hook-wait) also wakes, with a distinct "wait interrupted" message pointing at `agy_status`, rather than exiting silently and dropping the owed wake. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes. The hook-level `timeout` in `settings.json` (3700 above) must exceed hook-wait's own `-timeout` (1h by default), so hook-wait's internal timeout always fires first and reports the wake itself; if the outer `timeout` is equal or lower, Claude Code kills the hook process first and the exit-2 wake is lost, silently defeating that guarantee.
+- On timeout (default 1h, `-timeout` to change) the hook still wakes Claude, reporting the job as still running, so a long job is never silently lost, provided the outer hook `timeout` exceeds hook-wait's own `-timeout` (see the `settings.json` note below). An externally interrupted wait (a SIGINT or SIGTERM delivered to hook-wait) also wakes, with a distinct "wait interrupted" message pointing at `agy_wait` and `agy_status`, rather than exiting silently and dropping the owed wake. On any internal error the hook exits 0 silently; it can never disrupt the tool call it observes. The hook-level `timeout` in `settings.json` (3700 above) must exceed hook-wait's own `-timeout` (1h by default), so hook-wait's internal timeout always fires first and reports the wake itself; if the outer `timeout` is equal or lower, Claude Code kills the hook process first and the exit-2 wake is lost, silently defeating that guarantee.
 - The `agy` in the matcher pattern `mcp__agy__agy_run(_sync)?` is the server name you passed to `claude mcp add agy`; if you registered the server under a different name, change both the `claude mcp add` name and that `agy` segment of the matcher.
 - Claude Code runs hooks with the user's shell environment, not the MCP server entry's own env block, so if the server is registered with a custom `AGY_MCP_STATE_DIR` the same value must also be exported in the shell (or passed inline in the hook command) or hook-wait will silently look in the wrong state directory and never wake.
 
@@ -144,7 +144,7 @@ Two related subcommands, useful beyond Claude Code:
 - `agy-mcp wait-job [-timeout 1h] <job_id>` blocks until the job is terminal and prints the final state word (`done`, `failed`, or `cancelled`) to stdout. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout, 130 interrupted. It needs only the job state directory, not the agy binary, so it works in minimal environments.
 - `agy-mcp hook-wait [-timeout 1h]` is the hook entrypoint described above: it reads the PostToolUse payload from stdin, so it is not useful to invoke by hand, but it is a single self-contained binary call, no shell wrapper or jq required, and it works on Linux, macOS, and Windows. The file-based wake contract is exercised by tests on all three platforms; the signal-interrupt wake (SIGINT/SIGTERM) is a POSIX behavior and is tested there.
 
-MCP clients other than Claude Code get the same no-polling benefit in-protocol: call `agy_wait` with the `job_id` returned by `agy_run` and the tool blocks (bounded by `wait`, default 2m, max 10m) until the job finishes.
+MCP clients other than Claude Code get the same no-polling benefit in-protocol: call `agy_wait` with a `job_id` from `agy_run` (or from an `agy_run_sync` that outlived its inline wait) and the tool blocks (bounded by `wait`, default 2m, max 10m) until the job finishes.
 
 ## HTTP mode
 

--- a/hookwait.go
+++ b/hookwait.go
@@ -70,21 +70,25 @@ func hookWaitMain(args []string, stdin io.Reader, stderr io.Writer) int {
 		// An externally delivered SIGINT/SIGTERM cancels only this observer, not the
 		// job, which keeps running under its detached supervisor. Exiting 0 would
 		// silently drop an owed wake, contradicting the documented guarantee, so wake
-		// with a distinct message and point the model at agy_status. Only cancellation
+		// with a distinct message and point the model at agy_wait. Only cancellation
 		// wakes here; a genuine internal error still exits 0 to stay out of the tool
 		// flow. When the outer hook timeout killed this process the parent has already
 		// stopped listening, so the extra exit 2 is harmless.
 		if !errors.Is(err, context.Canceled) {
 			return 0
 		}
-		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s wait interrupted; the job may still be running; poll agy_status with this job_id\n", jobID)
+		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s wait interrupted; the job may still be running; wait for it with agy_wait or check agy_status with this job_id\n", jobID)
 		return 2
 	}
 	if terminal {
 		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s finished: state=%s elapsed=%s; call agy_status with this job_id to collect the result\n",
 			jobID, st.State, st.Elapsed.Round(time.Second))
 	} else {
-		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s still running after %s; poll agy_status\n", jobID, *timeout)
+		// Lead with agy_status here, unlike the tool-level note: this branch only
+		// fires once the job has already outrun hook-wait's own timeout (1h by
+		// default), so agy_wait's 10m cap would most likely just overrun again. One
+		// cheap status read is the better first move for a job this long-lived.
+		_, _ = fmt.Fprintf(stderr, "agy async job notification (not an error): job %s still running after %s; check agy_status, or call agy_wait to block for another bounded window\n", jobID, *timeout)
 	}
 	return 2
 }

--- a/internal/mcptools/await.go
+++ b/internal/mcptools/await.go
@@ -27,7 +27,8 @@ func parseWait(s string) (time.Duration, error) {
 // once-per-second MCP progress notifications when the client supplied a
 // progress token. It is the wait phase shared by agy_run_sync and agy_wait,
 // so their semantics cannot drift. On a wait-cap overrun the returned output
-// carries the standard poll-with-agy_status note.
+// carries the standard still-running note, which names agy_wait before
+// agy_status.
 func awaitJob(ctx context.Context, req *mcp.CallToolRequest, mgr *manager.Manager, jobID string, deadline time.Time) (runSyncOutput, error) {
 	token := req.Params.GetProgressToken()
 	// Notify once per elapsed second, not per poll tick: the message has
@@ -61,13 +62,20 @@ func awaitJob(ctx context.Context, req *mcp.CallToolRequest, mgr *manager.Manage
 			// The client gave up on the call; the job stays alive under its
 			// detached supervisor. Carry the job id in the error so a
 			// gracefully-cancelling client can still find the job.
-			return runSyncOutput{}, fmt.Errorf("wait cancelled; job %s is still running, poll it with agy_status: %w", jobID, err)
+			return runSyncOutput{}, fmt.Errorf("wait cancelled; job %s is still running, wait for it with agy_wait or check it with agy_status: %w", jobID, err)
 		}
 		return runSyncOutput{}, fmt.Errorf("job %s status read failed: %w", jobID, err)
 	}
 	out := runSyncOutput{JobID: jobID, statusOutput: toStatusOutput(st)}
 	if !terminal {
-		out.Note = "wait cap reached; the job is still running, poll it with agy_status"
+		// Name agy_wait first: one blocking call is cheaper than an agy_status poll
+		// loop, and the note is the instruction a caller actually acts on at overrun
+		// (the tool description is far away by then). Saying the job is still running
+		// also has to be unambiguous, or a caller reads "not done" as "failed" and
+		// re-sends the same prompt, paying for the work twice.
+		out.Note = "wait cap reached; this is not a failure, the job is still running. " +
+			"Call agy_wait with this job_id to block until it finishes, or agy_status to check it now. " +
+			"Do not re-send the prompt."
 	}
 	return out, nil
 }

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -13,14 +13,14 @@ const (
 	// does not say otherwise; quick models finish well inside it.
 	defaultSyncWait = 2 * time.Minute
 	// maxSyncWait caps caller-supplied waits so a tool call cannot park a
-	// session indefinitely; longer runs are for agy_run + agy_status.
+	// session indefinitely; longer runs are for agy_run + agy_wait/agy_status.
 	maxSyncWait = 10 * time.Minute
 )
 
 // runSyncInput is runInput plus the inline wait cap.
 type runSyncInput struct {
 	runInput
-	Wait string `json:"wait,omitempty" jsonschema:"max time to wait inline (Go duration, default 2m, max 10m); on overrun the job keeps running and the job_id is returned for agy_status polling"`
+	Wait string `json:"wait,omitempty" jsonschema:"max time to wait inline (Go duration, default 2m, max 10m); on overrun the job keeps running and the job_id is returned for agy_wait or agy_status"`
 }
 
 type runSyncOutput struct {
@@ -35,10 +35,12 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: toolAgyRunSync,
 		Description: "Delegate a prompt to an agy model and wait for the result inline (bounded by wait, default 2m). " +
-			"Use for peer review, a second opinion, research, or any task whose answer you need before your next step. " +
+			"Use when the answer is needed before the next step AND the task is bounded enough to finish within the wait: " +
+			"a focused peer review, a second opinion, a rubber-duck question. " +
 			"Sends MCP progress notifications while waiting. If the job outlives the wait cap " +
-			"it keeps running and the returned job_id can be polled with agy_status or waited on with agy_wait. " +
-			"For long runs or parallel work, prefer agy_run.",
+			"it keeps running and the returned job_id can be waited on with agy_wait or polled with agy_status. " +
+			"For open-ended work that routinely runs past the wait cap (web research, a whole-codebase review), " +
+			"and for parallel work, prefer agy_run.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in runSyncInput) (*mcp.CallToolResult, runSyncOutput, error) {
 		wait, err := parseWait(in.Wait)
 		if err != nil {

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -72,7 +72,7 @@ type runOutput struct {
 }
 
 type statusInput struct {
-	JobID string `json:"job_id" jsonschema:"the job id returned by agy_run"`
+	JobID string `json:"job_id" jsonschema:"the job id returned by agy_run or agy_run_sync"`
 }
 
 type statusOutput struct {
@@ -87,7 +87,7 @@ type statusOutput struct {
 }
 
 // toStatusOutput converts a manager status into its wire shape, shared by
-// agy_status and agy_run_sync so the two cannot drift.
+// agy_status, agy_run_sync and agy_wait so they cannot drift.
 func toStatusOutput(st manager.Status) statusOutput {
 	return statusOutput{
 		State:          st.State,
@@ -145,8 +145,9 @@ const serverInstructions = `agy delegates a prompt to a background coding agent 
 - Background delegation: fire off an independent task and reconcile the result later, so two things run at once.
 
 Choosing a tool:
-- agy_run_sync starts a run and waits inline (bounded by the wait argument). Use it when you need the answer before your next step.
-- agy_run returns a job_id immediately; poll it with agy_status or block on it with agy_wait. Use these for long runs or to fan several tasks out in parallel.
+- agy_run_sync starts a run and waits inline (bounded by the wait argument). Use it when you need the answer before your next step and the task is bounded enough to finish within that wait.
+- agy_run returns a job_id immediately; block on it with agy_wait or poll it with agy_status. Use these for long runs, for open-ended work that routinely outlives an inline wait (web research, a large review), or to fan several tasks out in parallel.
+- Outliving the inline wait is not a failure: the job keeps running under its own supervisor and the returned job_id still resolves to its outcome. Wait on it or poll it; do not re-send the prompt.
 - list_models enumerates models; call it only if you want to override the default. list_sessions lists known conversations.
 
 Notes:
@@ -163,7 +164,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        toolAgyRun,
-		Description: "Delegate a prompt to a background agy model as an async job (peer review, research, or any self-contained task) and keep working. Returns a job_id; poll with agy_status or block with agy_wait. Prefer this over agy_run_sync for long runs or to fan several tasks out in parallel.",
+		Description: "Delegate a prompt to a background agy model as an async job (peer review, research, or any self-contained task) and keep working. Returns a job_id; block on it with agy_wait or poll it with agy_status. Prefer this over agy_run_sync for long runs, for open-ended work that routinely outlives an inline wait (web research, a large review), or to fan several tasks out in parallel.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runInput) (*mcp.CallToolResult, runOutput, error) {
 		req, err := in.toStartRequest()
 		if err != nil {

--- a/internal/mcptools/wait.go
+++ b/internal/mcptools/wait.go
@@ -21,10 +21,12 @@ type waitInput struct {
 func registerWait(s *mcp.Server, mgr *manager.Manager) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name: toolAgyWait,
-		Description: "Block until an agy_run job finishes (bounded by wait, default 2m, max 10m). " +
-			"Sends MCP progress notifications while waiting. Prefer one agy_wait over repeated " +
-			"agy_status polling when the next step depends on the job's result. If the job " +
-			"outlives the wait cap it keeps running; call agy_wait again or poll agy_status.",
+		Description: "Block until an agy job finishes (bounded by wait, default 2m, max 10m). " +
+			"Accepts any job_id, whether it came from agy_run or from an agy_run_sync that " +
+			"outlived its inline wait. Sends MCP progress notifications while waiting. Prefer " +
+			"one agy_wait over repeated agy_status polling when the next step depends on the " +
+			"job's result. If the job outlives the wait cap that is not a failure: it keeps " +
+			"running; call agy_wait again or poll agy_status.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in waitInput) (*mcp.CallToolResult, runSyncOutput, error) {
 		wait, err := parseWait(in.Wait)
 		if err != nil {


### PR DESCRIPTION
## Summary

An `agy_run_sync` call that outlives its wait cap returns normally: `state=running`, the `job_id`, and a note, while the job keeps running under its detached supervisor. Nothing has failed. The guidance around that path pushed callers the wrong way in two respects, and this fixes both.

**Research was advertised on the wrong tool.** The `agy_run_sync` description listed "research" as a use case, which is exactly the open-ended shape that routinely outruns the 2m default wait. Research and whole-codebase reviews now route to `agy_run`, and `agy_run_sync` is gated on the task being bounded enough to finish within the wait.

**`agy_wait` was never mentioned at the moment it was most useful.** Every surface described an overrun as something to poll `agy_status` about, so the cheapest recovery, one blocking call, was the one option the caller was not told about. The overrun note and the wait-cancelled error now name `agy_wait` first, and say outright that an overrun is not a failure, so a caller does not read "still running" as "broken" and re-send the prompt, paying for the same work twice.

Recommending those two tools with a `job_id` from `agy_run_sync` then exposed sibling surfaces still describing them as `agy_run`-only: `agy_wait`'s own description ("block until an **agy_run** job finishes"), `agy_status`'s `job_id` schema, the hook-wait wake messages, and two README sentences. Both tools have always accepted any job id, since `agy_run` and `agy_run_sync` share one `StartJob` and the job store is not origin-aware, so this is wording rather than behaviour. They are updated so the recommendation is not contradicted by the tool it recommends.

Two deliberate asymmetries worth calling out. The hook-wait "still running" wake keeps leading with `agy_status`, because it only fires once a job has already outrun hook-wait's own 1h timeout, so `agy_wait`'s 10m cap would most likely just overrun again. And an overclaim was removed: the new instructions initially said a `job_id` "still resolves to the full result", but `manager.Status` marks a result recovered without a completion sentinel as `partial` and possibly truncated, which `agy_status`'s description already documents.

## Behaviour change for existing users

No API, schema, CLI, or on-disk format changes. But tool descriptions and server instructions are sent fresh at every MCP `initialize`, so this changes which tool a model reaches for by default on research-shaped prompts as soon as the upgraded binary is used. There is no version gate and no opt-out. That is the intent of the change, recorded here so it is discoverable from the history.

## Test Plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` full suite passing
- [x] `golangci-lint run ./...` 0 issues
- [x] `TestHTTPServeAdvertisesInstructions` still passes: it asserts the instructions contain `Peer review`, `agy_run_sync` and `conflict error`, and that both entry-point tool descriptions still name a use case (`peer review`); all four anchors are preserved
- [x] Verified no consumer parses the changed prose. `internal/hookinput` walks for the `job_id` and `state` keys only, and the two tests touching `note` assert non-emptiness rather than wording