### PR TITLE
Remove the conversation-cache capture residue (#96, part 1)

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -10,13 +10,13 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
-// Meta describes a job. The identity fields are set at creation; PID,
-// StartTimeTicks, and ConversationID are filled in afterward by atomic rewrites
-// (UpdateMeta / SetConversationID).
+// Meta describes a job. The identity fields are set at creation, as is
+// ConversationID, which agy names in the init event of its stream before the job
+// is recorded. PID and StartTimeTicks are filled in afterward by an atomic
+// rewrite (UpdateMeta) once the supervisor has been spawned.
 type Meta struct {
 	ID             string        `json:"id"`
 	AgyPath        string        `json:"agy_path"`
@@ -222,13 +222,15 @@ func writeFileAtomic(dir, name string, b []byte) error {
 var ErrInvalidID = errors.New("invalid job id")
 
 // Store is a directory-backed collection of jobs.
+// Store holds no mutex on purpose. It once needed one to make
+// SetConversationID's load-modify-rewrite atomic against a concurrent
+// UpdateMeta; with the conversation-cache capture gone there is no
+// read-modify-write left, and every remaining writer hands in a complete Meta.
+// What protects a reader is writeMetaAtomic's temp-file-and-rename, not a lock,
+// and that holds across the manager/supervisor process boundary where a mutex
+// could not reach anyway.
 type Store struct {
 	root string
-	// mu serializes every meta rewrite (UpdateMeta and SetConversationID). It is
-	// what lets SetConversationID's read-modify-write be atomic: it holds mu across
-	// the Load and the rewrite, and because UpdateMeta also takes mu a concurrent
-	// UpdateMeta cannot land between the two and be clobbered.
-	mu sync.Mutex
 }
 
 // New returns a Store rooted at dir/jobs.
@@ -294,24 +296,14 @@ func (s *Store) Load(id string) (Meta, error) {
 	return LoadDir(s.jobDir(id))
 }
 
-// UpdateMeta atomically rewrites a job's meta.json. It takes s.mu so every meta
-// rewrite is serialized: a concurrent reader (such as the freshly spawned
-// supervisor) never observes a partially written file, and SetConversationID's
-// read-modify-write cannot be clobbered by a concurrent UpdateMeta landing
-// between its Load and its rewrite.
+// UpdateMeta atomically rewrites a job's meta.json. The caller supplies a
+// complete Meta, so there is nothing to serialize: writeMetaAtomic's rename is
+// what stops a concurrent reader (such as the freshly spawned supervisor) from
+// observing a partially written file.
 func (s *Store) UpdateMeta(m Meta) error {
 	if !validJobID(m.ID) {
 		return ErrInvalidID
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.updateMetaLocked(m)
-}
-
-// updateMetaLocked performs the atomic rewrite. The caller must hold s.mu. It is
-// the shared body of UpdateMeta (which acquires the lock) and SetConversationID
-// (which already holds it), so the two never deadlock by re-locking.
-func (s *Store) updateMetaLocked(m Meta) error {
 	return writeMetaAtomic(s.jobDir(m.ID), m)
 }
 
@@ -325,32 +317,6 @@ func writeMetaAtomic(dir string, m Meta) error {
 		return err
 	}
 	return writeFileAtomic(dir, MetaFile, b)
-}
-
-// SetConversationID persists convID as the job's conversation id, but only when
-// it is currently unset: it reloads the latest meta and rewrites just that field,
-// so it cannot clobber a concurrent meta update, and a second caller that races to
-// capture the same job is a no-op. It returns the effective conversation id (the
-// existing one if already set, otherwise convID).
-func (s *Store) SetConversationID(id, convID string) (string, error) {
-	// Serialize the read-modify-write so two callers racing to capture the same
-	// job cannot both observe an empty id and have the later write win (TOCTOU).
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	m, err := s.Load(id)
-	if err != nil {
-		return "", err
-	}
-	if m.ConversationID != "" {
-		return m.ConversationID, nil
-	}
-	m.ConversationID = convID
-	// Already holding s.mu, so rewrite via the locked variant; calling UpdateMeta
-	// here would re-acquire s.mu and deadlock.
-	if err := s.updateMetaLocked(m); err != nil {
-		return "", err
-	}
-	return convID, nil
 }
 
 // Remove deletes a job's directory and everything in it.

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -13,10 +13,16 @@ import (
 	"time"
 )
 
-// Meta describes a job. The identity fields are set at creation, as is
-// ConversationID, which agy names in the init event of its stream before the job
-// is recorded. PID and StartTimeTicks are filled in afterward by an atomic
-// rewrite (UpdateMeta) once the supervisor has been spawned.
+// Meta describes a job. The identity fields are set at creation. PID and
+// StartTimeTicks are filled in afterward by an atomic rewrite (UpdateMeta) once
+// the supervisor has been spawned.
+//
+// ConversationID is set at creation for a continuation only, from the id the
+// caller supplied or the one continue_latest resolved. A fresh run's id is never
+// recorded here at all: agy names it in the init event of its stream, which
+// necessarily arrives after Create, and the supervisor records it in
+// progress.json. Anything that needs a fresh run's conversation id must read
+// progress.json, which is why Status and conversationLive both scan it.
 type Meta struct {
 	ID             string        `json:"id"`
 	AgyPath        string        `json:"agy_path"`
@@ -75,10 +81,10 @@ func ResultPath(dir string) string   { return filepath.Join(dir, ResultFile) }
 //
 // It is deliberately a separate file rather than a field on Meta. The manager
 // rewrites meta.json after spawning the supervisor (to record the supervisor
-// PID), so a supervisor writing the same file would race that update; the
-// Store mutex serializes writers within one process and cannot span the
-// manager/supervisor process boundary. Splitting the file gives each one a
-// single writer instead.
+// PID), so a supervisor writing the same file would race that update, and no
+// lock could arbitrate it: the two are separate processes. Splitting the file
+// gives each of them a file with exactly one writer, which is what makes the
+// atomic rewrite sufficient on its own.
 type Progress struct {
 	ConversationID string    `json:"conversation_id,omitempty"`
 	StepIndex      int       `json:"step_index"`

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -173,47 +173,6 @@ func TestUpdateMetaRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSetConversationID(t *testing.T) {
-	const first = "conv-1"
-	s := New(t.TempDir())
-	if _, err := s.Create(Meta{ID: "j", PID: 4242, AgyPath: "/usr/bin/agy"}); err != nil {
-		t.Fatal(err)
-	}
-	// Set on an unset job: persists the id and returns it, preserving other fields.
-	got, err := s.SetConversationID("j", first)
-	if err != nil {
-		t.Fatalf("SetConversationID: %v", err)
-	}
-	if got != first {
-		t.Fatalf("returned id = %q, want %q", got, first)
-	}
-	reloaded, err := s.Load("j")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reloaded.ConversationID != first {
-		t.Fatalf("persisted id = %q, want %q", reloaded.ConversationID, first)
-	}
-	if reloaded.PID != 4242 || reloaded.AgyPath != "/usr/bin/agy" {
-		t.Fatalf("other fields clobbered: %+v", reloaded)
-	}
-	// Setting again is a no-op: returns the existing id, does not overwrite.
-	got, err = s.SetConversationID("j", "conv-2")
-	if err != nil {
-		t.Fatalf("second SetConversationID: %v", err)
-	}
-	if got != first {
-		t.Fatalf("second set returned %q, want existing %q", got, first)
-	}
-	reloaded, err = s.Load("j")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if reloaded.ConversationID != first {
-		t.Fatalf("existing id was overwritten: %q", reloaded.ConversationID)
-	}
-}
-
 func TestExitCodeSentinel(t *testing.T) {
 	s := New(t.TempDir())
 	if _, err := s.Create(Meta{ID: "j"}); err != nil {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -745,29 +745,18 @@ func (m *Manager) runPeriodicGC(ctx context.Context, interval time.Duration) {
 
 // reqFromMeta reconstructs the parts of a StartRequest that determine a job's
 // gate key from its persisted meta. continue_latest is resolved into
-// ConversationID at start time, so ConversationID + Cwd reproduce the same key
+// ConversationID at start time, so the conversation id alone reproduces the key
 // the original run held.
 //
-// The cwd is re-normalized (best effort) so a job persisted by an older binary,
-// before StartJob canonicalized cwd, restores under the same key a new
-// same-directory run now computes. Without this, across the upgrade a restored
-// legacy job (raw cwd) and a new run (normalized cwd) would hold different keys,
-// fail to serialize, and risk concurrent O_TRUNC writes to the same agy cache
-// entry. For jobs started by the current binary meta.Cwd is already normalized,
-// so this is idempotent.
+// It used to re-normalize meta.Cwd as well, because the key was once derived
+// from the directory and a legacy job's raw cwd would otherwise restore under a
+// different key than a new same-directory run computed. Fresh runs stopped being
+// keyed by directory when the conversation id started coming from agy's own
+// stream, so keyFor reads nothing but ConversationID and the Abs plus
+// EvalSymlinks (plus an os.Getwd for a relative cwd) ran once per job in the
+// startup scan for a value nothing consumed.
 func reqFromMeta(meta jobstore.Meta) StartRequest {
-	cwd := meta.Cwd
-	if norm, err := normalizeCwd(cwd); err == nil {
-		cwd = norm
-	} else {
-		// Restore stays resilient (unlike StartJob, which fails closed), so a job
-		// whose cwd cannot be normalized keeps its raw cwd for the gate key. Log it:
-		// under this rare path (a legacy relative cwd plus an os.Getwd failure) the
-		// restored key may not match a new same-directory run's normalized key, the
-		// one inconsistency that can still split serialization for that job.
-		log.Printf("normalize cwd %q for restored job %s: %v; using raw cwd for gate key", cwd, meta.ID, err)
-	}
-	return StartRequest{ConversationID: meta.ConversationID, Cwd: cwd}
+	return StartRequest{ConversationID: meta.ConversationID}
 }
 
 // RestoreGate re-acquires gate slots and keys for jobs whose detached supervisor

--- a/internal/manager/normalize.go
+++ b/internal/manager/normalize.go
@@ -2,13 +2,15 @@ package manager
 
 import "path/filepath"
 
-// normalizeCwd canonicalizes a working directory so the gate key, the agy
-// conversation-cache lookups, the spawned cmd.Dir, and the persisted meta all
-// agree on one spelling. A trailing slash, a relative path, or a symlinked alias
-// would otherwise yield a distinct gate key (two "same dir" fresh runs would not
-// serialize, re-exposing the agy session-lock hang the gate exists to prevent)
-// and a missed cache entry (continue_latest silently starts a new conversation,
-// and a fresh run's id capture never matches).
+// normalizeCwd canonicalizes a working directory so the agy conversation-cache
+// lookups, the spawned cmd.Dir, and the persisted meta all agree on one
+// spelling. A trailing slash, a relative path, or a symlinked alias would
+// otherwise miss a cache entry, so continue_latest would silently start a new
+// conversation and a list_sessions directory filter would match nothing.
+//
+// The gate key is no longer among the consumers: fresh runs stopped being keyed
+// by directory once the conversation id started arriving in agy's own stream, so
+// keyFor reads only the conversation id.
 //
 // EvalSymlinks also aligns the key with the physical path agy records: the
 // supervisor sets cmd.Dir to this value, so agy's own getcwd returns the

--- a/internal/manager/normalize.go
+++ b/internal/manager/normalize.go
@@ -18,9 +18,12 @@ import "path/filepath"
 func normalizeCwd(cwd string) (string, error) {
 	if cwd == "" {
 		// filepath.Abs("") resolves to the process working directory, which would
-		// turn an empty cwd (a legacy job persisted with no cwd, or any caller that
-		// means "no directory") into a bogus, unrelated gate key. An empty cwd has
-		// no canonical form; keep it empty so keyFor yields the no-key behavior.
+		// turn "no directory" into a confident claim about an unrelated one: a cache
+		// lookup against the manager's own cwd, or a cmd.Dir the caller never asked
+		// for. An empty cwd has no canonical form, so keep it empty and let each
+		// consumer decide what to do with it. Both live callers already guarantee a
+		// non-empty value (StartJob fails closed, readSessions guards), so this is
+		// defence in depth.
 		return "", nil
 	}
 	abs, err := filepath.Abs(cwd)

--- a/internal/manager/normalize_test.go
+++ b/internal/manager/normalize_test.go
@@ -11,8 +11,9 @@ import (
 // TestNormalizeCwdCollapsesEquivalentSpellings is the core regression guard for
 // issue #24: a trailing slash, a relative path, and a symlinked alias of one
 // directory must all canonicalize to the same absolute, symlink-resolved path,
-// so they produce one gate key (same-dir fresh runs serialize) and hit the same
-// agy conversation-cache entry.
+// so they hit the same agy conversation-cache entry and hand the supervisor the
+// same cmd.Dir. They no longer have to agree on a gate key; fresh runs stopped
+// serializing by directory when keyFor narrowed to the conversation id.
 func TestNormalizeCwdCollapsesEquivalentSpellings(t *testing.T) {
 	realDir := t.TempDir()
 	canonical, err := filepath.EvalSymlinks(realDir)

--- a/internal/manager/normalize_test.go
+++ b/internal/manager/normalize_test.go
@@ -56,27 +56,6 @@ func TestNormalizeCwdCollapsesEquivalentSpellings(t *testing.T) {
 	})
 }
 
-// TestReqFromMetaNormalizesLegacyCwd guards the upgrade window: a job persisted
-// by an older binary may have a raw, un-normalized meta.Cwd, and reqFromMeta
-// must canonicalize it. The cwd no longer feeds the gate key (only a
-// conversation does), but it still has to be normalized so a restored job's cwd
-// matches the spelling StartJob persists.
-func TestReqFromMetaNormalizesLegacyCwd(t *testing.T) {
-	dir := t.TempDir()
-	canonical, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatalf("EvalSymlinks: %v", err)
-	}
-	req := reqFromMeta(jobstore.Meta{Cwd: dir + "/"})
-	if req.Cwd != canonical {
-		t.Errorf("restored cwd = %q, want %q (legacy cwd not normalized)", req.Cwd, canonical)
-	}
-	// A restored fresh run keys on nothing, so it blocks no new run.
-	if got := keyFor(req); got != "" {
-		t.Errorf("restored gate key = %q, want empty for a fresh run", got)
-	}
-}
-
 // A restored job that was continuing a conversation still keys on it, which is
 // the serialization that remains.
 func TestReqFromMetaKeysOnConversation(t *testing.T) {
@@ -96,14 +75,6 @@ func TestNormalizeCwdPreservesEmpty(t *testing.T) {
 	}
 	if got != "" {
 		t.Errorf("normalizeCwd(empty) = %q, want empty", got)
-	}
-}
-
-// TestReqFromMetaPreservesEmptyCwd verifies a legacy job persisted with no cwd
-// restores under the no-key behavior, not under the manager's working directory.
-func TestReqFromMetaPreservesEmptyCwd(t *testing.T) {
-	if k := keyFor(reqFromMeta(jobstore.Meta{Cwd: ""})); k != "" {
-		t.Errorf("restored gate key for empty cwd = %q, want empty", k)
 	}
 }
 

--- a/internal/manager/store.go
+++ b/internal/manager/store.go
@@ -19,7 +19,6 @@ type jobStore interface {
 	Create(m jobstore.Meta) (string, error)
 	Load(id string) (jobstore.Meta, error)
 	UpdateMeta(m jobstore.Meta) error
-	SetConversationID(id, convID string) (string, error)
 	Remove(id string) error
 	Dir(id string) (string, error)
 	WriteExitCode(id string, code int) error


### PR DESCRIPTION
First slice of #96: the machinery that outlived the conversation-cache capture, all of it still carrying comments that justified it by hazards which no longer exist.

## What went

`jobstore.Store.SetConversationID` had no production caller. Its load-modify-rewrite was the only reason `Store` held a mutex and the only reason `updateMetaLocked` existed, so the three go together. Every remaining writer hands in a complete `Meta`, and what stops a reader seeing a half-written file is `writeMetaAtomic`'s temp-file-and-rename, not a lock. The lock could never have helped across the manager/supervisor process boundary anyway, which is exactly why progress lives in its own file.

`reqFromMeta` re-normalized the persisted cwd for every job in the startup restore scan, an `Abs` plus `EvalSymlinks` (plus an `os.Getwd` for a relative cwd), and handed the result to `keyFor`, which reads nothing but the conversation id. Those are the only two halves that matter and both were verified: one production caller, and a `keyFor` that already ignored `Cwd` at the base commit. `keyFor(reqFromMeta(m))` is therefore bit-identical before and after for every possible `Meta`.

Two tests pinned that normalization. One of them conceded in its own comment that the cwd no longer feeds the gate key, and then asserted it anyway.

`normalizeCwd` itself stays. It still has real consumers in the agy cache lookups, `cmd.Dir` and the persisted meta; the gate key just is not one of them, and its doc now says so.

## Review found one thing worth its own paragraph

The first commit's replacement `Meta` doc was wrong. It said `ConversationID` is set at creation, when that holds for a continuation only: a fresh run's id is never recorded in `Meta` at all, since agy names it in the init event of its stream, which necessarily arrives after `Create`, and the supervisor writes it to `progress.json`. That mattered more than a comment usually does, because a reader who believed `meta.json` always carries the id could delete the `progress.json` fallbacks in `Status` and `conversationLive` as redundant, and `conversationLive` is the only thing preventing a second agy session joining a running fresh conversation. Corrected in the second commit, along with three comments this branch had itself made stale.

## Verification

- `go test ./... -race`: green, all 11 packages. `golangci-lint run ./...`: 0 issues.
- The mutex removal was the risky edit, so it was attacked directly rather than argued: every `*jobstore.Store` method and every caller enumerated, confirming the only remaining `meta.json` writers are `Create` (unique id) and `UpdateMeta` (one production call site, which builds its `Meta` locally in `StartJob`), with no load-then-write anywhere and no cross-process meta writer.
- That was then proven empirically with a throwaway stress test (32 concurrent `UpdateMeta` writers, 8 concurrent readers, plus concurrent `Create`/`List` and `UpdateMeta`/`WriteExitCode`) under `-race -count=3`: zero torn reads, zero blended `Meta`s. Negative control: swapping `writeFileAtomic` for a plain `os.WriteFile` makes the same test report 58 torn reads, so it is sensitive rather than vacuous.
- Worth stating plainly: no test in the repo exercises concurrent `Store` use, and `-race` instruments memory, not file ordering, so a lost-update regression would be invisible to the suite. That was equally true with the mutex present; it is a coverage gap this change neither creates nor closes.

## Not in this PR

`loadCacheRetry` is listed under the same #96 heading but is not dead: it has a live caller. The real finding there is that two readers of the same cache behave differently (`resolveLatest` retries, `readSessions` does not), which is a behaviour decision rather than a deletion, so it belongs with the other cache items.
