### PR TITLE
config: start without agy on PATH, defer the lookup to first exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Two transports run the same core:
 ## Requirements
 
 - The `agy` binary on `PATH` (or configured explicitly via `AGY_MCP_AGY_PATH`). agy 1.0.9 or newer is recommended (see the continuation note below).
+
+  A missing `agy` does not stop the server from starting. `initialize`, `tools/list`, and `list_sessions` never exec it, so the lookup is deferred: the server starts, logs a warning to stderr, serves discovery normally, and the tools that do need the binary (`agy_run`, `agy_run_sync`, `list_models`) fail per call with `agy not found on PATH; set AGY_MCP_AGY_PATH`. An `agy` installed later is picked up without restarting the server. An explicit `AGY_MCP_AGY_PATH` is treated differently: it is a claim about one specific binary, so a typo or a non-executable target still fails fast at startup.
 - Go 1.26+ to build.
 - The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) is implemented on **Linux** and **macOS** (process groups, SIGTERM cancel, an advisory flock) and on **Windows** (Job Objects, `OpenProcess` + process creation time, `LockFileEx`); stdio/HTTP serving, `list_models`, and `list_sessions` work identically everywhere.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,32 +43,27 @@ func Resolve() (Config, error) {
 	c.DefaultModel = os.Getenv("AGY_MCP_DEFAULT_MODEL")
 	c.HTTPToken = os.Getenv("AGY_MCP_HTTP_TOKEN")
 
+	// The two lookup branches fail differently, on purpose.
+	//
+	// An explicit AGY_MCP_AGY_PATH is a claim about one specific binary, so a typo,
+	// a non-executable file, or a bad PATH-relative name fails fast at startup
+	// rather than surfacing on the first job.
+	//
+	// A bare PATH miss is not an error at all. initialize, tools/list, and
+	// list_sessions never exec agy, so refusing to start would deny a client the
+	// whole introspection surface over a binary it may not be about to use, and
+	// would make the server unrunnable in a container that has no agy at all.
+	// AgyPath is left empty and AgyBinary retries the lookup at exec time, where a
+	// genuinely missing agy becomes a clear per-call error instead.
 	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {
-		// Resolve the override with LookPath, symmetric with the PATH branch below, so
-		// a typo, a non-executable file, or a bad PATH-relative name fails fast at
-		// startup instead of only at exec time on the first job. LookPath also handles
-		// a bare name (PATH lookup).
-		resolved, err := exec.LookPath(p)
+		resolved, err := lookupAgy(p)
 		if err != nil {
 			return Config{}, fmt.Errorf("AGY_MCP_AGY_PATH %q: %w", p, err)
 		}
 		c.AgyPath = resolved
-	} else {
-		p, err := exec.LookPath("agy")
-		if err != nil {
-			return Config{}, fmt.Errorf("agy not found on PATH; set AGY_MCP_AGY_PATH: %w", err)
-		}
-		c.AgyPath = p
+	} else if resolved, err := lookupAgy("agy"); err == nil {
+		c.AgyPath = resolved
 	}
-	// agy runs under the supervisor with cmd.Dir set to the job's cwd, so AgyPath
-	// must be absolute or it would resolve against the wrong directory; LookPath can
-	// return a relative path (a relative override, or a relative PATH entry). Report
-	// the pre-Abs value on failure since Abs returns "" then.
-	abs, err := filepath.Abs(c.AgyPath)
-	if err != nil {
-		return Config{}, fmt.Errorf("resolve agy path %q: %w", c.AgyPath, err)
-	}
-	c.AgyPath = abs
 
 	self, err := resolveSupervisorExe()
 	if err != nil {
@@ -83,6 +78,43 @@ func Resolve() (Config, error) {
 	c.StateDir = stateRoot
 
 	return c, nil
+}
+
+// AgyBinary returns the absolute path to the agy binary. Every site that execs
+// agy must go through it rather than reading AgyPath directly.
+//
+// AgyPath is empty when agy was not on PATH at startup, because Resolve defers
+// that lookup instead of refusing to start (see Resolve). The lookup is retried
+// here, at the moment agy is actually needed, so the error lands on the tool
+// call that needs it. A side benefit: an agy installed after the server started
+// is picked up without a restart.
+//
+// A path already resolved at startup is returned unchanged. Re-running LookPath
+// per job would let a mid-session PATH change swap the binary under a running
+// server, which is exactly the ambiguity the startup resolution removes.
+func (c Config) AgyBinary() (string, error) {
+	if c.AgyPath != "" {
+		return c.AgyPath, nil
+	}
+	return lookupAgy("agy")
+}
+
+// lookupAgy resolves an agy name or path to an absolute executable path. It is
+// shared by Resolve and AgyBinary so the two can never disagree about what
+// counts as a usable binary. Absolutizing is not optional: agy runs under the
+// supervisor with cmd.Dir set to the job's cwd, so a relative result (a relative
+// override, or a relative PATH entry) would resolve against the wrong directory.
+// Report the pre-Abs value on failure since Abs returns "" then.
+func lookupAgy(name string) (string, error) {
+	p, err := exec.LookPath(name)
+	if err != nil {
+		return "", fmt.Errorf("agy not found on PATH; set AGY_MCP_AGY_PATH: %w", err)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve agy path %q: %w", p, err)
+	}
+	return abs, nil
 }
 
 // resolveStateDir returns the job-state root: AGY_MCP_STATE_DIR (made absolute)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -96,7 +97,11 @@ func (c Config) AgyBinary() (string, error) {
 	if c.AgyPath != "" {
 		return c.AgyPath, nil
 	}
-	return lookupAgy("agy")
+	p, err := lookupAgy("agy")
+	if err != nil {
+		return "", pathLookupGuidance(err)
+	}
+	return p, nil
 }
 
 // lookupAgy resolves an agy name or path to an absolute executable path. It is
@@ -105,16 +110,36 @@ func (c Config) AgyBinary() (string, error) {
 // supervisor with cmd.Dir set to the job's cwd, so a relative result (a relative
 // override, or a relative PATH entry) would resolve against the wrong directory.
 // Report the pre-Abs value on failure since Abs returns "" then.
+//
+// The LookPath error is returned unwrapped. Each caller knows what the name it
+// passed meant and adds guidance to match: an explicit override that fails is a
+// different problem from a bare PATH miss, and telling someone who just set
+// AGY_MCP_AGY_PATH to set AGY_MCP_AGY_PATH points them away from the real fault.
 func lookupAgy(name string) (string, error) {
 	p, err := exec.LookPath(name)
 	if err != nil {
-		return "", fmt.Errorf("agy not found on PATH; set AGY_MCP_AGY_PATH: %w", err)
+		return "", err
 	}
 	abs, err := filepath.Abs(p)
 	if err != nil {
 		return "", fmt.Errorf("resolve agy path %q: %w", p, err)
 	}
 	return abs, nil
+}
+
+// pathLookupGuidance annotates a failed bare-name PATH lookup with the fix.
+//
+// exec.ErrDot is called out separately because it is not a missing binary at
+// all: agy was found, through a relative PATH entry, and Go refuses to run it
+// because the result would depend on the caller's working directory. That is
+// precisely the situation a job hits, since each one runs with cmd.Dir set to
+// its own cwd, so reporting it as "not found" would send the reader hunting for
+// an installation that is already there.
+func pathLookupGuidance(err error) error {
+	if errors.Is(err, exec.ErrDot) {
+		return fmt.Errorf("agy is on PATH only through a relative entry, which cannot be used because each job runs in its own working directory; set AGY_MCP_AGY_PATH to an absolute path: %w", err)
+	}
+	return fmt.Errorf("agy not found on PATH; set AGY_MCP_AGY_PATH: %w", err)
 }
 
 // resolveStateDir returns the job-state root: AGY_MCP_STATE_DIR (made absolute)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -232,7 +232,8 @@ func TestAgyBinaryRejectsRelativePathEntry(t *testing.T) {
 	// binary found via a relative PATH entry would mean a different program per
 	// job. Go's LookPath refuses that outright (exec.ErrDot); the point here is
 	// that AgyBinary surfaces the refusal instead of execing something
-	// cwd-dependent.
+	// cwd-dependent, and explains it as what it is. "not found" would be a lie:
+	// agy is right there, it just cannot be addressed safely.
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "agy"), []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatal(err)
@@ -241,8 +242,34 @@ func TestAgyBinaryRejectsRelativePathEntry(t *testing.T) {
 	t.Setenv("PATH", ".")
 
 	var c Config
-	if _, err := c.AgyBinary(); err == nil {
+	_, err := c.AgyBinary()
+	if err == nil {
 		t.Fatal("AgyBinary must refuse an agy found via a relative PATH entry")
+	}
+	if !strings.Contains(err.Error(), "relative") {
+		t.Errorf("error should explain the relative PATH entry, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "not found on PATH") {
+		t.Errorf("agy was found, just not usably; error must not claim otherwise: %v", err)
+	}
+}
+
+func TestResolveOverrideErrorDoesNotEchoTheFix(t *testing.T) {
+	// The override branch must not inherit the PATH branch's guidance. Telling
+	// someone who just set AGY_MCP_AGY_PATH to "set AGY_MCP_AGY_PATH" sends them
+	// looking in the wrong place; the useful part is which value failed and why.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("AGY_MCP_AGY_PATH", missing)
+
+	_, err := Resolve()
+	if err == nil {
+		t.Fatal("Resolve should fail when AGY_MCP_AGY_PATH points at a missing file")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error should name the value that failed, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "set AGY_MCP_AGY_PATH") {
+		t.Errorf("error tells the user to set the variable they already set: %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,14 +62,29 @@ func TestResolveDefaultModelAndJobTTL(t *testing.T) {
 	}
 }
 
-// TestResolveAgyNotOnPath: with no override and no agy on PATH, Resolve fails
-// fast with a clear error rather than deferring to exec time.
-func TestResolveAgyNotOnPath(t *testing.T) {
-	t.Setenv("AGY_MCP_AGY_PATH", "")
-	t.Setenv("PATH", t.TempDir()) // empty dir: no agy anywhere on PATH
+// TestResolveWaitSkipsAgyLookupWhenPresent pins the seam between the two
+// resolvers using the case that still separates them: with agy sitting on PATH,
+// Resolve records it and ResolveWait deliberately does not. The wait-only
+// subcommands are pure observers of the job store and must never grow a
+// dependency on the binary. (The no-agy direction is TestResolveWaitNeedsNoAgy,
+// kept untagged so it also covers Windows.)
+func TestResolveWaitSkipsAgyLookupWhenPresent(t *testing.T) {
+	fakeAgyOnPath(t)
+	t.Setenv("AGY_MCP_STATE_DIR", t.TempDir())
 
-	if _, err := Resolve(); err == nil || !strings.Contains(err.Error(), "agy not found on PATH") {
-		t.Fatalf("err = %v, want an 'agy not found on PATH' error", err)
+	c, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if c.AgyPath == "" {
+		t.Fatal("Resolve left AgyPath empty with agy on PATH; the control condition is broken")
+	}
+	w, err := ResolveWait()
+	if err != nil {
+		t.Fatalf("ResolveWait: %v", err)
+	}
+	if w.AgyPath != "" {
+		t.Errorf("wait config resolved a binary it must not need: agy=%q", w.AgyPath)
 	}
 }
 
@@ -157,6 +172,91 @@ func TestResolveAgyPathOverrideNotExecutable(t *testing.T) {
 	t.Setenv("AGY_MCP_AGY_PATH", agy)
 	if _, err := Resolve(); err == nil {
 		t.Fatal("Resolve should fail when AGY_MCP_AGY_PATH is not executable")
+	}
+}
+
+// TestResolveWithoutAgyOnPathDefers pins the asymmetry between the two lookup
+// branches. An explicit AGY_MCP_AGY_PATH is a claim about a specific binary, so
+// a bad one fails fast (see TestResolveAgyPathOverrideMissing). A bare PATH miss
+// is not: initialize, tools/list, and list_sessions never exec agy, so refusing
+// to start would make the server unusable for introspection (and unrunnable in
+// a container that has no agy). Defer that lookup to the first exec instead.
+func TestResolveWithoutAgyOnPathDefers(t *testing.T) {
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	t.Setenv("AGY_MCP_STATE_DIR", t.TempDir())
+	t.Setenv("PATH", t.TempDir()) // an empty dir: no agy anywhere on PATH
+
+	c, err := Resolve()
+	if err != nil {
+		t.Fatalf("Resolve must succeed without agy on PATH: %v", err)
+	}
+	if c.AgyPath != "" {
+		t.Errorf("AgyPath = %q, want empty so the lookup is retried at exec time", c.AgyPath)
+	}
+}
+
+func TestAgyBinaryUsesPathResolvedAtStartup(t *testing.T) {
+	// A path already resolved by Resolve wins without consulting PATH again: a
+	// mid-session PATH change must not silently swap the binary under running jobs.
+	t.Setenv("PATH", t.TempDir())
+	got, err := Config{AgyPath: "/opt/agy/agy"}.AgyBinary()
+	if err != nil {
+		t.Fatalf("AgyBinary: %v", err)
+	}
+	if got != "/opt/agy/agy" {
+		t.Errorf("AgyBinary = %q, want the startup-resolved path", got)
+	}
+}
+
+func TestAgyBinaryLooksUpDeferredPath(t *testing.T) {
+	// The deferred case: agy was absent at startup but is present now, so the
+	// first job picks it up without needing a server restart.
+	dir := t.TempDir()
+	agy := filepath.Join(dir, "agy")
+	if err := os.WriteFile(agy, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := Config{}.AgyBinary()
+	if err != nil {
+		t.Fatalf("AgyBinary: %v", err)
+	}
+	if got != agy {
+		t.Errorf("AgyBinary = %q, want %q", got, agy)
+	}
+}
+
+func TestAgyBinaryRejectsRelativePathEntry(t *testing.T) {
+	// agy runs under the supervisor with cmd.Dir set to the job's cwd, so a
+	// binary found via a relative PATH entry would mean a different program per
+	// job. Go's LookPath refuses that outright (exec.ErrDot); the point here is
+	// that AgyBinary surfaces the refusal instead of execing something
+	// cwd-dependent.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "agy"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	t.Setenv("PATH", ".")
+
+	var c Config
+	if _, err := c.AgyBinary(); err == nil {
+		t.Fatal("AgyBinary must refuse an agy found via a relative PATH entry")
+	}
+}
+
+func TestAgyBinaryMissingNamesTheOverride(t *testing.T) {
+	// The deferred lookup carries the startup error's guidance: a user who never
+	// saw a startup failure meets this message on their first job instead.
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := Config{}.AgyBinary()
+	if err == nil {
+		t.Fatal("AgyBinary must fail when agy is not on PATH")
+	}
+	if !strings.Contains(err.Error(), "AGY_MCP_AGY_PATH") {
+		t.Errorf("error should point at the override env var, got: %v", err)
 	}
 }
 

--- a/internal/config/config_wait_test.go
+++ b/internal/config/config_wait_test.go
@@ -5,9 +5,11 @@ import (
 )
 
 // TestResolveWaitNeedsNoAgy: ResolveWait must succeed with no agy anywhere on
-// PATH (the wait-only subcommands are pure observers of the job store), while
-// Resolve fails in the same environment, proving the seam matters. Untagged so
-// it runs on Windows too, where the wait subcommands ship the same guarantee.
+// PATH, since the wait-only subcommands are pure observers of the job store.
+// Untagged so it runs on Windows too, where the wait subcommands ship the same
+// guarantee. Resolve tolerates a missing agy as well now (it defers the lookup
+// to exec time), so the seam between the two resolvers is pinned by
+// TestResolveWaitSkipsAgyLookupWhenPresent instead, with agy actually present.
 func TestResolveWaitNeedsNoAgy(t *testing.T) {
 	// os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows; pin both to
 	// temp dirs so the XDG fallback (should Resolve reach it) never touches the
@@ -22,9 +24,6 @@ func TestResolveWaitNeedsNoAgy(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("AGY_MCP_STATE_DIR", stateDir)
 
-	if _, err := Resolve(); err == nil {
-		t.Fatal("Resolve succeeded without agy on PATH; the control condition is broken")
-	}
 	c, err := ResolveWait()
 	if err != nil {
 		t.Fatalf("ResolveWait: %v", err)

--- a/internal/manager/agybinary_test.go
+++ b/internal/manager/agybinary_test.go
@@ -1,0 +1,58 @@
+package manager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/internal/proc"
+)
+
+// noAgyOnPath empties PATH so exec.LookPath("agy") cannot succeed. It models the
+// state config.Resolve now tolerates: a server that started with no agy
+// installed, leaving the lookup to the first call that actually execs it.
+func noAgyOnPath(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+// TestListModelsWithoutAgyReportsClearly: the startup error moved to the call
+// site, so it must arrive intact. Execing an empty AgyPath would surface as
+// "exec: no command", which says nothing about what the operator should fix.
+func TestListModelsWithoutAgyReportsClearly(t *testing.T) {
+	noAgyOnPath(t)
+	m := newManager(t, managerOpts{})
+
+	_, err := m.ListModels(t.Context())
+	if err == nil {
+		t.Fatal("ListModels must fail when agy cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "agy not found on PATH") {
+		t.Errorf("error should name the missing binary, got: %v", err)
+	}
+}
+
+// TestStartJobWithoutAgyReportsClearlyAndHoldsNoGate covers the same message on
+// the job path, plus where the lookup sits: before admission. Resolving after
+// admit would let a missing agy burn a concurrency slot and hold the cwd key,
+// blocking every later same-cwd run for the life of the process.
+func TestStartJobWithoutAgyReportsClearlyAndHoldsNoGate(t *testing.T) {
+	if !proc.Supported {
+		t.Skip("StartJob refuses on platforms without job supervision before it ever looks for agy")
+	}
+	noAgyOnPath(t)
+	m := newManager(t, managerOpts{})
+
+	_, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err == nil {
+		t.Fatal("StartJob must fail when agy cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "agy not found on PATH") {
+		t.Errorf("error should name the missing binary, got: %v", err)
+	}
+	if m.gate.inFlight != 0 {
+		t.Errorf("in-flight = %d, want 0: a refused start must not consume a slot", m.gate.inFlight)
+	}
+	if len(m.gate.keys) != 0 {
+		t.Errorf("gate holds %v, want no keys: a refused start must not block later same-cwd runs", m.gate.keys)
+	}
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -329,6 +329,14 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	if !proc.Supported {
 		return Job{}, proc.ErrUnsupported
 	}
+	// Resolve agy before anything reservable is taken. config.Resolve tolerates a
+	// missing agy so the server can still serve introspection, which makes this
+	// the first point that genuinely needs the binary; doing it after admit would
+	// burn a concurrency slot and strand the cwd key on a run that cannot start.
+	agy, err := m.cfg.AgyBinary()
+	if err != nil {
+		return Job{}, err
+	}
 	id, err := newID()
 	if err != nil {
 		return Job{}, fmt.Errorf("generate job id: %w", err)
@@ -397,7 +405,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	args := buildAgyArgs(req)
 	meta := jobstore.Meta{
 		ID:             id,
-		AgyPath:        m.cfg.AgyPath,
+		AgyPath:        agy,
 		Args:           args,
 		Cwd:            req.Cwd,
 		Model:          req.Model,

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -10,7 +10,11 @@ import (
 
 // ListModels runs `agy models` and returns the available model names.
 func (m *Manager) ListModels(ctx context.Context) ([]string, error) {
-	out, err := exec.CommandContext(ctx, m.cfg.AgyPath, "models").Output()
+	agy, err := m.cfg.AgyBinary()
+	if err != nil {
+		return nil, err
+	}
+	out, err := exec.CommandContext(ctx, agy, "models").Output()
 	if err != nil {
 		// Output() captures stderr into (*exec.ExitError).Stderr; include it so a
 		// real cause (an auth prompt, a usage error) is visible instead of a bare

--- a/main.go
+++ b/main.go
@@ -79,6 +79,13 @@ func serve() error {
 			cfg.HTTPToken = *httpToken
 		}
 	})
+	if cfg.AgyPath == "" {
+		// Resolve deferred the lookup rather than refusing to start, so say once what
+		// that means. Without this the server looks healthy and every run fails, which
+		// is a worse diagnostic than the startup refusal this replaced. log goes to
+		// stderr; stdout is the JSON-RPC stream in stdio mode and must stay clean.
+		log.Print("agy not found on PATH: the server will serve tool discovery, but agy_run, agy_run_sync, and list_models fail until agy is installed or AGY_MCP_AGY_PATH is set")
+	}
 	mgr := manager.New(cfg)
 	// Run startup garbage collection and concurrency-gate restoration in one
 	// job-store scan (RestoreAndCollect), instead of two back-to-back scans that

--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,15 @@ var builtBin string
 // are per-test and unavailable here (this is package-level, with no *testing.T),
 // so TestMain owns the cleanup instead.
 var buildBinary = sync.OnceValues(func() (string, error) {
-	f, err := os.CreateTemp("", "agy-mcp-*")
+	// Windows resolves an executable through PATHEXT, so an extensionless file is
+	// not runnable there no matter that it is a valid PE binary: exec.Command
+	// reports "executable file not found in %PATH%" for it. CreateTemp substitutes
+	// the last "*", so the suffix survives.
+	pattern := "agy-mcp-*"
+	if runtime.GOOS == "windows" {
+		pattern = "agy-mcp-*.exe"
+	}
+	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", err
 	}

--- a/serve_noagy_test.go
+++ b/serve_noagy_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestServeIntrospectsWithoutAgy is the end-to-end guarantee behind the deferred
+// lookup: the real binary, started with no agy reachable anywhere on PATH, must
+// still complete initialize and answer tools/list.
+//
+// This is what a client sees before it ever runs a prompt, and what an automated
+// directory check sees in a container that has only the agy-mcp binary in it.
+// Refusing to start there made the server undiscoverable over a dependency that
+// introspection never touches.
+func TestServeIntrospectsWithoutAgy(t *testing.T) {
+	bin, err := buildBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin)
+	// An empty PATH plus a state dir of our own, so the server cannot find agy and
+	// cannot touch the developer's real job store. HOME/USERPROFILE are pinned too:
+	// the XDG fallback reads them when AGY_MCP_STATE_DIR is unset, and this run
+	// must not depend on the ambient home either way.
+	home := t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"PATH="+t.TempDir(),
+		"AGY_MCP_AGY_PATH=",
+		"AGY_MCP_STATE_DIR="+t.TempDir(),
+		"HOME="+home,
+		"USERPROFILE="+home,
+	)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "introspect", Version: "0"}, nil)
+	ctx := t.Context()
+	cs, err := client.Connect(ctx, &mcp.CommandTransport{Command: cmd}, nil)
+	if err != nil {
+		t.Fatalf("initialize must succeed without agy on PATH: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	tools, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("tools/list must succeed without agy on PATH: %v", err)
+	}
+	got := make(map[string]bool, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		got[tool.Name] = true
+	}
+	for _, name := range []string{"agy_run", "agy_run_sync", "agy_status", "agy_wait", "agy_cancel", "list_models", "list_sessions"} {
+		if !got[name] {
+			t.Errorf("tool %q missing from a server started without agy", name)
+		}
+	}
+}
+
+// TestServeWarnsWhenAgyMissing: tolerating a missing agy must not be silent.
+// Starting cleanly and then failing every run with no hint at startup is worse
+// for an operator than the old hard refusal was, so the server says so once, on
+// stderr (stdout is the JSON-RPC stream and must stay clean).
+func TestServeWarnsWhenAgyMissing(t *testing.T) {
+	bin, err := buildBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stderrPath := filepath.Join(t.TempDir(), "stderr.log")
+	stderr, err := os.Create(stderrPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stderr.Close() }()
+
+	cmd := exec.Command(bin)
+	cmd.Stderr = stderr
+	home := t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"PATH="+t.TempDir(),
+		"AGY_MCP_AGY_PATH=",
+		"AGY_MCP_STATE_DIR="+t.TempDir(),
+		"HOME="+home,
+		"USERPROFILE="+home,
+	)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "introspect", Version: "0"}, nil)
+	cs, err := client.Connect(t.Context(), &mcp.CommandTransport{Command: cmd}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	// Close before reading: the warning is emitted during startup, so a completed
+	// initialize means it has already been written, and closing flushes the pipe.
+	_ = cs.Close()
+
+	logged, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logged), "agy not found on PATH") {
+		t.Errorf("startup must warn that agy is missing; stderr was:\n%s", logged)
+	}
+}
+
+// TestRunWithoutAgyFailsPerCall is the other half of the contract: tolerating a
+// missing agy at startup must not turn into a silent no-op later. The tool call
+// that actually needs the binary has to say so, and name the way to fix it.
+func TestRunWithoutAgyFailsPerCall(t *testing.T) {
+	bin, err := buildBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin)
+	home := t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"PATH="+t.TempDir(),
+		"AGY_MCP_AGY_PATH=",
+		"AGY_MCP_STATE_DIR="+t.TempDir(),
+		"HOME="+home,
+		"USERPROFILE="+home,
+	)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "introspect", Version: "0"}, nil)
+	ctx := t.Context()
+	cs, err := client.Connect(ctx, &mcp.CommandTransport{Command: cmd}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "list_models",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("call list_models: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("list_models must report an error when agy cannot be resolved")
+	}
+	var text strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			text.WriteString(tc.Text)
+		}
+	}
+	if !strings.Contains(text.String(), "AGY_MCP_AGY_PATH") {
+		t.Errorf("error should point at the fix, got: %s", text.String())
+	}
+}


### PR DESCRIPTION
The server refused to start when `agy` was not on `PATH`. That is stricter than the protocol needs: `initialize`, `tools/list`, and `list_sessions` never exec agy, so a client could not discover the tool surface over a binary it might not be about to use, and the server could not run at all in a container holding only the agy-mcp binary (which is what automated MCP directory checks build).

## What changed

`Resolve` leaves `AgyPath` empty on a bare PATH miss, and a new `Config.AgyBinary()` retries the lookup at the two sites that actually exec agy: `ListModels` and `StartJob`. A genuinely missing agy becomes a clear per-call error carrying the same guidance the startup error had, and an agy installed after the server started is picked up without a restart.

An explicit `AGY_MCP_AGY_PATH` keeps failing fast. It is a claim about one specific binary, so a typo or a non-executable target is a configuration error rather than a deferrable lookup.

Two details worth calling out:

- `StartJob` resolves **before** admission. Resolving after `admit` would let a missing agy consume a concurrency slot and strand the cwd key, blocking every later same-cwd run for the life of the process.
- Startup logs a warning to stderr when agy is absent, so the new tolerance is not silent. A healthy-looking server whose every run fails is a worse diagnostic than the refusal this replaces.

## Tests

Written first, and each confirmed red before the implementation landed:

- `TestServeIntrospectsWithoutAgy` spawns the real built binary with `PATH` emptied and drives MCP over stdio, asserting `initialize` and `tools/list` both succeed. Against the old fail-fast this fails with `calling "initialize": EOF`.
- `TestServeWarnsWhenAgyMissing` pins the stderr warning.
- `TestRunWithoutAgyFailsPerCall` asserts `list_models` returns a tool error naming `AGY_MCP_AGY_PATH`.
- `TestStartJobWithoutAgyReportsClearlyAndHoldsNoGate` also asserts the gate holds no slot and no key after the refusal.
- Config-level coverage for the deferred lookup, the startup-resolved path winning, and a relative PATH entry being refused.

`TestResolveAgyNotOnPath` asserted the exact behavior being changed and is replaced by `TestResolveWithoutAgyOnPathDefers`. `TestResolveWaitNeedsNoAgy` used "Resolve fails here" as its control, which no longer holds; the Resolve/ResolveWait seam is now pinned by `TestResolveWaitSkipsAgyLookupWhenPresent`, with agy actually present, which is the case that still distinguishes them.

Full suite green under `-race`, `go vet` clean, `golangci-lint run` reports 0 issues.