### PR TITLE
Remove the last of the capture-era dead code, and correct the prose it left (#96 part 2)

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -86,10 +86,19 @@ func ResultPath(dir string) string   { return filepath.Join(dir, ResultFile) }
 // gives each of them a file with exactly one writer, which is what makes the
 // atomic rewrite sufficient on its own.
 type Progress struct {
-	ConversationID string    `json:"conversation_id,omitempty"`
-	StepIndex      int       `json:"step_index"`
-	StepType       string    `json:"step_type,omitempty"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	// StepIndex is the index of the step the run is on. No PRODUCTION code reads it
+	// back off disk: the manager reports StepType, not the index. It is kept
+	// because the supervisor compares it against each incoming event to decide
+	// whether anything observable actually moved (see consumeStream), which is what
+	// stops a repeated update for one step from atomically rewriting a
+	// byte-identical file. Persisting it lets a test assert the value, which keeps
+	// the ASSIGNMENT honest; the comparison itself is asserted by nothing, and
+	// deleting it leaves the whole suite green, so treat that dedup as an
+	// optimization a later change can silently revert.
+	StepIndex int       `json:"step_index"`
+	StepType  string    `json:"step_type,omitempty"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // WriteProgressDir atomically rewrites a job's progress file.
@@ -228,8 +237,9 @@ func writeFileAtomic(dir, name string, b []byte) error {
 var ErrInvalidID = errors.New("invalid job id")
 
 // Store is a directory-backed collection of jobs.
-// Store holds no mutex on purpose. It once needed one to make
-// SetConversationID's load-modify-rewrite atomic against a concurrent
+//
+// Store holds no mutex on purpose. It once needed one to make a since-deleted
+// load-modify-rewrite (SetConversationID) atomic against a concurrent
 // UpdateMeta; with the conversation-cache capture gone there is no
 // read-modify-write left, and every remaining writer hands in a complete Meta.
 // What protects a reader is writeMetaAtomic's temp-file-and-rename, not a lock,

--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
-	// withCacheFile injects a test-owned cache file so the fresh run's id capture
-	// does not read the developer's real agy cache or leak a capture goroutine
-	// racing cleanup.
+	// withCacheFile injects a test-owned cache file so nothing here can read the
+	// developer's real agy cache. This run resolves no conversation (no
+	// continue_latest), so the file is never actually read; the injection is
+	// insurance against a future change here, not a dependency of this test.
 	m := newManager(t, managerOpts{
 		agyPath:        "/usr/bin/agy",
 		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),

--- a/internal/manager/keylock.go
+++ b/internal/manager/keylock.go
@@ -13,16 +13,16 @@ import (
 // gate's per-key serialization holds across separate agy-mcp processes that share
 // one AGY_MCP_STATE_DIR. That sharing is the default in stdio mode, where every MCP
 // client session spawns its own agy-mcp process: the in-process gate (concurrency.go)
-// stops same-key concurrency within one process, and this stops it across processes,
-// closing the agy session-lock hang and the conversation-cache misattribution the
-// gate alone cannot prevent on a shared state dir.
+// stops same-key concurrency within one process, and this stops it across
+// processes, closing the agy session-lock hang that the gate alone cannot prevent
+// on a shared state dir.
 //
 // A lock is held by the manager process for the whole run: acquired alongside the
 // gate slot and released when the job ends. The held fd is kept open and stored
 // here; closing it drops the flock. Lock files are never unlinked, because removing
 // a flock file races (one process unlinks while another recreates, and both then
 // hold locks on different inodes for the same path), so the empty files are left in
-// place. They accumulate one per distinct conversation/cwd ever locked, each zero
+// place. They accumulate one per distinct conversation ever locked, each zero
 // bytes.
 type crossLock struct {
 	dir string
@@ -34,10 +34,34 @@ func newCrossLock(stateDir string) *crossLock {
 	return &crossLock{dir: filepath.Join(stateDir, "locks"), fds: map[string]*os.File{}}
 }
 
-// lockPath maps a gate key to its lock file. The key (a conversation id or an
-// absolute cwd) is hashed so an arbitrary path can neither escape the locks dir nor
-// collide with another key, and so sibling processes derive the same path for the
-// same key.
+// lockPath maps a gate key to its lock file, as <locks dir>/<sha256 of key>.lock.
+//
+// The hash is load-bearing, not cosmetic. The key is "conv:" plus a conversation
+// id (keyFor), and nothing validates that id anywhere on the way here: it arrives
+// raw off the MCP wire, or out of agy's own cache via resolveLatest, or replayed
+// from meta.json on restore. Hashing is what turns that arbitrary string into one
+// safe, unique, fixed-length filename. So it cannot escape the locks dir (an id
+// carrying enough ".." would otherwise resolve to a path outside it; how far out
+// depends on the state dir's depth, and whether the open then succeeds or merely
+// fails somewhere it should never have reached is not the point); cannot alias onto
+// another key's file, which matters because NTFS and a default APFS or HFS+ volume
+// are case-insensitive, so an unhashed "conv:ABC" and "conv:abc" would land on one
+// lock file; cannot outgrow a filesystem's name limit; and is a legal filename
+// everywhere, which the raw key is not: the "conv:" colon selects an alternate data
+// stream on Windows rather than naming a file.
+// Hashing is also deterministic, so sibling processes derive one path from one key
+// without agreeing on an escaping scheme. Validate the id at the entry point and
+// the escape half stops being the only guard; until then it is.
+//
+// No worked example of the length case, and none of Windows' name-mangling ones
+// (trailing dots and spaces, reserved device names), on purpose. Those arguments
+// fit validJobID (jobstore), where the id IS the whole path component, and they do
+// not transplant to here, where the component is the hash plus ".lock"; derive any
+// concrete case for "conv:"+id+".lock" rather than for the id on its own. The
+// case-folding example above survives that test, which is why it is stated.
+//
+// The empty key never reaches here: both routes into tryLock (admit and
+// forceAdmit) return before it.
 func (c *crossLock) lockPath(key string) string {
 	return filepath.Join(c.dir, fmt.Sprintf("%x.lock", sha256.Sum256([]byte(key))))
 }

--- a/internal/manager/keylock_posix_test.go
+++ b/internal/manager/keylock_posix_test.go
@@ -86,10 +86,13 @@ func TestCrossLockTryLockRejectsDuplicateHeldKey(t *testing.T) {
 	}
 }
 
-// TestCrossLockHashesArbitraryKeys: a gate key is an absolute cwd or a conversation
-// id, so it can contain path separators and "..". Hashing the key into the filename
-// must keep the lock file inside the locks dir (no path escape) and still serialize
-// siblings, for both traversal-laden and very long keys.
+// TestCrossLockHashesArbitraryKeys: a gate key embeds a conversation id that
+// nothing on the way in validates (see lockPath), so it can contain path
+// separators and "..". Hashing the key into the filename must keep the lock file
+// inside the locks dir (no path escape) and still serialize siblings, for both
+// traversal-laden and very long keys. The keys below are spelled "cwd:" for
+// historical reasons; the prefix is immaterial, since what is under test is that
+// an arbitrary key cannot escape.
 func TestCrossLockHashesArbitraryKeys(t *testing.T) {
 	dir := t.TempDir()
 	a := newCrossLock(dir)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -341,8 +341,10 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	if cwd == "" {
 		wd, err := os.Getwd()
 		if err != nil {
-			// An empty cwd would produce gate key "", which skips serialization
-			// entirely and runs agy in an inherited directory. Fail instead.
+			// An empty cwd would run agy in whatever directory this process
+			// inherited, and would be persisted as the job's cwd. Fail instead.
+			// (It has no bearing on serialization: keyFor reads only the
+			// conversation id, so every fresh run keys on nothing regardless.)
 			return Job{}, fmt.Errorf("determine working directory: %w", err)
 		}
 		cwd = wd

--- a/internal/manager/sessions.go
+++ b/internal/manager/sessions.go
@@ -17,8 +17,8 @@ type Session struct {
 }
 
 // agyCachePath returns the path to last_conversations.json, honoring HOME. An
-// empty return (the home dir is unresolvable) degrades every consumer to "no
-// sessions" and disables conversation-id capture, so log it rather than failing
+// empty return (the home dir is unresolvable) disables both features that read the
+// cache, continue_latest and session listing, so log it rather than failing
 // silently; the cause is almost always a missing HOME in a restricted environment.
 func agyCachePath() string {
 	home, err := os.UserHomeDir()
@@ -31,7 +31,7 @@ func agyCachePath() string {
 
 // ListSessions returns known conversations, optionally filtered to one dir. It
 // reads m.cacheFile so it shares the manager's single source of truth for the agy
-// cache path (and is injectable in tests) like the capture/resolve paths.
+// cache path (and is injectable in tests), as resolveLatest does.
 func (m *Manager) ListSessions(dir string) ([]Session, error) {
 	return readSessions(m.cacheFile, dir)
 }

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -70,8 +70,13 @@ type Result struct {
 	Usage           *Usage  `json:"usage,omitempty"`
 }
 
-// Event is one decoded line of the stream. Exactly one payload pointer is set,
-// matching Kind.
+// Event is one decoded line of the stream. agy sets exactly one payload pointer,
+// matching Kind, and nothing here validates that, so production consumers
+// nil-check the pointer for the kind they handle instead of trusting Kind on its
+// own. An event whose pointer does not match its Kind is neither skipped nor
+// counted in Malformed: Next returns it and the consumer's nil check drops it
+// silently. A line is skipped and counted only when it fails to decode or when it
+// overruns maxLineBytes, which is checked before any decode is attempted.
 type Event struct {
 	Kind string `json:"event"`
 	// ConversationID is carried at the top level on the init event; the other
@@ -126,7 +131,11 @@ func NewReader(r io.Reader) *Reader {
 // is readable at any point and is final once Next has returned an error.
 func (r *Reader) Malformed() int { return r.malformed }
 
-// Next returns the next decodable event, or io.EOF at end of stream.
+// Next returns the next decodable event. It returns io.EOF at a clean end of
+// stream and any other read error unchanged, so a stream torn off mid-run is
+// reported as the failure it is rather than passed off as a finished one. Along
+// the way it skips blank lines silently, and skips undecodable and over-long
+// lines after counting them in Malformed.
 func (r *Reader) Next() (Event, error) {
 	for {
 		line, truncated, err := r.readLine()
@@ -161,9 +170,17 @@ func (r *Reader) Next() (Event, error) {
 }
 
 // readLine reads one newline-terminated line, growing past bufio's internal
-// buffer. It returns the line without its terminator, whether the line exceeded
-// maxLineBytes (in which case the overflow is discarded and the retained prefix
-// must not be decoded), and the terminating error if any.
+// buffer. It returns the line with its terminator still attached whenever the
+// stream supplied one, whether the line exceeded maxLineBytes (in which case the
+// overflow is discarded and the retained prefix must not be decoded), and the
+// terminating error if any. Two reachable paths carry no terminator: a stream that
+// ends mid-line, and a truncated line, whose newline sits in the discarded
+// overflow.
+//
+// Nothing here strips it, because nothing needs it stripped: Next trims
+// surrounding space before decoding, which removes the terminator along with a
+// stray \r from a Windows-written stream, and json.Unmarshal would ignore trailing
+// whitespace regardless.
 //
 // bufio.Scanner is deliberately not used: it fails the whole stream with
 // ErrTooLong on a single over-long line, which would drop every later event

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -131,11 +131,19 @@ func NewReader(r io.Reader) *Reader {
 // is readable at any point and is final once Next has returned an error.
 func (r *Reader) Malformed() int { return r.malformed }
 
-// Next returns the next decodable event. It returns io.EOF at a clean end of
-// stream and any other read error unchanged, so a stream torn off mid-run is
-// reported as the failure it is rather than passed off as a finished one. Along
-// the way it skips blank lines silently, and skips undecodable and over-long
-// lines after counting them in Malformed.
+// Next returns the next decodable event, io.EOF at a clean end of stream, or a read
+// error, so a stream torn off mid-run is reported as the failure it is rather than
+// passed off as a finished one. Along the way it skips blank lines silently, and
+// skips undecodable and over-long lines after counting them in Malformed.
+//
+// A read error arriving on the same call as a decodable event is DEFERRED rather
+// than returned with it: the event comes back first, which is what io.Reader asks
+// of a caller (process the bytes, then consider the error), and the next call
+// reports the failure. Nothing is swallowed. Measured both ways: a reader that
+// repeats its error (a torn pipe) yields it again, and one that falls silent yields
+// io.ErrNoProgress. The case is narrow anyway, since bufio hands back a buffered
+// whole line with a nil error and keeps the error for the following read, so the
+// two only coincide when the tear lands on a line with no terminator.
 func (r *Reader) Next() (Event, error) {
 	for {
 		line, truncated, err := r.readLine()
@@ -170,8 +178,8 @@ func (r *Reader) Next() (Event, error) {
 }
 
 // readLine reads one newline-terminated line, growing past bufio's internal
-// buffer. It returns the line with its terminator still attached whenever the
-// stream supplied one, whether the line exceeded maxLineBytes (in which case the
+// buffer. It returns the line with its terminator still attached whenever the line
+// came back whole, whether the line exceeded maxLineBytes (in which case the
 // overflow is discarded and the retained prefix must not be decoded), and the
 // terminating error if any. Two reachable paths carry no terminator: a stream that
 // ends mid-line, and a truncated line, whose newline sits in the discarded

--- a/internal/supervisor/stream.go
+++ b/internal/supervisor/stream.go
@@ -11,12 +11,18 @@ import (
 )
 
 // streamOutcome is what the supervisor learned from one run's stream-json
-// output: the conversation agy used, the terminal result if the run reached
-// one, and how many unusable lines were skipped along the way.
+// output: the terminal result if the run reached one, and how many unusable
+// lines were skipped along the way.
+//
+// It carries no conversation id of its own, because nothing outside the tests
+// ever read one, and the id already leaves here by the two routes callers do
+// read: live in progress.json, written as soon as the init event names it, which
+// is what lets the manager report it mid-run; and after the fact inside
+// result.json, since result carries agy's own ConversationID (the manager reads
+// that as a fallback, see carryResultMetadata).
 type streamOutcome struct {
-	conversationID string
-	result         *streamjson.Result
-	malformed      int
+	result    *streamjson.Result
+	malformed int
 }
 
 // consumeStream decodes agy's event stream to completion, mirroring it into the
@@ -48,7 +54,6 @@ func consumeStream(jobDir string, r io.Reader, out io.Writer) streamOutcome {
 		changed := false
 		if cid := ev.ConversationIDOf(); cid != "" && cid != prog.ConversationID {
 			prog.ConversationID = cid
-			oc.conversationID = cid
 			changed = true
 		}
 		switch ev.Kind {

--- a/internal/supervisor/stream_test.go
+++ b/internal/supervisor/stream_test.go
@@ -41,9 +41,6 @@ const goodStream = `{"event":"init","conversation_id":"c-1","init":{"cwd":"/tmp/
 func TestConsumeStreamHappyPath(t *testing.T) {
 	dir, out, oc := consume(t, goodStream)
 
-	if oc.conversationID != "c-1" {
-		t.Fatalf("conversationID = %q, want c-1", oc.conversationID)
-	}
 	if oc.result == nil || oc.result.Response != "the answer" {
 		t.Fatalf("result = %+v", oc.result)
 	}
@@ -72,9 +69,15 @@ func TestConsumeStreamOnlyAppendsAgentResponse(t *testing.T) {
 {"event":"step_update","step_update":{"step_index":1,"step_type":"agent_response","text_delta":"kept"}}
 {"event":"step_update","step_update":{"step_index":2,"step_type":"checkpoint","text_delta":"NOR THIS"}}
 `
-	_, out, _ := consume(t, stream)
+	_, out, oc := consume(t, stream)
 	if got := out.String(); got != "kept" {
 		t.Fatalf("out = %q, want only the agent_response text", got)
+	}
+	// Positive control. Without it a typo in either "must not appear" line makes
+	// this pass for the wrong reason: an undecodable line is skipped, so its text
+	// never reaches out and the absence assertions hold vacuously.
+	if oc.malformed != 0 {
+		t.Fatalf("malformed = %d, want 0; a skipped line would satisfy the absence checks without proving anything", oc.malformed)
 	}
 }
 
@@ -95,8 +98,10 @@ func TestConsumeStreamAccumulatesDeltas(t *testing.T) {
 	}
 }
 
-// A run cut off before its result event leaves the streamed text and the
-// conversation behind, which is what the manager reports as a partial result.
+// A run cut off before its result event still leaves its conversation behind,
+// which is what lets the manager report a continuable partial result. This
+// fixture's cut lands mid-line, so the truncated step contributes no text: the
+// line is counted as malformed rather than decoded.
 func TestConsumeStreamInterruptedKeepsPartial(t *testing.T) {
 	stream := `{"event":"init","conversation_id":"c-9"}
 {"event":"step_update","step_update":{"step_index":0,"step_type":"agent_response","text_delta":"half an ans`
@@ -104,11 +109,14 @@ func TestConsumeStreamInterruptedKeepsPartial(t *testing.T) {
 	if oc.result != nil {
 		t.Fatal("no terminal result should have been decoded")
 	}
-	if oc.conversationID != "c-9" {
-		t.Fatalf("conversationID = %q, want c-9 from the init event", oc.conversationID)
-	}
 	if out.Len() != 0 {
 		t.Fatalf("out = %q; a truncated line is not a decodable step", out.String())
+	}
+	// The count is the only observable separating "cut mid-line" from "ended
+	// cleanly with no result", which the accumulates-deltas test already covers,
+	// and it is what makes persist emit its skipped-lines note.
+	if oc.malformed != 1 {
+		t.Fatalf("malformed = %d, want 1 for the truncated tail", oc.malformed)
 	}
 	if p := readProgress(t, dir); p.ConversationID != "c-9" {
 		t.Fatalf("progress = %+v, want the conversation recorded before the cut", p)
@@ -134,9 +142,8 @@ func TestPersistWritesResultAndNotesMalformed(t *testing.T) {
 	dir := t.TempDir()
 	var errBuf bytes.Buffer
 	oc := streamOutcome{
-		conversationID: "c-1",
-		result:         &streamjson.Result{ConversationID: "c-1", Status: streamjson.StatusSuccess, Response: "done"},
-		malformed:      3,
+		result:    &streamjson.Result{ConversationID: "c-1", Status: streamjson.StatusSuccess, Response: "done"},
+		malformed: 3,
 	}
 	oc.persist(dir, &errBuf)
 
@@ -163,7 +170,7 @@ func TestPersistWritesResultAndNotesMalformed(t *testing.T) {
 func TestPersistWritesNoResultFileWhenNoneReached(t *testing.T) {
 	dir := t.TempDir()
 	var errBuf bytes.Buffer
-	streamOutcome{conversationID: "c-1"}.persist(dir, &errBuf)
+	streamOutcome{}.persist(dir, &errBuf)
 
 	if b, _ := jobstore.ReadResultDir(dir); b != nil {
 		t.Fatal("a run with no terminal result must not write a result file")

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -16,10 +16,11 @@ import (
 	"github.com/tphakala/agy-mcp/v2/internal/streamjson"
 )
 
-// DefaultFakeConversationID is the conversation id a FakeAgy reports when the
+// defaultFakeConversationID is the conversation id a FakeAgy reports when the
 // test does not pin one. It is a well-formed UUID so it reads like a real agy
-// value in failure output.
-const DefaultFakeConversationID = "11111111-2222-3333-4444-555555555555"
+// value in failure output. Tests read it through ConvID rather than directly,
+// which is why it is not exported.
+const defaultFakeConversationID = "11111111-2222-3333-4444-555555555555"
 
 // FakeAgy configures a stand-in agy binary for tests.
 //
@@ -43,7 +44,7 @@ type FakeAgy struct {
 	IgnoreSIGTERM bool
 
 	// ConversationID overrides the conversation id in the emitted events.
-	// Defaults to DefaultFakeConversationID.
+	// Defaults to defaultFakeConversationID.
 	ConversationID string
 	// NoConversationID emits events with no conversation id, reproducing a run
 	// that failed before agy created a conversation (an unresolvable model, say).
@@ -57,10 +58,6 @@ type FakeAgy struct {
 	// OmitResult emits the init and step events but no terminal result, standing
 	// in for a run cut short before agy could summarize it.
 	OmitResult bool
-	// RawStdout, when set, is written to stdout verbatim instead of a generated
-	// event stream. It is how a test feeds the supervisor malformed or oversized
-	// lines. It overrides Stdout and the other stream fields.
-	RawStdout string
 
 	// Version is what the script reports for `agy --version`, which the manager
 	// probes once before it will run anything. Defaults to the minimum agy-mcp
@@ -102,17 +99,15 @@ func (cfg FakeAgy) ConvID() string {
 	case cfg.ConversationID != "":
 		return cfg.ConversationID
 	}
-	return DefaultFakeConversationID
+	return defaultFakeConversationID
 }
 
-// StreamLines renders the configured run as agy's stream-json output. It is
-// exported so a test can feed the same bytes straight to a reader without going
-// through a spawned process.
-func (cfg FakeAgy) StreamLines(t *testing.T) string {
+// streamLines renders the configured run as agy's stream-json output, which
+// WriteFakeAgy stages as the script's stdout payload. It is unexported because the
+// only consumer is in this file. One candidate does exist if anyone wants it back:
+// supervisor_windows_test.go hand-rolls an equivalent three-event stream.
+func (cfg FakeAgy) streamLines(t *testing.T) string {
 	t.Helper()
-	if cfg.RawStdout != "" {
-		return cfg.RawStdout
-	}
 	convID := cfg.ConvID()
 	status := cfg.Status
 	if status == "" {
@@ -225,7 +220,7 @@ func WriteFakeAgy(t *testing.T, cfg FakeAgy) string {
 	outPath := filepath.Join(dir, "fake-agy.out")
 	errPath := filepath.Join(dir, "fake-agy.err")
 	plainPath := filepath.Join(dir, "fake-agy.plain")
-	if err := os.WriteFile(outPath, []byte(cfg.StreamLines(t)), 0o644); err != nil {
+	if err := os.WriteFile(outPath, []byte(cfg.streamLines(t)), 0o644); err != nil {
 		t.Fatalf("write fake agy stdout: %v", err)
 	}
 	if err := os.WriteFile(errPath, []byte(cfg.Stderr), 0o644); err != nil {

--- a/internal/testutil/fakesupervisor.go
+++ b/internal/testutil/fakesupervisor.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
 )
@@ -42,18 +41,14 @@ type FakeSupervisor struct {
 	Out string
 	// Exit is the fixed exit code recorded when AgyPath is empty.
 	Exit int
-	// CachePath, when set, makes the script write CacheJSON to that path
-	// after exit_code, mimicking the real ordering: the supervisor writes the
-	// exit sentinel at process exit, and agy's cache daemon flushes the
-	// conversation cache around or after that moment.
+	// CachePath, when set, makes the script write CacheJSON to that path after
+	// exit_code. It stages agy's own last_conversations.json for the two features
+	// that read it, continue_latest and list_sessions; the position after the
+	// sentinel is just where the real cache daemon happens to flush, and no manager
+	// path observes the cache relative to job completion any more.
 	CachePath string
 	// CacheJSON is the cache payload to write; requires CachePath.
 	CacheJSON string
-	// CacheDelay, when positive, writes the cache from a backgrounded subshell
-	// that sleeps this long first, so the cache lands only after the script
-	// (and its exit_code) is gone. This reproduces the cache-daemon lag that
-	// the manager's capture retry exists for. Requires CachePath.
-	CacheDelay time.Duration
 	// OmitProgressMarker stages a job dir WITHOUT the marker the real supervisor
 	// writes before exec, which is the shape a job an older build wrote produces,
 	// and also the shape a job exec'd under another output format produces (the
@@ -68,9 +63,10 @@ type FakeSupervisor struct {
 // supervisor (`agy-mcp run-job <jobdir>`) and returns its path. The script is
 // created under t.TempDir(). Fixed out and cache payloads are written to
 // sibling files and reproduced via cat so arbitrary byte content survives
-// shell quoting. exit_code is written before the cache payload, matching the
-// real ordering the manager must tolerate: job completion (the sentinel) can
-// be observable before the conversation cache has been flushed.
+// shell quoting. exit_code is written before the cache payload, which is the
+// order the real pair happens to produce; nothing in the manager depends on it
+// any more, since the cache is read only by continue_latest (before a supervisor
+// exists) and by list_sessions.
 func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 	t.Helper()
 	if cfg.AgyPath != "" && (cfg.Out != "" || cfg.Exit != 0) {
@@ -78,9 +74,6 @@ func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 	}
 	if cfg.CacheJSON != "" && cfg.CachePath == "" {
 		t.Fatal("FakeSupervisor: CacheJSON requires CachePath")
-	}
-	if cfg.CacheDelay > 0 && cfg.CachePath == "" {
-		t.Fatal("FakeSupervisor: CacheDelay requires CachePath")
 	}
 	if cfg.Agy != nil && cfg.AgyPath == "" {
 		t.Fatal("FakeSupervisor: Agy requires AgyPath")
@@ -147,14 +140,7 @@ func WriteFakeSupervisor(t *testing.T, cfg FakeSupervisor) string {
 		if err := os.WriteFile(cachePayload, []byte(cfg.CacheJSON), 0o644); err != nil {
 			t.Fatalf("write fake supervisor cache payload: %v", err)
 		}
-		if cfg.CacheDelay > 0 {
-			// Backgrounded so the script (the fake supervisor process) exits
-			// first and the cache lands later, like agy's real cache daemon.
-			fmt.Fprintf(&sb, "( sleep %.3f; cat %q > %q ) &\n",
-				cfg.CacheDelay.Seconds(), cachePayload, cfg.CachePath)
-		} else {
-			fmt.Fprintf(&sb, "cat %q > %q\n", cachePayload, cfg.CachePath)
-		}
+		fmt.Fprintf(&sb, "cat %q > %q\n", cachePayload, cfg.CachePath)
 	}
 
 	if err := os.WriteFile(path, []byte(sb.String()), 0o755); err != nil {


### PR DESCRIPTION
## Summary

Continues #106. Removes what the deleted conversation-cache capture left behind and corrects the prose its deletion falsified, minus two items that did not survive being re-derived. No behaviour changes: the only non-comment lines in the diff are two added test assertions and the bindings they need.

**Dead code**, each verified to have no reader on any platform (`go vet` on darwin, `GOOS=linux`, `GOOS=windows`, which type-checks build-tagged test files) before removal: `supervisor.streamOutcome.conversationID` (written per run, read only by two test assertions), `testutil.FakeSupervisor.CacheDelay` with its validation and the backgrounded-subshell branch it generated, and `testutil.FakeAgy.RawStdout`. `StreamLines` and `DefaultFakeConversationID` are unexported, because the reason given for exporting them named a consumer that does not exist. History confirms these were residue rather than regressions: `CacheDelay`'s three real users went with the capture itself in f80f9b0, and `RawStdout` plus the exported `StreamLines` were born dead in that same commit.

**`jobstore.Progress.StepIndex` is deliberately NOT deleted**, against this issue's reading of it. It is load-bearing in memory: the supervisor compares it per event to avoid atomically rewriting a byte-identical progress file. Its doc now records that, plus a sharper finding a reviewer produced by mutation: deleting the comparison leaves the whole suite green, so the dedup is an optimization nothing guards.

**Prose the capture deletion falsified**, in the four files this slice started from and four more it did not. `keylock.go` described keys as "a conversation id or an absolute cwd". `manager.go` claimed an empty cwd produces gate key `""` as though that were special, when `keyFor` ignores cwd entirely and every fresh run keys on nothing. `sessions.go` and `job_posix_test.go` still referred to a conversation-id capture and a capture goroutine. `fakesupervisor.go` justified its write order as "the real ordering the manager must tolerate", which nothing tolerates now. `supervisor.go`'s mention of agy's own cache daemon is deliberately kept: that is a true statement about agy, and it is the justification for `drainGrace`.

**`streamjson`'s three docs** were each wrong differently. `readLine` claimed it returned the line without its terminator, which it never stripped. `Next` omitted the non-EOF error path and counted blank lines as malformed, contradicting the `Malformed` doc four lines above it. `Event` asserted a payload invariant nothing validates.

## The one that needed three tries

`lockPath`'s doc is rewritten rather than patched. Three review rounds each replaced a refuted example with a new one, and all three failed the same way: they transplanted arguments from `jobstore.validJobID`, where the id IS the whole path component, into a function whose component is the sha256 hash plus `.lock`.

- Round 1: "Windows strips trailing dots, so `conv:x.` and `conv:x` alias." The real components are `conv:x..lock` and `conv:x.lock`, both ending in `k`, so no trimming applies.
- Round 2: "no filesystem accepts a 1500-byte path component, which is what the long-key row locks." That row is `"cwd:" + strings.Repeat("/deep", 300)`: a 1504-byte *path* of 301 components whose longest is 4 bytes. It fails `PATH_MAX` on darwin and would not fail on length at all on Linux.
- Round 3: assert properties only, keep the one example that survives the transplant test (case folding, since NTFS and a default APFS or HFS+ volume are case-insensitive), and state why the others are absent.

The claim that must not be lost, and which an earlier draft of this branch had thrown away: **nothing validates a conversation id on any of its three ingress routes** (raw off the MCP wire, agy's own cache via `resolveLatest`, replayed from `meta.json` on restore), so the hash is the only thing keeping an id full of `..` inside the locks dir. A reviewer probe: `conv:../../../../tmp/x` unhashed resolves outside `<state>/locks`.

## Tests

Two positive controls, both added because a reviewer proved the existing assertions vacuous by mutation.

`TestConsumeStreamOnlyAppendsAgentResponse` passed with both of its "must not appear" fixture lines replaced by undecodable garbage that still contained their text, because a skipped line's text never reaches `out` either. It now asserts `malformed == 0`; that same mutation now fails with `malformed = 2, want 0`.

`TestConsumeStreamInterruptedKeepsPartial` asserts `malformed == 1`, the only observable separating a mid-line cut from a clean end with no result. A reviewer showed this is the sole assertion in the repo that catches a decode failure coinciding with end of stream.

**Deleting `streamOutcome.conversationID` improves coverage rather than reducing it.** The two assertions removed were satisfied by an in-memory value. The `progress.json` assertions that remain also cover the `changed` gate and the persist path, so a mutant that keeps the assignment but suppresses the write is caught only by the survivors. Verified independently by two reviewers.

## Related Issues

Part of #96 (part 2 of the batch; #106 was part 1).

## Test Plan

- [x] `go build ./...`
- [x] `go vet ./...` on darwin, `GOOS=linux`, `GOOS=windows`
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./...`: 0 issues
- [x] `go test ./...`: all 11 packages ok
- [x] `go test -race` on the touched packages
- [x] Inverse-mutation checks on both new assertions, in scratch copies outside the repo

## Review provenance

Ran the full pre-push gate: six parallel review agents over 7/7 reviewable files, plus a Gemini cross-check, then three fix rounds with a report-only fresh reviewer on each round's fixes. The gate found seven false comments that the first draft of this changeset had itself introduced, which is the same defect class the changeset exists to remove; two of the three fix rounds introduced one more each. It stopped at its round limit, not on a clean convergence. Remaining Medium and Low findings are batched rather than fixed, and are listed in a follow-up comment on #96.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for job progress persistence, session caching, cross-process locking, working directories, and stream decoding.
* **Bug Fixes**
  * Improved stream handling by tracking conversation IDs in job progress and reporting malformed stream lines more consistently.
* **Tests**
  * Updated stream and locking tests to validate malformed input handling and safer behavior.
* **Refactor**
  * Simplified internal test utilities and removed obsolete cache-delay and raw-output configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->