### PR TITLE
Correct the status path's untrue claims and pre-size its out read (#102)

### DIFF
--- a/internal/manager/readfile_test.go
+++ b/internal/manager/readfile_test.go
@@ -1,0 +1,75 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// TestReadFileContract pins what readFile's three callers rely on, none of which
+// tested it directly before its read was pre-sized: a missing file is an empty
+// result rather than an error (an absent answer must not be reported as a
+// failure), the trailing newline is trimmed so a payload response and a streamed
+// out read identically, and interior newlines survive.
+func TestReadFileContract(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name    string
+		write   bool
+		content string
+		want    string
+	}{
+		{name: "missing file reads empty, not an error"},
+		{name: "empty file", write: true},
+		{name: "trailing newlines trimmed", write: true, content: "answer\n\n", want: "answer"},
+		{name: "interior newlines kept", write: true, content: "a\nb\n", want: "a\nb"},
+		{name: "no trailing newline", write: true, content: "answer", want: "answer"},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// One path per case so the missing-file case cannot read a sibling's file.
+			p := filepath.Join(dir, "out"+strconv.Itoa(i))
+			if tc.write {
+				if err := os.WriteFile(p, []byte(tc.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := readFile(p)
+			if err != nil {
+				t.Fatalf("readFile: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("readFile = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadFileCapsAtMaxReadBytes: pre-sizing the read from the file's own size
+// must not widen the cap that keeps a runaway agy from OOMing the server, which
+// is the one place the Stat-derived size and the LimitReader interact. The
+// fixture is sparse (Truncate with no writes), so it costs a file size rather
+// than 32 MiB of disk traffic; the bytes it reads back are NULs, which
+// TrimRight leaves alone, so the length is the whole assertion.
+func TestReadFileCapsAtMaxReadBytes(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "out")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(maxReadBytes + 1024); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readFile(p)
+	if err != nil {
+		t.Fatalf("readFile: %v", err)
+	}
+	if len(got) != maxReadBytes {
+		t.Fatalf("read %d bytes, want the %d-byte cap", len(got), maxReadBytes)
+	}
+}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -40,10 +41,17 @@ const (
 type Status struct {
 	State   string // running | done | failed | cancelled
 	Elapsed time.Duration
-	// Result is the assistant's response. It is set whenever the job produced
-	// any text, which is NOT only when State is done: a cancelled, timed-out or
-	// crashed run carries whatever it managed to say, so that work is offered
-	// back rather than discarded. Consult Partial before treating it as final.
+	// Result is the assistant's response. Every TERMINAL state that produced any
+	// text carries one, not done alone: a cancelled, timed-out or crashed run
+	// carries whatever it managed to say, so that work is offered back rather
+	// than discarded. Consult Partial before treating it as final.
+	//
+	// A running job deliberately reports none, even once it has streamed text.
+	// Status returns above without reading the out file while the job is live,
+	// which is what makes polling one cheap (the agy_status tool description
+	// promises exactly that); reading per tick would re-read a growing file, and
+	// mid-stream text is not an answer. Collect a result once the state is
+	// terminal.
 	Result         string
 	Error          string // present when failed: agy's own message, or a stderr tail + exit code
 	ConversationID string
@@ -67,6 +75,9 @@ type Status struct {
 	Usage    *streamjson.Usage
 	// StepType names the stream step the job is on, for progress reporting. It
 	// is a hint: empty until the first step arrives, and stale by up to one poll.
+	// It is read from progress.json before the exit-code sentinel is consulted,
+	// so a terminal job keeps the last step it recorded rather than clearing it;
+	// only a running job's is current.
 	StepType string
 }
 
@@ -516,6 +527,13 @@ func (m *Manager) frozenElapsed(meta jobstore.Meta, running time.Duration) time.
 // maxReadBytes. A missing file yields "" with no error: a job may legitimately
 // have produced no output. Any other error is returned so callers can tell an
 // unreadable file (report a failure) from an empty one (a clean empty result).
+//
+// The read is pre-sized from the file's own size, so a large out file is not
+// rebuilt by the grow-and-copy an unsized io.ReadAll performs. That is worth the
+// Stat because every agy_status on a terminal job reads its full output, and
+// polling is the primary way a result is collected. The size is only a hint: the
+// LimitReader still owns the cap, and the buffer still grows on its own if the
+// file changed since the Stat.
 func readFile(p string) (string, error) {
 	f, err := os.Open(p)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -525,11 +543,19 @@ func readFile(p string) (string, error) {
 		return "", err
 	}
 	defer func() { _ = f.Close() }()
-	b, err := io.ReadAll(io.LimitReader(f, maxReadBytes))
-	if err != nil {
+	var buf bytes.Buffer
+	// Pre-size from the file's own size. bytes.MinRead of headroom on top of it
+	// keeps ReadFrom's final read-to-EOF from forcing one last reallocation, and
+	// the cap keeps a huge file from reserving more than the LimitReader can ever
+	// deliver. A Stat failure costs only the pre-sizing, so it is not reported;
+	// a zero or negative size skips it (Grow panics on a negative argument).
+	if info, serr := f.Stat(); serr == nil && info.Size() > 0 {
+		buf.Grow(int(min(info.Size(), maxReadBytes) + bytes.MinRead))
+	}
+	if _, err := buf.ReadFrom(io.LimitReader(f, maxReadBytes)); err != nil {
 		return "", err
 	}
-	return strings.TrimRight(string(b), "\n"), nil
+	return strings.TrimRight(buf.String(), "\n"), nil
 }
 
 // tailFile returns the last n bytes of the file at path. Unlike a LimitReader

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -544,11 +544,17 @@ func readFile(p string) (string, error) {
 	}
 	defer func() { _ = f.Close() }()
 	var buf bytes.Buffer
-	// Pre-size from the file's own size. bytes.MinRead of headroom on top of it
-	// keeps ReadFrom's final read-to-EOF from forcing one last reallocation, and
-	// the cap keeps a huge file from reserving more than the LimitReader can ever
-	// deliver. A Stat failure costs only the pre-sizing, so it is not reported;
-	// a zero or negative size skips it (Grow panics on a negative argument).
+	// Pre-size from the file's own size, plus bytes.MinRead of headroom. The
+	// headroom is what keeps ReadFrom's last pass from reallocating: it grows by
+	// MinRead before every read, which is a free reslice while that much spare
+	// capacity remains and a full grow-and-copy once it is not. That applies to
+	// an oversized file too, so this deliberately reserves MinRead more than the
+	// LimitReader can ever deliver; reserving exactly maxReadBytes instead buys
+	// back those 512 bytes and pays a 32 MiB copy to discover EOF (measured on a
+	// file over the cap: 100.7 MB allocated per read against 33.6 MB, and 3.5ms
+	// against 2.4ms). A Stat failure costs only the pre-sizing, so it is not
+	// reported; a zero or negative size skips it (Grow panics on a negative
+	// argument).
 	if info, serr := f.Stat(); serr == nil && info.Size() > 0 {
 		buf.Grow(int(min(info.Size(), maxReadBytes) + bytes.MinRead))
 	}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -41,10 +41,15 @@ const (
 type Status struct {
 	State   string // running | done | failed | cancelled
 	Elapsed time.Duration
-	// Result is the assistant's response. Every TERMINAL state that produced any
-	// text carries one, not done alone: a cancelled, timed-out or crashed run
-	// carries whatever it managed to say, so that work is offered back rather
-	// than discarded. Consult Partial before treating it as final.
+	// Result is the assistant's response. Every TERMINAL state whose text can be
+	// RECOVERED carries one, not done alone: a cancelled, timed-out or crashed
+	// run carries whatever it managed to say, so that work is offered back rather
+	// than discarded. Recoverable is the operative word, since text can exist on
+	// disk and still not be readable: that leaves this empty, reported as an Error
+	// where the read was the only possible source of an answer
+	// (cleanExitWithoutPayload, recoverInterrupted) and passed over silently where
+	// the state was already decided without it (carryText). Consult Partial before
+	// treating it as final.
 	//
 	// A running job deliberately reports none, even once it has streamed text.
 	// Status returns above without reading the out file while the job is live,
@@ -529,10 +534,13 @@ func (m *Manager) frozenElapsed(meta jobstore.Meta, running time.Duration) time.
 // unreadable file (report a failure) from an empty one (a clean empty result).
 //
 // The read is pre-sized from the file's own size, so a large out file is not
-// rebuilt by the grow-and-copy an unsized io.ReadAll performs. That is worth the
-// Stat because every agy_status on a terminal job reads its full output, and
-// polling is the primary way a result is collected. The size is only a hint: the
-// LimitReader still owns the cap, and the buffer still grows on its own if the
+// rebuilt by the grow-and-copy an unsized io.ReadAll performs. What pays for
+// this is the fallback paths rather than every terminal status: a run whose
+// terminal payload carried a response is answered from that and never opens out
+// at all (see carryText). The callers that do open it are the runs cut short,
+// the recovered ones, and a legacy job dir, and those are polled like any other.
+// The size is only a hint: the LimitReader still owns the cap (so an out over it
+// is truncated, not read whole), and the buffer still grows on its own if the
 // file changed since the Stat.
 func readFile(p string) (string, error) {
 	f, err := os.Open(p)

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -81,9 +81,10 @@ var (
 	// annReadLocal: answers from local state (the job store, agy's conversation
 	// cache) and writes nothing at all, so readOnlyHint is literal here rather
 	// than a claim about the blast radius of some tolerable write. A status read
-	// derives everything from the job dir, and a conversation id reaches a job's
-	// meta exactly once, when StartJob creates it, so no read is left with
-	// bookkeeping to persist.
+	// answers from files the supervisor owns, and a fresh run's conversation id
+	// is never copied back into its meta (see jobstore.Meta: it lives only in
+	// progress.json, which is where every reader of it looks), so there is no
+	// memoization for a read to perform.
 	annReadLocal = &mcp.ToolAnnotations{
 		ReadOnlyHint:  true,
 		OpenWorldHint: new(false),

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -81,8 +81,8 @@ var (
 	// annReadLocal: answers from local state (the job store, agy's conversation
 	// cache) and writes nothing at all, so readOnlyHint is literal here rather
 	// than a claim about the blast radius of some tolerable write. A status read
-	// answers from files the supervisor owns, and a fresh run's conversation id
-	// is never copied back into its meta (see jobstore.Meta: it lives only in
+	// only reads the job dir's files, and a fresh run's conversation id is never
+	// copied back into its meta (see jobstore.Meta: it lives only in
 	// progress.json, which is where every reader of it looks), so there is no
 	// memoization for a read to perform.
 	annReadLocal = &mcp.ToolAnnotations{
@@ -147,7 +147,7 @@ type statusInput struct {
 type statusOutput struct {
 	State          string `json:"state" jsonschema:"running, done, failed or cancelled"`
 	Elapsed        string `json:"elapsed" jsonschema:"wall-clock time the job has run, frozen at completion once terminal"`
-	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set on any terminal state that produced text, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first. A running job carries none even once it has produced text, so collect the result once the state is terminal"`
+	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set on any terminal state whose text could be recovered, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first. A running job carries none even once it has produced text, so collect the result once the state is terminal"`
 	Error          string `json:"error,omitempty" jsonschema:"why the job failed; present only when state is failed"`
 	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread"`
 	// Partial marks a result that is not a verified final answer; see

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -79,11 +79,11 @@ var (
 		OpenWorldHint:   new(true),
 	}
 	// annReadLocal: answers from local state (the job store, agy's conversation
-	// cache) and changes nothing the caller can observe. Not literally
-	// side-effect-free: reading a finished job's status memoizes the captured
-	// conversation id into the job's meta (manager.persistCapturedID). That write
-	// is idempotent bookkeeping over a value the job already produced, so
-	// readOnlyHint still describes the blast radius accurately.
+	// cache) and writes nothing at all, so readOnlyHint is literal here rather
+	// than a claim about the blast radius of some tolerable write. A status read
+	// derives everything from the job dir, and a conversation id reaches a job's
+	// meta exactly once, when StartJob creates it, so no read is left with
+	// bookkeeping to persist.
 	annReadLocal = &mcp.ToolAnnotations{
 		ReadOnlyHint:  true,
 		OpenWorldHint: new(false),
@@ -136,7 +136,7 @@ func (in runInput) toStartRequest() (manager.StartRequest, error) {
 type runOutput struct {
 	JobID          string `json:"job_id" jsonschema:"handle for this run; pass it to agy_wait, agy_status or agy_cancel"`
 	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread. Rarely empty on a fresh run, when agy had not yet named the conversation; agy_status reports it moments later"`
-	State          string `json:"state" jsonschema:"always running: the job has been started and cannot have finished yet. Block with agy_wait or check agy_status for the outcome"`
+	State          string `json:"state" jsonschema:"always running: the state at hand-off, not a live check. A short run can already have finished by the time this is returned and still reports running here. Block with agy_wait or check agy_status for the outcome"`
 }
 
 type statusInput struct {
@@ -146,7 +146,7 @@ type statusInput struct {
 type statusOutput struct {
 	State          string `json:"state" jsonschema:"running, done, failed or cancelled"`
 	Elapsed        string `json:"elapsed" jsonschema:"wall-clock time the job has run, frozen at completion once terminal"`
-	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set whenever the run produced any text, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first"`
+	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set on any terminal state that produced text, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first. A running job carries none even once it has produced text, so collect the result once the state is terminal"`
 	Error          string `json:"error,omitempty" jsonschema:"why the job failed; present only when state is failed"`
 	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread"`
 	// Partial marks a result that is not a verified final answer; see
@@ -159,7 +159,7 @@ type statusOutput struct {
 	// StepType answers "what is it doing" for a running job, which is the whole
 	// point of polling one. It reaches the wire as well as the progress
 	// notification because Claude Code never surfaces notifications to the model.
-	StepType string `json:"step_type,omitempty" jsonschema:"what agy is doing right now (for example agent_response or a tool call), for a running job; a hint that lags by up to one poll"`
+	StepType string `json:"step_type,omitempty" jsonschema:"what agy is doing right now (for example agent_response or a tool call); a hint that lags by up to one poll. A terminal job keeps the last step it recorded rather than clearing it, so read it as live progress only while state is running"`
 }
 
 // usageOutput mirrors agy's usage object on the wire. It is declared here rather


### PR DESCRIPTION
Five items from the #102 batch, each re-verified against the code rather than taken from the issue. Four are claims the code does not follow; one is the measured efficiency item.

## The claims

**`annReadLocal` cited a symbol that never existed.** The comment said reading a finished job's status "memoizes the captured conversation id into the job's meta (`manager.persistCapturedID`)". No such symbol is anywhere in the repo, and since #106 deleted `jobstore.Store.SetConversationID` there is no remnant of the mechanism at all, so `readOnlyHint: true` is literally true and the caveat is gone rather than reworded. Checked every path reachable from the three tools carrying the annotation (`agy_status`, `agy_wait`, `list_sessions`): none writes. The replacement also describes only the property, not the tools, per the convention stated fifteen lines above it. Worth noting because an earlier draft of this comment said "both tools" and there are three, which is exactly the rot that convention exists to prevent.

**`runOutput.State` gave a false reason for a correct value.** It justified "always running" with "the job has been started and cannot have finished yet". `StartJob` does return `StateRunning` unconditionally, but only after `awaitConversationID`, which explicitly handles the job already being terminal inside its wait (`if _, terminal := m.store.ExitCode(id); terminal`). So a short run can already have finished. The field's value is fine; only the reason was untrue.

**`Status.Result` overpromised on a running job.** It was documented as set "whenever the job produced any text, which is NOT only when State is done". `Status` returns for a running job before reading the out file, so a run that has already streamed text reports an empty result. That is deliberate: reading a growing file on every poll tick is precisely what the `agy_status` description promises not to do ("Checking a still-running job is cheap"). Both the Go doc and the model-facing schema now say so, rather than pointing a poller at a field it will find empty.

**`step_type` was scoped too narrowly.** Its description said "for a running job", but `Status` reads `progress.json` before it consults the exit-code sentinel and nothing clears the field afterwards, so a terminal job carries the last step it recorded.

## The measurement

`readFile` hand-rolls `os.Open` + `io.LimitReader` + `io.ReadAll` to express the 32 MiB cap `os.ReadFile` cannot, and lost the Stat-and-pre-size half in the process. It is now pre-sized from the file's own size, with `bytes.MinRead` of headroom so `ReadFrom`'s final read to EOF does not force one last reallocation, and with the cap still owned by the `LimitReader` rather than by the hint. Measured on an M4 Pro, three runs each, old implementation against new:

| out file | allocs | allocated bytes | ns/op |
|---|---|---|---|
| 64 KiB | 21 -> 7 | 204 KB -> 140 KB | within noise |
| 1 MiB | 29 -> 7 | 3.3 MB -> 2.1 MB | within noise |
| 16 MiB | 36 -> 7 | 53.0 MB -> 33.6 MB | ~2.3ms -> ~1.7ms |

The allocation count is the result to read; the 16 MiB wall-clock gain was consistent across all three runs but the smaller sizes are noise-dominated. The issue predicted "roughly 3x its size in copy traffic", which measures as 3.3x for a 16 MiB file, falling to 2.1x (the buffer plus the one unavoidable `string` copy).

Corrected after review: an earlier version of this description said every `agy_status` on a terminal job reads its full output. It does not. A run whose terminal payload carried a response is answered from the payload and never opens `out` at all, so the pre-sizing pays off on the fallback paths (runs cut short, recovered ones, a legacy job dir), which are polled like any other job. "Full output" was also loose, since an `out` over `maxReadBytes` is truncated rather than read whole.

`readFile` had no direct test, so its contract is pinned: a missing file reads empty rather than erroring (an absent answer must not be reported as a failure), the trailing newline is trimmed so a payload response and a streamed out read identically, interior newlines survive, and the cap holds. The cap test uses a sparse fixture (`Truncate` with no writes) so it costs a file size instead of 32 MiB of disk traffic, and runs in 10ms.

## Deliberately left in #102

**Tightening `streamJSONRun`** to ask "did this run stream stream-json?" rather than "did the caller name any output format". It is conservative and unreachable from the current arg builder, and #103 documented its breadth in the code rather than changing it because tightening interacts with the `markStreamJSON` gate that PR narrowed for the same reason. It deserves its own change with that interaction in view.

**`recoverInterrupted`'s unconditional `Partial`.** This one does not survive re-derivation. The issue argues an identical job dir is reported partial without a sentinel and complete with one, but the sentinel is not incidental to the comparison: it is precisely the evidence of clean completion that the no-sentinel case lacks. A legacy dir whose supervisor vanished mid-run genuinely may hold truncated text, so `Partial` is the correct pessimistic answer there. Recorded in the issue rather than silently dropped.

## Verification

`go build`, `go vet`, `gofmt`, `golangci-lint run` (0 issues), full `go test ./...` green, `go test -race` on the touched package green. Both new tests pass. The four doc claims were also independently checked against the code by Gemini 3.1 Pro, which confirmed all five (its route description for the Result claim is imprecise, `cleanExitWithoutPayload` reads out itself rather than through `carryText`, but the conclusion holds).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified run and job status fields, including when results become available and how progress indicators should be interpreted.
  * Updated descriptions for read-only local status access.

* **Tests**
  * Added coverage for file reading behavior, including missing files, newline handling, content preservation, and maximum read limits.

* **Refactor**
  * Improved the efficiency of bounded file reads while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
