### PR TITLE
Declare tool annotations and correct the tool descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Driving `agy` from a shell for automation has two recurring problems:
 
 Session continuation rides `agy`'s own durable conversation store (`--conversation <id>`), so threads survive across calls without keeping a process warm.
 
+**A delegated run can modify your files.** `agy` is launched with
+`--dangerously-skip-permissions`, so the agent it starts can read *and write* anywhere under
+`cwd` and under every directory passed in `dirs`, without prompting. For a review that must
+not touch the repo, say so explicitly in the prompt. The tools declare this on the wire: `agy_run` and
+`agy_run_sync` are annotated `destructiveHint: true` / `openWorldHint: true`, `agy_cancel` is
+`destructiveHint: true` / `idempotentHint: true`, and `agy_status`, `agy_wait`, `list_models`
+and `list_sessions` are `readOnlyHint: true`. Annotations are hints, so a client is free to
+ignore them; one that does gate confirmation on them may stop prompting for the four
+read-only tools.
+
 Two transports run the same core:
 
 - **stdio** (default): zero-config, one line in your MCP client config.
@@ -84,6 +94,16 @@ Or add to your MCP client config:
 - `agy_cancel(job_id)` -> `{ state }`
 - `list_models()` -> `{ models }`
 - `list_sessions(dir?)` -> `{ sessions }`
+
+Parameter and result fields carry their own descriptions in the tool schemas, so a client sees
+them without consulting this file. The constraints worth knowing up front: `conversation_id`
+and `continue_latest` are mutually exclusive (setting `continue_latest` true alongside a
+`conversation_id` is an error); `timeout` is a Go duration and a value above 24h is rejected
+outright, and on expiry the
+`agy` process tree is killed and the job ends in state `failed`; `wait` defaults to 2m and is
+silently clamped to 10m, and it bounds only the inline wait, never the job itself. `agy_cancel`
+is asynchronous, so it usually returns `running` and the job settles to `cancelled` a moment
+later.
 
 A fresh `agy_run` (no `conversation_id`, no `continue_latest`) starts with an empty
 `conversation_id`; agy assigns one as the run proceeds, and `agy_status` reports it once the

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -8,9 +8,12 @@ import (
 )
 
 // Session pairs a workspace path with its most recent agy conversation UUID.
+//
+// The jsonschema tags reach clients through list_sessions' output schema, which
+// nests this type under "sessions"; see TestToolDefinitionsDescribeThemselves.
 type Session struct {
-	Workspace      string `json:"workspace"`
-	ConversationID string `json:"conversation_id"`
+	Workspace      string `json:"workspace" jsonschema:"absolute path of the workspace directory this conversation belongs to; pass it as cwd to continue the thread there"`
+	ConversationID string `json:"conversation_id" jsonschema:"most recent conversation id agy recorded for this workspace; pass it as conversation_id to agy_run or agy_run_sync"`
 }
 
 // agyCachePath returns the path to last_conversations.json, honoring HOME. An

--- a/internal/mcptools/harness_test.go
+++ b/internal/mcptools/harness_test.go
@@ -1,0 +1,34 @@
+package mcptools
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/agy-mcp/internal/manager"
+)
+
+// connect wires a NewServer(mgr) to a fresh client over in-memory transports
+// and returns the client session.
+//
+// This lives in an untagged file rather than beside the posix job-supervision
+// tests that first used it: nothing in it is platform-specific, and the
+// cross-platform tool tests (which must stay green on Windows) need it too.
+func connect(t *testing.T, mgr *manager.Manager, opts *mcp.ClientOptions) *mcp.ClientSession {
+	t.Helper()
+	srv := NewServer(mgr)
+	ct, st := mcp.NewInMemoryTransports()
+	if _, err := srv.Connect(t.Context(), st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, opts)
+	cs, err := client.Connect(t.Context(), ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cs.Close(); err != nil {
+			t.Errorf("close client session: %v", err)
+		}
+	})
+	return cs
+}

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -20,7 +20,7 @@ const (
 // runSyncInput is runInput plus the inline wait cap.
 type runSyncInput struct {
 	runInput
-	Wait string `json:"wait,omitempty" jsonschema:"max time to wait inline (Go duration, default 2m, max 10m); on overrun the job keeps running and the job_id is returned for agy_wait or agy_status"`
+	Wait string `json:"wait,omitempty" jsonschema:"max time to block inline (Go duration, default 2m, max 10m). Caps only the inline wait, not the job itself: on overrun the job keeps running and the returned job_id can be waited on with agy_wait or polled with agy_status"`
 }
 
 type runSyncOutput struct {
@@ -33,14 +33,18 @@ type runSyncOutput struct {
 // (bounded), streaming progress notifications when the client asked for them.
 func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 	mcp.AddTool(s, &mcp.Tool{
-		Name: toolAgyRunSync,
-		Description: "Delegate a prompt to an agy model and wait for the result inline (bounded by wait, default 2m). " +
-			"Use when the answer is needed before the next step AND the task is bounded enough to finish within the wait: " +
+		Name:        toolAgyRunSync,
+		Title:       "Delegate to agy (wait inline)",
+		Annotations: annDelegate,
+		Description: "Delegate a prompt to an agy model and wait for the result inline (bounded by wait, default 2m, max 10m). " +
+			"Use when the answer is needed before your next step AND the task is bounded enough to finish within the wait: " +
 			"a focused peer review, a second opinion, a rubber-duck question. " +
-			"Sends MCP progress notifications while waiting. If the job outlives the wait cap " +
-			"it keeps running and the returned job_id can be waited on with agy_wait or polled with agy_status. " +
+			"Sends MCP progress notifications while waiting. Outliving the wait cap is not a failure: the job keeps " +
+			"running and the returned job_id resolves through agy_wait or agy_status, so never re-send the prompt. " +
 			"For open-ended work that routinely runs past the wait cap (web research, a whole-codebase review), " +
-			"and for parallel work, prefer agy_run.",
+			"and for parallel work, prefer agy_run. " +
+			"The delegated agent has web access and can edit files under cwd, so say so in the prompt if the run " +
+			"must not touch the repo. Two fresh runs in the same cwd conflict rather than queueing.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in runSyncInput) (*mcp.CallToolResult, runSyncOutput, error) {
 		wait, err := parseWait(in.Wait)
 		if err != nil {

--- a/internal/mcptools/run_sync.go
+++ b/internal/mcptools/run_sync.go
@@ -20,13 +20,13 @@ const (
 // runSyncInput is runInput plus the inline wait cap.
 type runSyncInput struct {
 	runInput
-	Wait string `json:"wait,omitempty" jsonschema:"max time to block inline (Go duration, default 2m, max 10m). Caps only the inline wait, not the job itself: on overrun the job keeps running and the returned job_id can be waited on with agy_wait or polled with agy_status"`
+	Wait string `json:"wait,omitempty" jsonschema:"max time to block inline (Go duration, default 2m); a larger value is silently clamped to 10m. Caps only the inline wait, not the job itself: on overrun the job keeps running and the returned job_id can be waited on with agy_wait or polled with agy_status, so never re-send the prompt"`
 }
 
 type runSyncOutput struct {
-	JobID string `json:"job_id"`
+	JobID string `json:"job_id" jsonschema:"handle for this run; still valid after the inline wait runs out, for agy_wait, agy_status or agy_cancel"`
 	statusOutput
-	Note string `json:"note,omitempty"`
+	Note string `json:"note,omitempty" jsonschema:"set when the job outlived the inline wait, explaining that it is still running and how to collect it"`
 }
 
 // registerRunSync adds the agy_run_sync tool: start a job, wait inline for it
@@ -36,15 +36,15 @@ func registerRunSync(s *mcp.Server, mgr *manager.Manager) {
 		Name:        toolAgyRunSync,
 		Title:       "Delegate to agy (wait inline)",
 		Annotations: annDelegate,
-		Description: "Delegate a prompt to an agy model and wait for the result inline (bounded by wait, default 2m, max 10m). " +
+		Description: "Delegate a prompt to an agy model and wait for the result inline (bounded by wait). " +
 			"Use when the answer is needed before your next step AND the task is bounded enough to finish within the wait: " +
 			"a focused peer review, a second opinion, a rubber-duck question. " +
-			"Sends MCP progress notifications while waiting. Outliving the wait cap is not a failure: the job keeps " +
-			"running and the returned job_id resolves through agy_wait or agy_status, so never re-send the prompt. " +
 			"For open-ended work that routinely runs past the wait cap (web research, a whole-codebase review), " +
-			"and for parallel work, prefer agy_run. " +
-			"The delegated agent has web access and can edit files under cwd, so say so in the prompt if the run " +
-			"must not touch the repo. Two fresh runs in the same cwd conflict rather than queueing.",
+			"and for parallel work, prefer agy_run. If this call outlives its wait the job keeps running: " +
+			"block on the returned job_id with agy_wait, or take a single non-blocking look with agy_status. " +
+			"Streams progress notifications while waiting when the client asks for them. " +
+			"The delegated agent runs with permission checks disabled: it can edit files under cwd and under any " +
+			"dirs, and may reach the network. Say so in the prompt if the run must not touch the repo.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in runSyncInput) (*mcp.CallToolResult, runSyncOutput, error) {
 		wait, err := parseWait(in.Wait)
 		if err != nil {

--- a/internal/mcptools/run_sync_posix_test.go
+++ b/internal/mcptools/run_sync_posix_test.go
@@ -19,24 +19,6 @@ import (
 	"github.com/tphakala/agy-mcp/internal/testutil"
 )
 
-// connect wires a NewServer(mgr) to a fresh client over in-memory transports
-// and returns the client session.
-func connect(t *testing.T, mgr *manager.Manager, opts *mcp.ClientOptions) *mcp.ClientSession {
-	t.Helper()
-	srv := NewServer(mgr)
-	ct, st := mcp.NewInMemoryTransports()
-	if _, err := srv.Connect(t.Context(), st, nil); err != nil {
-		t.Fatalf("server connect: %v", err)
-	}
-	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "0"}, opts)
-	cs, err := client.Connect(t.Context(), ct, nil)
-	if err != nil {
-		t.Fatalf("client connect: %v", err)
-	}
-	t.Cleanup(func() { _ = cs.Close() })
-	return cs
-}
-
 // testConversationID is the id the fake supervisor's cache write attributes to
 // fresh runs started by newTestManager.
 const testConversationID = "abcdabcd-1234-5678-9abc-def012345678"

--- a/internal/mcptools/toolquality_test.go
+++ b/internal/mcptools/toolquality_test.go
@@ -1,6 +1,7 @@
 package mcptools
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -9,92 +10,126 @@ import (
 
 // listRegisteredTools returns the tools/list payload a real client receives, so
 // these assertions run against the wire shape rather than the registration
-// literals. NewServer takes a nil manager: listing tools never dispatches a
+// literals. connect takes a nil manager: listing tools never dispatches a
 // handler, so no manager is needed.
 func listRegisteredTools(t *testing.T) []*mcp.Tool {
 	t.Helper()
-	ctx := t.Context()
-	ct, st := mcp.NewInMemoryTransports()
-	srv := NewServer(nil)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_ = srv.Run(ctx, st)
-	}()
-	t.Cleanup(func() { <-done })
-
-	cs, err := mcp.NewClient(&mcp.Implementation{Name: "toolquality-test"}, nil).Connect(ctx, ct, nil)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	t.Cleanup(func() { _ = cs.Close() })
-
-	res, err := cs.ListTools(ctx, nil)
+	res, err := connect(t, nil, nil).ListTools(t.Context(), nil)
 	if err != nil {
 		t.Fatalf("list tools: %v", err)
 	}
 	return res.Tools
 }
 
+// wantAnnotations is the expected annotation for every registered tool, written
+// out field by field rather than as "which shared var was used". Asserting the
+// values (not merely that some annotation is present) is the point: the choice
+// between destructive and read-only, and between an open and closed world, is
+// the claim this server makes to its clients, so a silent flip must fail here.
+var wantAnnotations = map[string]mcp.ToolAnnotations{
+	toolAgyRun:       {DestructiveHint: new(true), OpenWorldHint: new(true)},
+	toolAgyRunSync:   {DestructiveHint: new(true), OpenWorldHint: new(true)},
+	toolAgyCancel:    {DestructiveHint: new(true), IdempotentHint: true, OpenWorldHint: new(false)},
+	toolAgyStatus:    {ReadOnlyHint: true, OpenWorldHint: new(false)},
+	toolAgyWait:      {ReadOnlyHint: true, OpenWorldHint: new(false)},
+	toolListSessions: {ReadOnlyHint: true, OpenWorldHint: new(false)},
+	toolListModels:   {ReadOnlyHint: true, OpenWorldHint: new(true)},
+}
+
+// eqBoolPtr compares two optional hints. Nil is distinct from false: the MCP
+// spec defaults destructiveHint and openWorldHint to true, so "unset" and
+// "explicitly false" say different things on the wire.
+func eqBoolPtr(got, want *bool) bool {
+	if got == nil || want == nil {
+		return got == want
+	}
+	return *got == *want
+}
+
 // TestToolDefinitionsDeclareAnnotations: absent annotations are not neutral. The
 // MCP spec defaults them to destructiveHint=true, openWorldHint=true,
 // readOnlyHint=false, so a tool that ships none advertises itself as a
-// destructive open-world mutation. Every tool must state its real behaviour, and
-// the read-only ones must say so explicitly or clients keep assuming the worst.
+// destructive open-world mutation. Every tool must state its real behaviour.
 func TestToolDefinitionsDeclareAnnotations(t *testing.T) {
-	readOnly := map[string]bool{
-		toolAgyStatus:    true,
-		toolAgyWait:      true,
-		toolListModels:   true,
-		toolListSessions: true,
-		toolAgyRun:       false,
-		toolAgyRunSync:   false,
-		toolAgyCancel:    false,
+	tools := listRegisteredTools(t)
+	// A tool registered but never classified here would otherwise be reviewed by
+	// nothing, so require the two sets to match exactly in both directions.
+	if len(tools) != len(wantAnnotations) {
+		t.Errorf("got %d tools, want %d; a tool was added or removed without updating wantAnnotations", len(tools), len(wantAnnotations))
 	}
-	for _, tool := range listRegisteredTools(t) {
+	for _, tool := range tools {
 		t.Run(tool.Name, func(t *testing.T) {
-			if tool.Annotations == nil {
+			want, known := wantAnnotations[tool.Name]
+			if !known {
+				t.Fatalf("tool %q is not classified here; add it to wantAnnotations", tool.Name)
+			}
+			got := tool.Annotations
+			if got == nil {
 				t.Fatal("no annotations: clients will assume destructive + open-world")
 			}
-			want, known := readOnly[tool.Name]
-			if !known {
-				t.Fatalf("tool %q is not classified here; add it to the readOnly map", tool.Name)
+			if got.ReadOnlyHint != want.ReadOnlyHint {
+				t.Errorf("readOnlyHint = %v, want %v", got.ReadOnlyHint, want.ReadOnlyHint)
 			}
-			if tool.Annotations.ReadOnlyHint != want {
-				t.Errorf("readOnlyHint = %v, want %v", tool.Annotations.ReadOnlyHint, want)
+			if got.IdempotentHint != want.IdempotentHint {
+				t.Errorf("idempotentHint = %v, want %v", got.IdempotentHint, want.IdempotentHint)
 			}
-			if tool.Annotations.OpenWorldHint == nil {
-				t.Error("openWorldHint unset; it defaults to true, so state it explicitly")
+			if !eqBoolPtr(got.DestructiveHint, want.DestructiveHint) {
+				t.Errorf("destructiveHint = %v, want %v", fmtHint(got.DestructiveHint), fmtHint(want.DestructiveHint))
+			}
+			if !eqBoolPtr(got.OpenWorldHint, want.OpenWorldHint) {
+				t.Errorf("openWorldHint = %v, want %v", fmtHint(got.OpenWorldHint), fmtHint(want.OpenWorldHint))
 			}
 			// destructiveHint and idempotentHint are meaningful only when
-			// readOnlyHint is false, so require them exactly where they carry meaning.
-			if !want && tool.Annotations.DestructiveHint == nil {
-				t.Error("mutating tool must state destructiveHint")
-			}
-			if want && tool.Annotations.DestructiveHint != nil {
+			// readOnlyHint is false, so a read-only tool carrying either is stating
+			// something the spec says nothing reads.
+			if want.ReadOnlyHint && got.DestructiveHint != nil {
 				t.Error("read-only tool should not carry a decorative destructiveHint")
 			}
 		})
 	}
 }
 
-// TestToolDefinitionsDescribeThemselves guards the qualities a tool description
-// is actually judged on: it must exist, must not merely restate the tool's own
-// name, and must point at the sibling tools an agent could otherwise confuse it
-// with. Every input property needs its own description too, since that is where
-// parameter meaning belongs rather than duplicated into the prose.
-func TestToolDefinitionsDescribeThemselves(t *testing.T) {
-	// Each tool names at least one sibling, so an agent reading one definition
-	// learns when to reach for a different one instead.
-	wantSiblings := map[string][]string{
-		toolAgyRun:       {toolAgyRunSync, toolAgyWait, toolAgyStatus},
-		toolAgyRunSync:   {toolAgyRun, toolAgyWait, toolAgyStatus},
-		toolAgyWait:      {toolAgyRun, toolAgyStatus},
-		toolAgyStatus:    {toolAgyWait},
-		toolAgyCancel:    {toolAgyRun},
-		toolListModels:   {toolAgyRun, toolAgyRunSync},
-		toolListSessions: {toolAgyRun, toolAgyRunSync},
+// fmtHint renders an optional hint so a failure distinguishes unset from false.
+func fmtHint(b *bool) string {
+	if b == nil {
+		return "unset"
 	}
+	if *b {
+		return "true"
+	}
+	return "false"
+}
+
+// wantSiblings names, per tool, the other tools its description must mention, so
+// an agent reading one definition learns when to reach for a different one.
+var wantSiblings = map[string][]string{
+	toolAgyRun:     {toolAgyRunSync, toolAgyWait, toolAgyStatus},
+	toolAgyRunSync: {toolAgyRun, toolAgyWait, toolAgyStatus},
+	toolAgyWait:    {toolAgyRun, toolAgyStatus},
+	// agy_status routes to agy_wait (the blocking alternative) and no further:
+	// requiring it to name agy_cancel too bought nothing an agent needs at a
+	// status check, and the first attempt to satisfy that invented a claim about
+	// polling cost that the code did not support.
+	toolAgyStatus:    {toolAgyWait},
+	toolAgyCancel:    {toolAgyRun},
+	toolListModels:   {toolAgyRun, toolAgyRunSync},
+	toolListSessions: {toolAgyRun, toolAgyRunSync},
+}
+
+// mentions reports whether desc names tool as a whole word. A plain substring
+// test would let "agy_run_sync" satisfy a requirement to mention "agy_run",
+// which silently hollows out the cross-reference check for every tool whose
+// description happens to name the sync variant.
+func mentions(desc, tool string) bool {
+	return regexp.MustCompile(`\b` + regexp.QuoteMeta(tool) + `\b`).MatchString(desc)
+}
+
+// TestToolDefinitionsDescribeThemselves guards the qualities a tool description
+// is judged on: it must exist, must not merely restate the tool's own name, and
+// must route to the sibling tools an agent could otherwise confuse it with.
+// Every input and output property needs its own description too, since that is
+// where per-field meaning belongs rather than duplicated into the prose.
+func TestToolDefinitionsDescribeThemselves(t *testing.T) {
 	for _, tool := range listRegisteredTools(t) {
 		t.Run(tool.Name, func(t *testing.T) {
 			if tool.Title == "" {
@@ -115,26 +150,58 @@ func TestToolDefinitionsDescribeThemselves(t *testing.T) {
 					t.Errorf("description merely restates %q", tautology)
 				}
 			}
-			for _, sibling := range wantSiblings[tool.Name] {
-				if !strings.Contains(desc, sibling) {
+			siblings, known := wantSiblings[tool.Name]
+			if !known {
+				t.Fatalf("tool %q has no routing requirement; add it to wantSiblings", tool.Name)
+			}
+			for _, sibling := range siblings {
+				if !mentions(desc, sibling) {
 					t.Errorf("description never mentions sibling %q, so an agent cannot route between them", sibling)
 				}
 			}
-			schema, ok := tool.InputSchema.(map[string]any)
-			if !ok {
-				t.Fatalf("input schema has unexpected type %T", tool.InputSchema)
-			}
-			props, _ := schema["properties"].(map[string]any)
-			for name, raw := range props {
-				prop, ok := raw.(map[string]any)
-				if !ok {
-					t.Errorf("property %q has unexpected type %T", name, raw)
-					continue
-				}
-				if d, _ := prop["description"].(string); strings.TrimSpace(d) == "" {
-					t.Errorf("property %q has no description", name)
-				}
-			}
+			assertPropertiesDescribed(t, "input", tool.InputSchema)
+			assertPropertiesDescribed(t, "output", tool.OutputSchema)
 		})
+	}
+}
+
+// assertPropertiesDescribed requires every property of a tool's schema to carry
+// a description. An undescribed field forces the tool description to explain it
+// in prose instead, which is what the per-property descriptions exist to avoid.
+func assertPropertiesDescribed(t *testing.T, which string, raw any) {
+	t.Helper()
+	if raw == nil {
+		t.Errorf("%s schema is absent", which)
+		return
+	}
+	schema, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("%s schema has unexpected type %T", which, raw)
+	}
+	// A schema with no properties at all is legitimate (list_models takes no
+	// arguments), but a properties key of the wrong shape is not.
+	rawProps, present := schema["properties"]
+	if !present {
+		return
+	}
+	props, ok := rawProps.(map[string]any)
+	if !ok {
+		t.Fatalf("%s schema properties have unexpected type %T", which, rawProps)
+	}
+	for name, rawProp := range props {
+		prop, ok := rawProp.(map[string]any)
+		if !ok {
+			t.Errorf("%s property %q has unexpected type %T", which, name, rawProp)
+			continue
+		}
+		if d, _ := prop["description"].(string); strings.TrimSpace(d) == "" {
+			t.Errorf("%s property %q has no description", which, name)
+		}
+		// Recurse into an array's element schema. list_sessions returns its payload
+		// as a list of objects, so without this the fields a client actually reads
+		// (workspace, conversation_id) escape the requirement entirely.
+		if items, ok := prop["items"].(map[string]any); ok {
+			assertPropertiesDescribed(t, which+" "+name+" item", items)
+		}
 	}
 }

--- a/internal/mcptools/toolquality_test.go
+++ b/internal/mcptools/toolquality_test.go
@@ -1,0 +1,140 @@
+package mcptools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// listRegisteredTools returns the tools/list payload a real client receives, so
+// these assertions run against the wire shape rather than the registration
+// literals. NewServer takes a nil manager: listing tools never dispatches a
+// handler, so no manager is needed.
+func listRegisteredTools(t *testing.T) []*mcp.Tool {
+	t.Helper()
+	ctx := t.Context()
+	ct, st := mcp.NewInMemoryTransports()
+	srv := NewServer(nil)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = srv.Run(ctx, st)
+	}()
+	t.Cleanup(func() { <-done })
+
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "toolquality-test"}, nil).Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	res, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	return res.Tools
+}
+
+// TestToolDefinitionsDeclareAnnotations: absent annotations are not neutral. The
+// MCP spec defaults them to destructiveHint=true, openWorldHint=true,
+// readOnlyHint=false, so a tool that ships none advertises itself as a
+// destructive open-world mutation. Every tool must state its real behaviour, and
+// the read-only ones must say so explicitly or clients keep assuming the worst.
+func TestToolDefinitionsDeclareAnnotations(t *testing.T) {
+	readOnly := map[string]bool{
+		toolAgyStatus:    true,
+		toolAgyWait:      true,
+		toolListModels:   true,
+		toolListSessions: true,
+		toolAgyRun:       false,
+		toolAgyRunSync:   false,
+		toolAgyCancel:    false,
+	}
+	for _, tool := range listRegisteredTools(t) {
+		t.Run(tool.Name, func(t *testing.T) {
+			if tool.Annotations == nil {
+				t.Fatal("no annotations: clients will assume destructive + open-world")
+			}
+			want, known := readOnly[tool.Name]
+			if !known {
+				t.Fatalf("tool %q is not classified here; add it to the readOnly map", tool.Name)
+			}
+			if tool.Annotations.ReadOnlyHint != want {
+				t.Errorf("readOnlyHint = %v, want %v", tool.Annotations.ReadOnlyHint, want)
+			}
+			if tool.Annotations.OpenWorldHint == nil {
+				t.Error("openWorldHint unset; it defaults to true, so state it explicitly")
+			}
+			// destructiveHint and idempotentHint are meaningful only when
+			// readOnlyHint is false, so require them exactly where they carry meaning.
+			if !want && tool.Annotations.DestructiveHint == nil {
+				t.Error("mutating tool must state destructiveHint")
+			}
+			if want && tool.Annotations.DestructiveHint != nil {
+				t.Error("read-only tool should not carry a decorative destructiveHint")
+			}
+		})
+	}
+}
+
+// TestToolDefinitionsDescribeThemselves guards the qualities a tool description
+// is actually judged on: it must exist, must not merely restate the tool's own
+// name, and must point at the sibling tools an agent could otherwise confuse it
+// with. Every input property needs its own description too, since that is where
+// parameter meaning belongs rather than duplicated into the prose.
+func TestToolDefinitionsDescribeThemselves(t *testing.T) {
+	// Each tool names at least one sibling, so an agent reading one definition
+	// learns when to reach for a different one instead.
+	wantSiblings := map[string][]string{
+		toolAgyRun:       {toolAgyRunSync, toolAgyWait, toolAgyStatus},
+		toolAgyRunSync:   {toolAgyRun, toolAgyWait, toolAgyStatus},
+		toolAgyWait:      {toolAgyRun, toolAgyStatus},
+		toolAgyStatus:    {toolAgyWait},
+		toolAgyCancel:    {toolAgyRun},
+		toolListModels:   {toolAgyRun, toolAgyRunSync},
+		toolListSessions: {toolAgyRun, toolAgyRunSync},
+	}
+	for _, tool := range listRegisteredTools(t) {
+		t.Run(tool.Name, func(t *testing.T) {
+			if tool.Title == "" {
+				t.Error("no title")
+			}
+			desc := strings.TrimSpace(tool.Description)
+			if desc == "" {
+				t.Fatal("no description")
+			}
+			// A description that only restates the name (bare, spaced, or titled)
+			// tells an agent nothing the tool list already showed it.
+			for _, tautology := range []string{
+				tool.Name,
+				strings.ReplaceAll(tool.Name, "_", " "),
+				tool.Title,
+			} {
+				if strings.EqualFold(strings.TrimSuffix(desc, "."), tautology) {
+					t.Errorf("description merely restates %q", tautology)
+				}
+			}
+			for _, sibling := range wantSiblings[tool.Name] {
+				if !strings.Contains(desc, sibling) {
+					t.Errorf("description never mentions sibling %q, so an agent cannot route between them", sibling)
+				}
+			}
+			schema, ok := tool.InputSchema.(map[string]any)
+			if !ok {
+				t.Fatalf("input schema has unexpected type %T", tool.InputSchema)
+			}
+			props, _ := schema["properties"].(map[string]any)
+			for name, raw := range props {
+				prop, ok := raw.(map[string]any)
+				if !ok {
+					t.Errorf("property %q has unexpected type %T", name, raw)
+					continue
+				}
+				if d, _ := prop["description"].(string); strings.TrimSpace(d) == "" {
+					t.Errorf("property %q has no description", name)
+				}
+			}
+		})
+	}
+}

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -20,12 +20,12 @@ import (
 // here rather than in the tool description avoids restating the schema in prose.
 type runInput struct {
 	Prompt         string   `json:"prompt" jsonschema:"the complete task for the delegated agent: what to do, the context needed to do it, and the output wanted back; the agent cannot see this conversation, so the prompt must stand alone"`
-	Model          string   `json:"model,omitempty" jsonschema:"agy model name; omit to use agy's configured default. Call list_models for the accepted values"`
-	Dirs           []string `json:"dirs,omitempty" jsonschema:"absolute paths of extra directories the agent may read beyond cwd (agy --add-dir), e.g. a spec or a sibling repo outside the project"`
+	Model          string   `json:"model,omitempty" jsonschema:"agy model name; omit to use the server's default model, or agy's own default when the server sets none. Call list_models for the accepted values"`
+	Dirs           []string `json:"dirs,omitempty" jsonschema:"extra directories to grant the agent beyond cwd (agy --add-dir), e.g. a spec or a sibling repo. The agent can read and write there exactly as under cwd, so this widens the blast radius; prefer absolute paths"`
 	ConversationID string   `json:"conversation_id,omitempty" jsonschema:"continue this specific conversation instead of starting fresh, so earlier context need not be restated; take it from a previous run's conversation_id or from list_sessions. Mutually exclusive with continue_latest"`
-	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd instead of starting fresh. Mutually exclusive with conversation_id: supplying both is an error"`
-	Cwd            string   `json:"cwd,omitempty" jsonschema:"absolute path the agent runs in and may edit files under; also scopes continue_latest and the same-cwd concurrency gate. Defaults to the server's own working directory"`
-	Timeout        string   `json:"timeout,omitempty" jsonschema:"max wall-clock duration for the whole run (Go duration, e.g. 20m; max 24h); on expiry the agy process group is killed and the job ends in state failed. Omit to use the server's configured default"`
+	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd instead of starting fresh. Mutually exclusive with conversation_id: setting this true together with a conversation_id is an error, though leaving it false alongside one is fine"`
+	Cwd            string   `json:"cwd,omitempty" jsonschema:"absolute path of the directory the agent runs in and may edit files under; also scopes continue_latest and the concurrency gate, so two fresh runs sharing a cwd conflict rather than queueing. A relative path is resolved against the server's working directory, which is not necessarily yours, so pass an absolute one. Symlinks are resolved. Defaults to the server's own working directory"`
+	Timeout        string   `json:"timeout,omitempty" jsonschema:"max wall-clock duration for the whole run (Go duration, e.g. 20m); a value over 24h is rejected. On expiry the agy process tree is killed and the job ends in state failed. Omit to use the server's default"`
 }
 
 // maxJobTimeout caps a client-supplied per-job timeout. It bounds both the agy
@@ -60,35 +60,46 @@ const (
 // declare the truth instead.
 //
 // destructiveHint and idempotentHint are meaningful only when readOnlyHint is
-// false (see mcp.ToolAnnotations), so the read-only tools deliberately leave
-// them unset rather than carrying decorative values.
+// false (see mcp.ToolAnnotations), so the read-only sets below deliberately
+// leave them unset rather than carrying decorative values.
+//
+// Each var describes the PROPERTY it asserts, not the tools that currently use
+// it: a list of tool names in a comment has nothing enforcing it and goes stale
+// the moment a tool is added or reclassified. TestToolDefinitionsDeclareAnnotations
+// pins the per-tool mapping instead, where a drift fails the build.
 var (
-	// annDelegate covers agy_run and agy_run_sync. Both spawn a full agy agent
-	// that can edit files under cwd and reach the network, and each call starts a
-	// distinct job, so nothing here is read-only, safe, or idempotent.
-	// destructiveHint stays true on purpose: setting it false would soften
-	// confirmation prompts in some clients, but the delegated agent really can
-	// overwrite the repo, and an accurate hint is worth more than the friction it
-	// saves.
+	// annDelegate: spawns a full agy agent under --dangerously-skip-permissions,
+	// so it can edit files under cwd and under every dir passed in, and may reach
+	// the network. Each call starts a distinct job, so it is not idempotent.
+	// destructiveHint is stated rather than left to default because the delegated
+	// agent really can overwrite the repo; the SDK notes annotations are hints a
+	// client need not honour, so this documents intent rather than enforcing it.
 	annDelegate = &mcp.ToolAnnotations{
 		DestructiveHint: new(true),
 		OpenWorldHint:   new(true),
 	}
-	// annReadLocal covers agy_status, agy_wait and list_sessions: they only read
-	// the local job store or agy's conversation cache.
+	// annReadLocal: answers from local state (the job store, agy's conversation
+	// cache) and changes nothing the caller can observe. Not literally
+	// side-effect-free: reading a finished job's status memoizes the captured
+	// conversation id into the job's meta (manager.persistCapturedID). That write
+	// is idempotent bookkeeping over a value the job already produced, so
+	// readOnlyHint still describes the blast radius accurately.
 	annReadLocal = &mcp.ToolAnnotations{
 		ReadOnlyHint:  true,
 		OpenWorldHint: new(false),
 	}
-	// annReadExternal covers list_models: read-only, but it shells out to the agy
-	// CLI, whose model registry lives outside this server.
+	// annReadExternal: read-only like annReadLocal, but answers by shelling out to
+	// the agy CLI, whose model registry lives outside this server.
 	annReadExternal = &mcp.ToolAnnotations{
 		ReadOnlyHint:  true,
 		OpenWorldHint: new(true),
 	}
-	// annCancel covers agy_cancel: it terminates work in progress, which is
-	// destructive, but re-cancelling an already-cancelled job has no further
-	// effect, so it is idempotent.
+	// annCancel: terminates work in progress, which is destructive, but
+	// re-cancelling an already-cancelled job has no further effect. idempotentHint
+	// is a third field whose default this flips (false to true); some clients read
+	// it as licence to retry the call after a transport failure. Retrying re-sends
+	// the cancel request, which the supervisor's buffered signal channel absorbs
+	// while it is still listening.
 	annCancel = &mcp.ToolAnnotations{
 		DestructiveHint: new(true),
 		IdempotentHint:  true,
@@ -117,9 +128,9 @@ func (in runInput) toStartRequest() (manager.StartRequest, error) {
 }
 
 type runOutput struct {
-	JobID          string `json:"job_id"`
-	ConversationID string `json:"conversation_id,omitempty"`
-	State          string `json:"state"`
+	JobID          string `json:"job_id" jsonschema:"handle for this run; pass it to agy_wait, agy_status or agy_cancel"`
+	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; empty on a fresh run until agy assigns one, which agy_status reports once known"`
+	State          string `json:"state" jsonschema:"always running: the job has been started and cannot have finished yet. Block with agy_wait or check agy_status for the outcome"`
 }
 
 type statusInput struct {
@@ -127,14 +138,14 @@ type statusInput struct {
 }
 
 type statusOutput struct {
-	State          string `json:"state"`
-	Elapsed        string `json:"elapsed"`
-	Result         string `json:"result,omitempty"`
-	Error          string `json:"error,omitempty"`
-	ConversationID string `json:"conversation_id,omitempty"`
+	State          string `json:"state" jsonschema:"running, done, failed or cancelled; only done carries a result"`
+	Elapsed        string `json:"elapsed" jsonschema:"wall-clock time the job has run, frozen at completion once terminal"`
+	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output; present only when state is done"`
+	Error          string `json:"error,omitempty" jsonschema:"why the job failed; present only when state is failed"`
+	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread"`
 	// Partial is set when a done job's result was recovered without a completion
 	// sentinel and so may be truncated; see manager.Status.Partial.
-	Partial bool `json:"partial,omitempty"`
+	Partial bool `json:"partial,omitempty" jsonschema:"true when the result was recovered without a completion sentinel and may be truncated; treat the output as incomplete"`
 }
 
 // toStatusOutput converts a manager status into its wire shape, shared by
@@ -154,20 +165,20 @@ type cancelInput struct {
 	JobID string `json:"job_id" jsonschema:"job id to cancel, as returned by agy_run or agy_run_sync"`
 }
 type cancelOutput struct {
-	State string `json:"state"`
+	State string `json:"state" jsonschema:"state right after the cancel was requested: usually still running, since termination is asynchronous and settles to cancelled shortly after; a terminal state if the job had already finished, or unknown if the state could not be read"`
 }
 
 type emptyInput struct{}
 
 type modelsOutput struct {
-	Models []string `json:"models"`
+	Models []string `json:"models" jsonschema:"model names accepted by the model parameter of agy_run and agy_run_sync"`
 }
 
 type sessionsInput struct {
-	Dir string `json:"dir,omitempty" jsonschema:"absolute path of a workspace directory to filter to; omit to list every known conversation. Relative paths and symlinks are canonicalized before matching"`
+	Dir string `json:"dir,omitempty" jsonschema:"absolute path of a workspace directory to filter to; omit to list every known conversation. The filter is canonicalized (made absolute against the server's working directory, symlinks resolved) before matching, so a path agy cached in some other spelling may not match"`
 }
 type sessionsOutput struct {
-	Sessions []manager.Session `json:"sessions"`
+	Sessions []manager.Session `json:"sessions" jsonschema:"one entry per workspace directory, each holding that directory's most recent conversation id"`
 }
 
 // serverVersion reports the module version the Go toolchain stamped into the
@@ -217,7 +228,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		Name:        toolAgyRun,
 		Title:       "Delegate to agy (async)",
 		Annotations: annDelegate,
-		Description: "Delegate a prompt to a background agy model as an async job (peer review, research, or any self-contained task) and keep working. Returns a job_id immediately; block on it with agy_wait or poll it with agy_status. Prefer this over agy_run_sync for long runs, for open-ended work that routinely outlives an inline wait (web research, a large review), and to fan several tasks out in parallel; use agy_run_sync instead when you need the answer before your next step. The delegated agent has web access and can edit files under cwd, so say so in the prompt if the run must not touch the repo. Two fresh runs in the same cwd conflict rather than queueing: vary cwd or continue a conversation to parallelize.",
+		Description: "Delegate a prompt to a background agy model as an async job (peer review, research, or any self-contained task) and keep working. Returns a job_id; block on it with agy_wait or poll it with agy_status. Prefer this over agy_run_sync for long runs, for open-ended work that routinely outlives an inline wait (web research, a large review), and to fan several tasks out in parallel; use agy_run_sync instead when you need the answer before your next step. The delegated agent runs with permission checks disabled: it can edit files under cwd and under any dirs, and may reach the network. Say so in the prompt if the run must not touch the repo.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runInput) (*mcp.CallToolResult, runOutput, error) {
 		req, err := in.toStartRequest()
 		if err != nil {
@@ -234,7 +245,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		Name:        toolAgyStatus,
 		Title:       "Check an agy job",
 		Annotations: annReadLocal,
-		Description: `Check an agy job once, without blocking. Returns running, done (with result), failed, or cancelled. Use it for a cheap liveness check or to sweep several jobs at once; when the next step depends on one job's result, prefer a single agy_wait over a poll loop. A done result with "partial": true was recovered without a completion sentinel and may be truncated.`,
+		Description: "Check an agy job once, without blocking. Use it for a single snapshot, or to check several jobs in turn; when the next step depends on one job's result, prefer a single agy_wait over a poll loop. Checking a still-running job is cheap, but every check on a finished one re-reads its full output, so collect a result once rather than repeatedly.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in statusInput) (*mcp.CallToolResult, statusOutput, error) {
 		st, err := mgr.Status(in.JobID)
 		if err != nil {
@@ -247,7 +258,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		Name:        toolAgyCancel,
 		Title:       "Cancel an agy job",
 		Annotations: annCancel,
-		Description: `Stop a running agy job and terminate its agy process group. Use it to abandon a job whose result is no longer needed, or one that is stuck; there is no resume, so a cancelled run has to be re-sent as a new agy_run. Calling it on an already-finished job is a harmless no-op. Returns "cancelled", the job's terminal state if it had already finished, or "unknown" if the state could not be read after cancelling. Files the delegated agent already wrote under cwd are not rolled back.`,
+		Description: "Stop a running agy job: asks its supervisor to terminate the agy process tree. Use it to abandon a job whose result is no longer needed, or one that is stuck; there is no resume, so a cancelled run has to be re-sent as a new agy_run. Termination is asynchronous, so the returned state is usually still running and settles to cancelled a moment later; that is a delivered cancel, not a failed one. Calling it on an already-finished job is a harmless no-op. Files the delegated agent already wrote are not rolled back.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in cancelInput) (*mcp.CallToolResult, cancelOutput, error) {
 		if err := mgr.Cancel(in.JobID); err != nil {
 			return nil, cancelOutput{}, err
@@ -270,7 +281,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		Name:        toolListModels,
 		Title:       "List agy models",
 		Annotations: annReadExternal,
-		Description: "List the agy model names accepted by the model parameter of agy_run and agy_run_sync. Call it only when you intend to override the default; omitting model uses agy's configured default, so most runs need no call here. Shells out to the agy CLI, so it fails if agy is missing from PATH or not authenticated.",
+		Description: "List the agy model names accepted by the model parameter of agy_run and agy_run_sync. Call it only when you intend to override the default; omitting model picks a default already, so most runs need no call here. Shells out to the agy CLI, so it fails if agy is missing from PATH or not authenticated.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ emptyInput) (*mcp.CallToolResult, modelsOutput, error) {
 		models, err := mgr.ListModels(ctx)
 		if err != nil {

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -13,14 +13,19 @@ import (
 )
 
 // runInput is the input for agy_run.
+//
+// The jsonschema tags are the per-property descriptions the client sees, so
+// they carry the meaning that the Go types cannot: which fields are mutually
+// exclusive, what a field defaults to, and what happens on expiry. Keeping that
+// here rather than in the tool description avoids restating the schema in prose.
 type runInput struct {
-	Prompt         string   `json:"prompt" jsonschema:"the prompt to send to agy"`
-	Model          string   `json:"model,omitempty" jsonschema:"agy model name; defaults to agy's configured default"`
-	Dirs           []string `json:"dirs,omitempty" jsonschema:"extra workspace directories (--add-dir)"`
-	ConversationID string   `json:"conversation_id,omitempty" jsonschema:"continue a specific conversation"`
-	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd"`
-	Cwd            string   `json:"cwd,omitempty" jsonschema:"working directory for the run"`
-	Timeout        string   `json:"timeout,omitempty" jsonschema:"max run duration, e.g. 20m"`
+	Prompt         string   `json:"prompt" jsonschema:"the complete task for the delegated agent: what to do, the context needed to do it, and the output wanted back; the agent cannot see this conversation, so the prompt must stand alone"`
+	Model          string   `json:"model,omitempty" jsonschema:"agy model name; omit to use agy's configured default. Call list_models for the accepted values"`
+	Dirs           []string `json:"dirs,omitempty" jsonschema:"absolute paths of extra directories the agent may read beyond cwd (agy --add-dir), e.g. a spec or a sibling repo outside the project"`
+	ConversationID string   `json:"conversation_id,omitempty" jsonschema:"continue this specific conversation instead of starting fresh, so earlier context need not be restated; take it from a previous run's conversation_id or from list_sessions. Mutually exclusive with continue_latest"`
+	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd instead of starting fresh. Mutually exclusive with conversation_id: supplying both is an error"`
+	Cwd            string   `json:"cwd,omitempty" jsonschema:"absolute path the agent runs in and may edit files under; also scopes continue_latest and the same-cwd concurrency gate. Defaults to the server's own working directory"`
+	Timeout        string   `json:"timeout,omitempty" jsonschema:"max wall-clock duration for the whole run (Go duration, e.g. 20m; max 24h); on expiry the agy process group is killed and the job ends in state failed. Omit to use the server's configured default"`
 }
 
 // maxJobTimeout caps a client-supplied per-job timeout. It bounds both the agy
@@ -43,6 +48,52 @@ const (
 	toolAgyWait      = "agy_wait"
 	toolListModels   = "list_models"
 	toolListSessions = "list_sessions"
+)
+
+// Tool annotations. ToolAnnotations models destructiveHint and openWorldHint as
+// *bool because their spec default is true, so "unset" and "false" must stay
+// distinguishable on the wire; new(true) / new(false) supply those pointers.
+//
+// Absent annotations are not neutral: the MCP spec defaults them to
+// destructiveHint=true, openWorldHint=true, readOnlyHint=false, so a tool that
+// ships none is advertising itself as a destructive open-world mutation. These
+// declare the truth instead.
+//
+// destructiveHint and idempotentHint are meaningful only when readOnlyHint is
+// false (see mcp.ToolAnnotations), so the read-only tools deliberately leave
+// them unset rather than carrying decorative values.
+var (
+	// annDelegate covers agy_run and agy_run_sync. Both spawn a full agy agent
+	// that can edit files under cwd and reach the network, and each call starts a
+	// distinct job, so nothing here is read-only, safe, or idempotent.
+	// destructiveHint stays true on purpose: setting it false would soften
+	// confirmation prompts in some clients, but the delegated agent really can
+	// overwrite the repo, and an accurate hint is worth more than the friction it
+	// saves.
+	annDelegate = &mcp.ToolAnnotations{
+		DestructiveHint: new(true),
+		OpenWorldHint:   new(true),
+	}
+	// annReadLocal covers agy_status, agy_wait and list_sessions: they only read
+	// the local job store or agy's conversation cache.
+	annReadLocal = &mcp.ToolAnnotations{
+		ReadOnlyHint:  true,
+		OpenWorldHint: new(false),
+	}
+	// annReadExternal covers list_models: read-only, but it shells out to the agy
+	// CLI, whose model registry lives outside this server.
+	annReadExternal = &mcp.ToolAnnotations{
+		ReadOnlyHint:  true,
+		OpenWorldHint: new(true),
+	}
+	// annCancel covers agy_cancel: it terminates work in progress, which is
+	// destructive, but re-cancelling an already-cancelled job has no further
+	// effect, so it is idempotent.
+	annCancel = &mcp.ToolAnnotations{
+		DestructiveHint: new(true),
+		IdempotentHint:  true,
+		OpenWorldHint:   new(false),
+	}
 )
 
 // toStartRequest converts the wire input into a manager start request,
@@ -72,7 +123,7 @@ type runOutput struct {
 }
 
 type statusInput struct {
-	JobID string `json:"job_id" jsonschema:"the job id returned by agy_run or agy_run_sync"`
+	JobID string `json:"job_id" jsonschema:"job id returned by agy_run or agy_run_sync"`
 }
 
 type statusOutput struct {
@@ -100,7 +151,7 @@ func toStatusOutput(st manager.Status) statusOutput {
 }
 
 type cancelInput struct {
-	JobID string `json:"job_id" jsonschema:"the job id to cancel"`
+	JobID string `json:"job_id" jsonschema:"job id to cancel, as returned by agy_run or agy_run_sync"`
 }
 type cancelOutput struct {
 	State string `json:"state"`
@@ -113,7 +164,7 @@ type modelsOutput struct {
 }
 
 type sessionsInput struct {
-	Dir string `json:"dir,omitempty" jsonschema:"filter to one workspace directory"`
+	Dir string `json:"dir,omitempty" jsonschema:"absolute path of a workspace directory to filter to; omit to list every known conversation. Relative paths and symlinks are canonicalized before matching"`
 }
 type sessionsOutput struct {
 	Sessions []manager.Session `json:"sessions"`
@@ -164,7 +215,9 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        toolAgyRun,
-		Description: "Delegate a prompt to a background agy model as an async job (peer review, research, or any self-contained task) and keep working. Returns a job_id; block on it with agy_wait or poll it with agy_status. Prefer this over agy_run_sync for long runs, for open-ended work that routinely outlives an inline wait (web research, a large review), or to fan several tasks out in parallel.",
+		Title:       "Delegate to agy (async)",
+		Annotations: annDelegate,
+		Description: "Delegate a prompt to a background agy model as an async job (peer review, research, or any self-contained task) and keep working. Returns a job_id immediately; block on it with agy_wait or poll it with agy_status. Prefer this over agy_run_sync for long runs, for open-ended work that routinely outlives an inline wait (web research, a large review), and to fan several tasks out in parallel; use agy_run_sync instead when you need the answer before your next step. The delegated agent has web access and can edit files under cwd, so say so in the prompt if the run must not touch the repo. Two fresh runs in the same cwd conflict rather than queueing: vary cwd or continue a conversation to parallelize.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in runInput) (*mcp.CallToolResult, runOutput, error) {
 		req, err := in.toStartRequest()
 		if err != nil {
@@ -179,7 +232,9 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        toolAgyStatus,
-		Description: `Poll an agy job. Returns running, done (with result), failed, or cancelled. A done result with "partial": true was recovered without a completion sentinel and may be truncated.`,
+		Title:       "Check an agy job",
+		Annotations: annReadLocal,
+		Description: `Check an agy job once, without blocking. Returns running, done (with result), failed, or cancelled. Use it for a cheap liveness check or to sweep several jobs at once; when the next step depends on one job's result, prefer a single agy_wait over a poll loop. A done result with "partial": true was recovered without a completion sentinel and may be truncated.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in statusInput) (*mcp.CallToolResult, statusOutput, error) {
 		st, err := mgr.Status(in.JobID)
 		if err != nil {
@@ -190,7 +245,9 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        toolAgyCancel,
-		Description: `Cancel a running agy job. Returns the resulting state: "cancelled", or the job's terminal state if it had already finished, or "unknown" if the state could not be read after cancelling.`,
+		Title:       "Cancel an agy job",
+		Annotations: annCancel,
+		Description: `Stop a running agy job and terminate its agy process group. Use it to abandon a job whose result is no longer needed, or one that is stuck; there is no resume, so a cancelled run has to be re-sent as a new agy_run. Calling it on an already-finished job is a harmless no-op. Returns "cancelled", the job's terminal state if it had already finished, or "unknown" if the state could not be read after cancelling. Files the delegated agent already wrote under cwd are not rolled back.`,
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in cancelInput) (*mcp.CallToolResult, cancelOutput, error) {
 		if err := mgr.Cancel(in.JobID); err != nil {
 			return nil, cancelOutput{}, err
@@ -210,7 +267,10 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 	registerWait(s, mgr)
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: toolListModels, Description: "List available agy models. Call this to see the options if you want to override the default model for agy_run or agy_run_sync.",
+		Name:        toolListModels,
+		Title:       "List agy models",
+		Annotations: annReadExternal,
+		Description: "List the agy model names accepted by the model parameter of agy_run and agy_run_sync. Call it only when you intend to override the default; omitting model uses agy's configured default, so most runs need no call here. Shells out to the agy CLI, so it fails if agy is missing from PATH or not authenticated.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ emptyInput) (*mcp.CallToolResult, modelsOutput, error) {
 		models, err := mgr.ListModels(ctx)
 		if err != nil {
@@ -223,7 +283,10 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: toolListSessions, Description: "List known agy conversations (workspace to conversation id).",
+		Name:        toolListSessions,
+		Title:       "List agy conversations",
+		Annotations: annReadLocal,
+		Description: "List known agy conversations as workspace-directory to conversation-id pairs. Use it to recover a conversation_id to pass to agy_run or agy_run_sync when resuming an earlier thread, which beats restating context in a fresh prompt. To continue the latest thread for a directory you do not need this: set continue_latest instead. Reads agy's own conversation cache, so it also lists conversations this server never started, and it holds only the most recent id per workspace rather than full history.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in sessionsInput) (*mcp.CallToolResult, sessionsOutput, error) {
 		sessions, err := mgr.ListSessions(in.Dir)
 		if err != nil {

--- a/internal/mcptools/wait.go
+++ b/internal/mcptools/wait.go
@@ -11,7 +11,7 @@ import (
 // waitInput is the input for agy_wait.
 type waitInput struct {
 	JobID string `json:"job_id" jsonschema:"job id to wait for, as returned by agy_run or agy_run_sync"`
-	Wait  string `json:"wait,omitempty" jsonschema:"max time to block inline (Go duration, default 2m, max 10m). Caps only the inline wait, not the job itself: on overrun the job keeps running and can be waited on again or polled with agy_status"`
+	Wait  string `json:"wait,omitempty" jsonschema:"max time to block inline (Go duration, default 2m); a larger value is silently clamped to 10m. Caps only the inline wait, not the job itself: on overrun the job keeps running and can be waited on again or polled with agy_status"`
 }
 
 // registerWait adds the agy_wait tool: block on an existing job until it
@@ -23,13 +23,13 @@ func registerWait(s *mcp.Server, mgr *manager.Manager) {
 		Name:        toolAgyWait,
 		Title:       "Wait for an agy job",
 		Annotations: annReadLocal,
-		Description: "Block until an agy job finishes (bounded by wait, default 2m, max 10m). " +
+		Description: "Block until an agy job finishes (bounded by wait). " +
 			"Accepts any job_id, whether it came from agy_run or from an agy_run_sync that " +
-			"outlived its inline wait. Sends MCP progress notifications while waiting. Prefer " +
-			"one agy_wait over repeated agy_status polling when the next step depends on the " +
-			"job's result; use agy_status instead for a single non-blocking check. " +
-			"Outliving the wait cap is not a failure: the job keeps running under its own " +
-			"timeout, so call agy_wait again or poll agy_status.",
+			"outlived its inline wait. Prefer one agy_wait over repeated agy_status polling " +
+			"when the next step depends on the job's result; use agy_status instead for a " +
+			"single non-blocking check. Streams progress notifications while waiting when the " +
+			"client asks for them. Outliving the wait cap is not a failure: the job keeps " +
+			"running under its own timeout, so call agy_wait again.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in waitInput) (*mcp.CallToolResult, runSyncOutput, error) {
 		wait, err := parseWait(in.Wait)
 		if err != nil {

--- a/internal/mcptools/wait.go
+++ b/internal/mcptools/wait.go
@@ -10,8 +10,8 @@ import (
 
 // waitInput is the input for agy_wait.
 type waitInput struct {
-	JobID string `json:"job_id" jsonschema:"the job id to wait for"`
-	Wait  string `json:"wait,omitempty" jsonschema:"max time to wait inline (Go duration, default 2m, max 10m); on overrun the job keeps running and can be waited on again or polled with agy_status"`
+	JobID string `json:"job_id" jsonschema:"job id to wait for, as returned by agy_run or agy_run_sync"`
+	Wait  string `json:"wait,omitempty" jsonschema:"max time to block inline (Go duration, default 2m, max 10m). Caps only the inline wait, not the job itself: on overrun the job keeps running and can be waited on again or polled with agy_status"`
 }
 
 // registerWait adds the agy_wait tool: block on an existing job until it
@@ -20,13 +20,16 @@ type waitInput struct {
 // replaces an agy_status poll loop.
 func registerWait(s *mcp.Server, mgr *manager.Manager) {
 	mcp.AddTool(s, &mcp.Tool{
-		Name: toolAgyWait,
+		Name:        toolAgyWait,
+		Title:       "Wait for an agy job",
+		Annotations: annReadLocal,
 		Description: "Block until an agy job finishes (bounded by wait, default 2m, max 10m). " +
 			"Accepts any job_id, whether it came from agy_run or from an agy_run_sync that " +
 			"outlived its inline wait. Sends MCP progress notifications while waiting. Prefer " +
 			"one agy_wait over repeated agy_status polling when the next step depends on the " +
-			"job's result. If the job outlives the wait cap that is not a failure: it keeps " +
-			"running; call agy_wait again or poll agy_status.",
+			"job's result; use agy_status instead for a single non-blocking check. " +
+			"Outliving the wait cap is not a failure: the job keeps running under its own " +
+			"timeout, so call agy_wait again or poll agy_status.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in waitInput) (*mcp.CallToolResult, runSyncOutput, error) {
 		wait, err := parseWait(in.Wait)
 		if err != nil {


### PR DESCRIPTION
Every tool this server exposes shipped without MCP annotations. Absent annotations are not neutral: the spec defaults them to `destructiveHint: true`, `openWorldHint: true`, `readOnlyHint: false`, so `agy_status`, `agy_wait`, `list_models` and `list_sessions` were advertising themselves to every client as destructive, open-world mutations. They read a job store. This declares the truth for all seven tools, adds display titles, and fixes the descriptions I found to be wrong while checking them.

I started from Glama's [tool-definition-quality-score](https://github.com/glama-ai/tool-definition-quality-score) rubric as a lens. The score was a way to find gaps, not the goal; where the rubric and real usability disagreed I went with usability and said so in the code.

## Annotations

| Tool | readOnly | destructive | idempotent | openWorld |
|---|---|---|---|---|
| `agy_run`, `agy_run_sync` | - | true | - | true |
| `agy_cancel` | - | true | true | false |
| `agy_status`, `agy_wait`, `list_sessions` | true | - | - | false |
| `list_models` | true | - | - | true |

`destructiveHint` and `idempotentHint` are meaningful only when `readOnlyHint` is false, so the read-only tools leave them unset rather than carrying decorative values.

Two judgement calls worth flagging. `agy_run`/`agy_run_sync` keep `destructiveHint: true`: I checked whether stating it explicitly changes anything versus leaving it absent, and it does not, because the spec default is already true. The delegated agent really can overwrite the repo, so the accurate hint stays. And `agy_status`/`agy_wait` keep `readOnlyHint: true` even though reading a finished job's status memoizes the captured conversation id into the job meta. That write is idempotent bookkeeping over a value the job already produced, and the hint describes blast radius rather than literal purity. The comment says so instead of claiming the tools "only read", which is what it used to say and was false.

**One behaviour change worth knowing about on upgrade:** `readOnlyHint` defaults to false, so those four tools flip from "may mutate" to "does not mutate". A client that gates confirmation on the hint may stop prompting for them. That is the correction working as intended, but it is not silent-by-accident.

## Description corrections

These were the actual bugs. Each was verified against the source:

- `dirs` was described as directories the agent "may read". Runs are spawned with `--dangerously-skip-permissions` plus one `--add-dir` per entry, so the agent reads **and writes** there exactly as under `cwd`.
- "terminate its agy process group" is POSIX-only; Windows terminates a Job Object. Now "process tree".
- `agy_cancel` enumerated cancelled/terminal/unknown, but cancel only *requests* termination and the supervisor allows a 10s grace, so the usual return is `running`. Reading that as a failed cancel and retrying is the obvious wrong move.
- `agy_status` was called a "cheap liveness check". `State` exists precisely because `Status` reads the job's full output once terminal.
- "supplying both is an error" was wrong for the false case: the guard is `ContinueLatest && ConversationID != ""`.
- `cwd`/`dir` claimed to require absolute paths, which `filepath.Abs` does not; but a relative path resolves against the *server's* working directory, which under the HTTP transport is not the client's, so they now ask for absolute and explain why.
- `model` deferred to "agy's configured default"; the server substitutes `AGY_MCP_DEFAULT_MODEL` first.
- `runOutput.state` listed four values. `StartJob` always returns `running`.
- Progress notifications are sent only when the client supplies a progress token.
- `wait`'s cap is a silent clamp while `timeout`'s is a hard rejection. Identical phrasing, opposite behaviour; each now says which.

## Output schemas

All twenty output properties shipped bare, which is why `agy_status` had to explain `partial` in prose. They now carry descriptions, including `manager.Session`'s nested fields.

## Tests

`TestToolDefinitionsDeclareAnnotations` and `TestToolDefinitionsDescribeThemselves` assert against the live `tools/list` payload rather than the registration literals.

The first cut of these asserted that annotations were *present*. Mutation testing showed five silent flips passing green, including `destructiveHint` true to false on `agy_run` — the single decision the code comments argue for at length. They now assert values. Sibling cross-references match on a word boundary, because `strings.Contains` let `agy_run_sync` satisfy a requirement to name `agy_run` and hollowed out three of five checks. Unclassified tools fail loudly in both tests, the tool set must match the expectation table in both directions, and property descriptions are required through nested array items.

`connect` moves out from behind a posix build tag into an untagged `harness_test.go`; nothing in it is platform-specific and the cross-platform tests need it.

## Compatibility

Input and output schemas are byte-identical apart from `description` strings — no property renamed, retyped, added, removed, or moved in or out of `required`. `title` and `annotations` are optional fields. No handler logic, default, or constant changed.

The serialized `tools/list` payload grows roughly 6.8 KB to 14.5 KB, about +2k tokens per session. That is a real cost I chose to pay for accurate disclosure on a server whose job is delegating work an agent could otherwise misuse. Happy to trim if you would rather have it leaner.

## Verification

`go build`, `go vet` (linux, windows, darwin), `go test ./...`, `go test -race`, and `golangci-lint run` all clean.