### PR TITLE
streamjson: decode lines in place, fuzz the decoder, fix the cap (#96, #109)

### DIFF
--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -5,10 +5,10 @@ package streamjson
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
-	"strings"
 )
 
 // Event kinds emitted by agy on the stream-json stream.
@@ -42,10 +42,16 @@ type Usage struct {
 
 // Init is the payload of the init event. Its arrival is what makes a run's
 // conversation id known long before the run finishes.
+//
+// agy also puts its full tool list on this event. There is deliberately no field
+// for it, because it is the one part of this payload whose cost scales: a string
+// per tool, on every run, for a value nothing reads. A key with no field is
+// skipped by the decoder without allocating its value, so ignoring it costs only
+// the scan. Cwd and PermissionMode are unread too and stay anyway, being two
+// fixed strings that record what the event carries.
 type Init struct {
-	Cwd            string   `json:"cwd,omitempty"`
-	Tools          []string `json:"tools,omitempty"`
-	PermissionMode string   `json:"permission_mode,omitempty"`
+	Cwd            string `json:"cwd,omitempty"`
+	PermissionMode string `json:"permission_mode,omitempty"`
 }
 
 // StepUpdate is the payload of a step_update event.
@@ -101,12 +107,15 @@ func (e Event) ConversationIDOf() string {
 	return ""
 }
 
-// maxLineBytes caps how much of one NDJSON line is retained. agy's init event
+// maxLineBytes caps how much payload one NDJSON line may carry. agy's init event
 // embeds the full tool list and a step_update can carry a large text_delta, so
 // the limit is generous; it exists only to keep a corrupt or unterminated
 // stream from growing the supervisor's memory without bound. A longer line is
 // truncated and reported as malformed rather than decoded from a partial
-// prefix, which would be worse than dropping it.
+// prefix, which would be worse than dropping it. The '\n' is not payload and
+// does not count against the cap, so a line of exactly this many bytes plus its
+// terminator still decodes. On a \r\n stream the '\r' does count, costing that
+// one shape a byte of headroom, which is not worth a branch on the read path.
 const maxLineBytes = 8 << 20
 
 // Reader decodes events from an agy stream-json stream.
@@ -118,17 +127,40 @@ const maxLineBytes = 8 << 20
 type Reader struct {
 	br        *bufio.Reader
 	malformed int
+	// buf accumulates a line too long to arrive in one read, and is reused for
+	// the rest of the stream: a run whose lines are long then pays one growing
+	// allocation instead of one per line. A truncated line drops it rather than
+	// keeping it, because corruption is not evidence that this run's lines are
+	// large, and append's growth overshoots, so holding it would pin more than
+	// maxLineBytes for the life of the job on the one input the cap exists to
+	// contain. The cost of dropping it is paid by a stream of CONSECUTIVE
+	// over-long lines, which then regrows from nil each time: the bytes through
+	// the allocator go from constant to linear in the length of that run,
+	// measured at 39.7 MiB per line against 39.7 MiB total. That is the trade
+	// taken deliberately, since a bounded live set matters more than the
+	// throughput of a stream that is already corrupt.
+	// Nothing outside readLine may hold it past the next call.
+	buf []byte
 }
 
 // NewReader returns a Reader decoding r.
+//
+// bufio's default buffer size is deliberate. A larger one lets more lines be
+// decoded in place rather than accumulated, but measured against this decoder it
+// buys nothing: at every line length up to 256 KiB, 64 KiB was within noise of
+// the 4096 default on time and allocation count, because json.Unmarshal is 99%
+// of the per-line cost. It only added its own size to the resident footprint of
+// every running job.
 func NewReader(r io.Reader) *Reader {
 	return &Reader{br: bufio.NewReader(r)}
 }
 
 // Malformed returns how many lines have been skipped so far because they
 // exceeded maxLineBytes or failed to decode. Blank lines are padding and are
-// not counted. It is a running total, updated as the stream is consumed, so it
-// is readable at any point and is final once Next has returned an error.
+// not counted, unless they were over-long: a line that ran past the cap is
+// corruption whatever bytes survived in it. It is a running total, updated as
+// the stream is consumed, so it is readable at any point and is final once Next
+// has returned an error.
 func (r *Reader) Malformed() int { return r.malformed }
 
 // Next returns the next decodable event, io.EOF at a clean end of stream, or a read
@@ -147,23 +179,28 @@ func (r *Reader) Malformed() int { return r.malformed }
 func (r *Reader) Next() (Event, error) {
 	for {
 		line, truncated, err := r.readLine()
-		trimmed := strings.TrimSpace(string(line))
-		switch {
-		case trimmed == "":
-			// A blank line is padding, not corruption; do not count it.
-			if err != nil {
-				return Event{}, err
-			}
-			continue
-		case truncated:
+		if truncated {
+			// Counted before the line is so much as examined, which is what makes
+			// Malformed's contract hold: a line that ran past the cap is corruption
+			// whatever bytes survived in it, and the padding the blank case below
+			// forgives is a short line by definition. Trimming first would also mean
+			// scanning a discarded 8 MiB.
 			r.malformed++
 			if err != nil {
 				return Event{}, err
 			}
 			continue
 		}
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			// A blank line is padding, not corruption; do not count it.
+			if err != nil {
+				return Event{}, err
+			}
+			continue
+		}
 		var ev Event
-		if decErr := json.Unmarshal([]byte(trimmed), &ev); decErr != nil {
+		if decErr := json.Unmarshal(trimmed, &ev); decErr != nil {
 			r.malformed++
 			if err != nil {
 				return Event{}, err
@@ -177,37 +214,78 @@ func (r *Reader) Next() (Event, error) {
 	}
 }
 
-// readLine reads one newline-terminated line, growing past bufio's internal
-// buffer. It returns the line with its terminator still attached whenever the line
-// came back whole, whether the line exceeded maxLineBytes (in which case the
-// overflow is discarded and the retained prefix must not be decoded), and the
-// terminating error if any. Two reachable paths carry no terminator: a stream that
-// ends mid-line, and a truncated line, whose newline sits in the discarded
-// overflow.
+// readLine reads one line, growing past bufio's internal buffer. It returns the
+// line, whether it exceeded maxLineBytes (in which case the overflow is
+// discarded and the retained prefix must not be decoded), and the terminating
+// error if any.
 //
-// Nothing here strips it, because nothing needs it stripped: Next trims
-// surrounding space before decoding, which removes the terminator along with a
-// stray \r from a Windows-written stream, and json.Unmarshal would ignore trailing
-// whitespace regardless.
+// The '\n' comes back attached only on the fast path below, where the line
+// arrived in one read and the slice returned is bufio's own, and then only if
+// the line had one at all: a stream cut mid-line has none to return. An
+// accumulated line drops it, as does a truncated line, whose terminator sits in
+// the discarded overflow. Nothing needs it either way, since Next trims
+// surrounding space before decoding, which removes it along with a stray \r from
+// a Windows-written stream, and json.Unmarshal ignores trailing whitespace
+// regardless.
+//
+// The returned slice is valid only until the next call: it is bufio's buffer on
+// the fast path and the Reader's scratch otherwise, and both are overwritten by
+// the read after it. That is safe because Next is the only caller and decodes
+// before reading again, and because every field reachable from an Event is a
+// string, a number, or a pointer to more of the same, all of which
+// json.Unmarshal copies out. A []byte or json.RawMessage field, or any type with
+// an UnmarshalJSON that keeps its argument, would alias this buffer instead, and
+// must not be added to Event without copying.
 //
 // bufio.Scanner is deliberately not used: it fails the whole stream with
 // ErrTooLong on a single over-long line, which would drop every later event
 // including the result.
 func (r *Reader) readLine() (line []byte, truncated bool, err error) {
-	var buf []byte
+	buf := r.buf[:0]
 	for {
-		chunk, err := r.br.ReadSlice('\n')
-		if room := maxLineBytes - len(buf); len(chunk) > room {
-			truncated = true
-			if room > 0 {
-				buf = append(buf, chunk[:room]...)
-			}
-		} else {
-			buf = append(buf, chunk...)
-		}
+		// err is the named result rather than a per-iteration variable. Both forms
+		// behave identically today, since every return names it explicitly; this
+		// one keeps a later bare return from producing a nil error.
+		var chunk []byte
+		chunk, err = r.br.ReadSlice('\n')
 		// ErrBufferFull means the delimiter was not reached; keep accumulating.
-		if errors.Is(err, bufio.ErrBufferFull) {
+		more := errors.Is(err, bufio.ErrBufferFull)
+		payload := len(chunk)
+		if payload > 0 && chunk[payload-1] == '\n' {
+			payload--
+		}
+		switch room := maxLineBytes - len(buf); {
+		case payload > room:
+			// Fill the cap exactly with the head of the chunk that crosses it and
+			// discard the rest of the line. room cannot go negative and so needs no
+			// guard, because neither arm that grows buf can take it past the cap:
+			// the one below runs only when payload fits in the room left, and this
+			// one appends precisely the room left, landing on maxLineBytes exactly
+			// and leaving every later pass through here with room 0. How much of the
+			// crossing chunk lands here depends on the reader's chunk size, and is
+			// zero whenever those divide the cap; either way what is retained is
+			// dropped by Next rather than decoded.
+			truncated = true
+			buf = append(buf, chunk[:room]...)
+		case len(buf) == 0 && !more:
+			// The whole line came back in one read and nothing has been retained, so
+			// there is nothing to accumulate it with.
+			return chunk, false, err
+		default:
+			// Without the terminator: the cap is on payload, Next trims before
+			// decoding, and keeping it would push the retained line one byte past
+			// maxLineBytes, forcing a regrow of the whole buffer for a line whose
+			// payload happens to end on a read boundary.
+			buf = append(buf, chunk[:payload]...)
+		}
+		if more {
 			continue
+		}
+		if truncated {
+			// Corruption must not pin the scratch for the rest of the run; see buf.
+			r.buf = nil
+		} else {
+			r.buf = buf
 		}
 		return buf, truncated, err
 	}

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -189,12 +189,17 @@ func TestShortLineIsReturnedInPlace(t *testing.T) {
 	if err != nil || truncated {
 		t.Fatalf("first readLine: truncated=%v err=%v", truncated, err)
 	}
+	// Read the bytes before reading again, because that is the rule this test
+	// exists to demonstrate: the slice is only valid until the next call. The
+	// length and capacity are read afterwards on purpose, being fields of a slice
+	// header this test owns a copy of rather than bytes in a buffer it does not.
+	firstContents := string(first)
 	second, _, err := r.readLine()
 	if err != nil {
 		t.Fatalf("second readLine: %v", err)
 	}
-	if string(first) != line || string(second) != line {
-		t.Fatalf("lines = %q, %q, want %q twice", first, second, line)
+	if firstContents != line || string(second) != line {
+		t.Fatalf("lines = %q, %q, want %q twice", firstContents, second, line)
 	}
 	if r.buf != nil {
 		t.Errorf("the fast path grew the scratch to %d bytes; it must accumulate nothing", cap(r.buf))

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -1,10 +1,15 @@
 package streamjson
 
 import (
+	"bufio"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // A verbatim capture from agy 1.1.8, trimmed of the init event's long tool list.
@@ -14,7 +19,23 @@ const sample = `{"event":"init","conversation_id":"21f0f78b-95b7-4aa5-a438-85a50
 {"event":"result","result":{"conversation_id":"21f0f78b-95b7-4aa5-a438-85a5078eac48","status":"SUCCESS","response":"pang\n","duration_seconds":4.04,"num_turns":1,"usage":{"input_tokens":7896,"output_tokens":282,"total_tokens":8178}}}
 `
 
-// readAll drains a reader, returning the events and the malformed count.
+// bufioDefaultBytes is bufio's own default buffer size, which NewReader takes.
+// Several fixtures here have to sit either side of it, since it is the boundary
+// between a line readLine hands back in place and one it accumulates. It is
+// spelled out rather than assumed so those fixtures say which side they are on.
+const bufioDefaultBytes = 4096
+
+// The terminal result event, the shape most fixtures here need.
+// TestLineExactlyAtCapDecodes uses the two halves directly, having to count them.
+const (
+	resultPrefix = `{"event":"result","result":{"status":"SUCCESS","response":"`
+	resultSuffix = `"}}`
+)
+
+func resultLine(payload string) string { return resultPrefix + payload + resultSuffix + "\n" }
+
+// readAll drains a reader and returns its events. The malformed count is read
+// separately, off the Reader.
 func readAll(t *testing.T, r *Reader) []Event {
 	t.Helper()
 	var evs []Event
@@ -120,11 +141,11 @@ func TestUnterminatedFinalLine(t *testing.T) {
 
 // A line longer than bufio's internal buffer must decode, not fail: the init
 // event's tool list and a large text_delta both routinely exceed it. This is the
-// case bufio.Scanner would abort the whole stream on.
+// case bufio.Scanner would abort the whole stream on, and the one that drives
+// readLine's accumulation path.
 func TestLongLineBeyondBufioBuffer(t *testing.T) {
-	big := strings.Repeat("x", 512*1024)
-	in := `{"event":"result","result":{"status":"SUCCESS","response":"` + big + `"}}` + "\n"
-	r := NewReader(strings.NewReader(in))
+	big := strings.Repeat("x", 128*bufioDefaultBytes)
+	r := NewReader(strings.NewReader(resultLine(big)))
 	evs := readAll(t, r)
 	if len(evs) != 1 {
 		t.Fatalf("got %d events, want 1", len(evs))
@@ -137,22 +158,497 @@ func TestLongLineBeyondBufioBuffer(t *testing.T) {
 	}
 }
 
+// The fixtures below are sized either side of the read buffer, so what that
+// buffer actually is has to be checked rather than assumed: raising it would
+// leave every one of them passing while silently testing the wrong path.
+func TestReadBufferIsBufioDefault(t *testing.T) {
+	if got := NewReader(strings.NewReader("")).br.Size(); got != bufioDefaultBytes {
+		t.Fatalf("read buffer is %d bytes; the fixtures here are sized against %d", got, bufioDefaultBytes)
+	}
+}
+
+// The fast path is this decoder's core claim, and nothing else can observe it:
+// a copy decodes to exactly the same event, only slower, so both the suite and
+// the benchmark are blind to losing it.
+//
+// What identifies bufio's own slice is where it ends. ReadSlice returns a view
+// running from the read offset to the end of that buffer, so the capacity is the
+// buffer size minus everything consumed before it, and consecutive lines hand
+// back shrinking capacities that sum with their offsets to exactly Size(). No
+// copy reproduces that: it lands in an array sized by the allocator or by the
+// scratch's growth history, neither of which tracks the read offset. Watching
+// the bytes change instead is NOT enough, and was the first thing tried here: a
+// copy into a scratch that gets reused changes on the next line too.
+//
+// The scratch must also stay untouched, since the whole point of this path is
+// that it accumulates nothing.
+func TestShortLineIsReturnedInPlace(t *testing.T) {
+	const line = `{"event":"init","conversation_id":"c1"}` + "\n"
+	r := NewReader(strings.NewReader(line + line))
+	first, truncated, err := r.readLine()
+	if err != nil || truncated {
+		t.Fatalf("first readLine: truncated=%v err=%v", truncated, err)
+	}
+	second, _, err := r.readLine()
+	if err != nil {
+		t.Fatalf("second readLine: %v", err)
+	}
+	if string(first) != line || string(second) != line {
+		t.Fatalf("lines = %q, %q, want %q twice", first, second, line)
+	}
+	if r.buf != nil {
+		t.Errorf("the fast path grew the scratch to %d bytes; it must accumulate nothing", cap(r.buf))
+	}
+	// Sizes rather than contents: a line returned in place ends where the read
+	// buffer ends, and the second starts where the first left off.
+	// A failure here means either that readLine copied the line or that the read
+	// buffer is no longer the default; TestReadBufferIsBufioDefault says which.
+	if cap(first) != bufioDefaultBytes {
+		t.Errorf("first line has capacity %d, want the whole read buffer (%d)",
+			cap(first), bufioDefaultBytes)
+	}
+	if want := bufioDefaultBytes - len(first); cap(second) != want {
+		t.Errorf("second line has capacity %d, want %d, the buffer less the line before it",
+			cap(second), want)
+	}
+}
+
+// errAfter yields s and then fails with err on every later read, which is what a
+// pipe torn down mid-run does. Next's contract is that such a stream is reported
+// as the failure it is rather than passed off as a finished one, and that
+// promise reaches the caller through three separate arms.
+type errAfter struct {
+	s   string
+	err error
+}
+
+func (e *errAfter) Read(p []byte) (int, error) {
+	if e.s == "" {
+		return 0, e.err
+	}
+	n := copy(p, e.s)
+	e.s = e.s[n:]
+	return n, nil
+}
+
+// A read failure must never surface as io.EOF: the supervisor classifies a job
+// by whether its stream ended cleanly, so a torn pipe reported as a clean end is
+// a truncated answer presented as a complete one. Next carries the error out
+// through three separate arms and all three have to, so the rows are named for
+// the arm each one reaches, which is decided by what the stream holds when the
+// read fails. Verified one at a time: each row is the sole killer of its arm,
+// and this is the only test in the package that notices any of them.
+func TestReadFailureIsNotReportedAsACleanEnd(t *testing.T) {
+	want := errors.New("connection reset by peer")
+	for _, tc := range []struct {
+		name      string
+		tail      string
+		malformed int
+	}{
+		// Nothing follows the last terminator, so the failing read returns no bytes
+		// and the empty line reaches the blank-line arm.
+		{"the blank-line arm", "", 0},
+		{"the decode-failure arm", `{"event":"result","result":{`, 1},
+		{"the truncated arm", strings.Repeat("y", maxLineBytes+1024), 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewReader(&errAfter{s: resultLine("done") + tc.tail, err: want})
+			ev, err := r.Next()
+			if err != nil {
+				t.Fatalf("first Next: %v", err)
+			}
+			if ev.Result == nil || ev.Result.Response != "done" {
+				t.Fatalf("first event = %+v, want the complete line that preceded the failure", ev)
+			}
+			if _, err := r.Next(); !errors.Is(err, want) {
+				t.Fatalf("Next err = %v, want the read failure", err)
+			}
+			if r.Malformed() != tc.malformed {
+				t.Fatalf("malformed = %d, want %d", r.Malformed(), tc.malformed)
+			}
+		})
+	}
+}
+
+// Decoding happens inside a buffer that the next read overwrites, so a payload
+// field that aliased it rather than copying would corrupt events already handed
+// to the caller, and only once the stream outran the buffer. The supervisor
+// keeps a *Result past the loop and a StepType across iterations, so that
+// corruption would land in the answer a job reports. Every field is a string or
+// a number today, which is why this holds; the test is here so that adding a
+// []byte or a json.RawMessage to Event fails loudly instead of silently.
+func TestDecodedEventsSurviveLaterReads(t *testing.T) {
+	const lines = 400
+	var sb strings.Builder
+	for i := range lines {
+		fmt.Fprintf(&sb, `{"event":"result","result":{"conversation_id":"c-%d","status":"SUCCESS","response":"r-%d"}}`+"\n", i, i)
+	}
+	if sb.Len() < 4*bufioDefaultBytes {
+		t.Fatalf("fixture is %d bytes, too small to reuse the read buffer", sb.Len())
+	}
+	evs := readAll(t, NewReader(strings.NewReader(sb.String())))
+	if len(evs) != lines {
+		t.Fatalf("got %d events, want %d", len(evs), lines)
+	}
+	// Read back only after the whole stream has been drained, so every earlier
+	// event has had the buffer beneath it rewritten many times over.
+	for i, ev := range evs {
+		if ev.Result == nil {
+			t.Fatalf("event %d has no result payload", i)
+		}
+		wantID, wantResp := fmt.Sprintf("c-%d", i), fmt.Sprintf("r-%d", i)
+		if ev.Result.ConversationID != wantID || ev.Result.Response != wantResp {
+			t.Fatalf("event %d = %q/%q after the stream was drained, want %q/%q",
+				i, ev.Result.ConversationID, ev.Result.Response, wantID, wantResp)
+		}
+	}
+}
+
 // Past the retention cap a line is dropped rather than decoded from a prefix,
 // and the stream keeps going.
 func TestOverlongLineIsDroppedNotDecoded(t *testing.T) {
-	huge := strings.Repeat("y", maxLineBytes+1024)
-	in := `{"event":"result","result":{"status":"SUCCESS","response":"` + huge + `"}}` + "\n" +
-		`{"event":"result","result":{"status":"SUCCESS","response":"after"}}` + "\n"
-	r := NewReader(strings.NewReader(in))
+	overlong := resultLine(strings.Repeat("y", maxLineBytes+1024))
+	after := resultLine("after")
+	r := NewReader(strings.NewReader(overlong + after))
 	evs := readAll(t, r)
 	if len(evs) != 1 {
 		t.Fatalf("got %d events, want only the line that fits", len(evs))
 	}
-	if evs[0].Result.Response != "after" {
-		t.Fatalf("response = %q, want the following line", evs[0].Result.Response)
+	if evs[0].Result == nil || evs[0].Result.Response != "after" {
+		t.Fatalf("event = %+v, want the line following the over-long one", evs[0])
 	}
 	if r.Malformed() != 1 {
 		t.Fatalf("malformed = %d, want 1", r.Malformed())
+	}
+}
+
+// The whole reason maxLineBytes exists is to stop a corrupt or unterminated
+// stream growing the supervisor's memory without bound, and until this test
+// nothing checked it: deleting the clamp on the chunk that crosses the cap left
+// every other test in the package green while the reader retained the entire
+// stream. Asserting the retained length, rather than only that the line was
+// dropped, is what makes the bound observable.
+// Run over two chunk sizes, because they decide how the clamp is reached. The
+// default divides the cap, so the accumulation lands on it exactly and the clamp
+// keeps nothing. A caller may also hand NewReader a *bufio.Reader that is
+// already bigger than the default, which bufio then keeps as-is; pick a size
+// that does not divide the cap and the crossing chunk has to be cut. Both must
+// retain the same thing.
+func TestOverlongLineRetainsOnlyTheCap(t *testing.T) {
+	// Not a divisor of maxLineBytes, so the cap falls inside a chunk.
+	const straddlingBufBytes = 100_000
+	const overshoot = 64 * bufioDefaultBytes
+	for _, tc := range []struct {
+		name string
+		wrap func(io.Reader) io.Reader
+	}{
+		{"chunks that divide the cap", func(r io.Reader) io.Reader { return r }},
+		{"chunks that straddle the cap", func(r io.Reader) io.Reader {
+			return bufio.NewReaderSize(r, straddlingBufBytes)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := strings.NewReader(strings.Repeat("y", maxLineBytes+overshoot) + "\n")
+			r := NewReader(tc.wrap(src))
+			line, truncated, err := r.readLine()
+			if err != nil {
+				t.Fatalf("readLine: %v", err)
+			}
+			if !truncated {
+				t.Fatal("a line past the cap must come back reported as truncated")
+			}
+			if len(line) != maxLineBytes {
+				t.Errorf("retained %d bytes, want exactly the cap (%d)", len(line), maxLineBytes)
+			}
+			if r.buf != nil {
+				t.Errorf("a truncated line left %d bytes of scratch pinned for the rest of the run", cap(r.buf))
+			}
+		})
+	}
+}
+
+// The cap is on payload, not on payload plus terminator: a line of exactly
+// maxLineBytes followed by a newline is the longest legal line, not the first
+// illegal one.
+func TestLineExactlyAtCapDecodes(t *testing.T) {
+	pad := maxLineBytes - len(resultPrefix) - len(resultSuffix)
+	line := resultLine(strings.Repeat("z", pad))
+	if got := len(line) - 1; got != maxLineBytes {
+		t.Fatalf("fixture payload is %d bytes, want exactly %d", got, maxLineBytes)
+	}
+	r := NewReader(strings.NewReader(line))
+	evs := readAll(t, r)
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want the line at the cap to decode", len(evs))
+	}
+	if evs[0].Result == nil || len(evs[0].Result.Response) != pad {
+		t.Fatalf("response is %d bytes, want %d", len(evs[0].Result.Response), pad)
+	}
+	if r.Malformed() != 0 {
+		t.Fatalf("malformed = %d, want 0 at exactly the cap", r.Malformed())
+	}
+}
+
+// An over-long line made entirely of whitespace is corruption, not padding.
+// Malformed's contract is "counted whenever it exceeded maxLineBytes or failed
+// to decode", and the blank-line carve-out must not quietly except this shape.
+func TestOverlongBlankLineIsCounted(t *testing.T) {
+	in := strings.Repeat(" ", maxLineBytes+1024) + "\n" + resultLine("after")
+	r := NewReader(strings.NewReader(in))
+	if evs := readAll(t, r); len(evs) != 1 {
+		t.Fatalf("got %d events, want the line after the over-long one", len(evs))
+	}
+	if r.Malformed() != 1 {
+		t.Fatalf("malformed = %d, want 1: an over-long line is not padding", r.Malformed())
+	}
+}
+
+// A line that fails to decode on the same call that ends the stream must still
+// be counted. The count is what the supervisor reports as "skipped N unreadable
+// line(s)", and agy's last line is the one that matters, so a truncated final
+// line silently vanishing is exactly the case worth pinning: bufio hands back
+// the buffered bytes together with io.EOF when the stream ends without a
+// terminator.
+func TestDecodeFailureArrivingWithEndOfStream(t *testing.T) {
+	r := NewReader(strings.NewReader(`{"event":"result","result":{`))
+	if _, err := r.Next(); !errors.Is(err, io.EOF) {
+		t.Fatalf("Next err = %v, want io.EOF", err)
+	}
+	if r.Malformed() != 1 {
+		t.Fatalf("malformed = %d, want 1 for an undecodable final line", r.Malformed())
+	}
+}
+
+// stallAfter yields s and then reports neither data nor an error, ever, which is
+// a reader that has simply stopped.
+type stallAfter struct{ s string }
+
+func (e *stallAfter) Read(p []byte) (int, error) {
+	if e.s == "" {
+		return 0, nil
+	}
+	n := copy(p, e.s)
+	e.s = e.s[n:]
+	return n, nil
+}
+
+// What Next's doc says happens AFTER a stream fails, which until now was
+// asserted only in that doc: the error keeps coming back rather than being
+// cleared once it has been handed out, and a reader that stalls is reported as
+// no progress instead of as a clean end. The manager polls a job repeatedly, so
+// the second answer matters as much as the first.
+func TestNextKeepsReportingAFailedStream(t *testing.T) {
+	want := errors.New("connection reset by peer")
+	torn := NewReader(&errAfter{s: resultLine("done"), err: want})
+	if _, err := torn.Next(); err != nil {
+		t.Fatalf("first Next: %v", err)
+	}
+	for i := range 4 {
+		if _, err := torn.Next(); !errors.Is(err, want) {
+			t.Fatalf("Next %d after the failure = %v, want the failure again", i+2, err)
+		}
+	}
+
+	stalled := NewReader(&stallAfter{s: resultLine("done")})
+	if _, err := stalled.Next(); err != nil {
+		t.Fatalf("first Next on the stalled reader: %v", err)
+	}
+	if _, err := stalled.Next(); !errors.Is(err, io.ErrNoProgress) {
+		t.Fatalf("Next on a stalled reader = %v, want io.ErrNoProgress", err)
+	}
+}
+
+// The same coincidence one branch over: a line that ends the stream by running
+// past the cap rather than by failing to decode. This is the shape a killed agy
+// leaves behind mid-answer, and it is the only arm of Next that no other test
+// here reaches.
+func TestOverlongUnterminatedLineIsCounted(t *testing.T) {
+	r := NewReader(strings.NewReader(strings.Repeat("y", maxLineBytes+1024)))
+	if _, err := r.Next(); !errors.Is(err, io.EOF) {
+		t.Fatalf("Next err = %v, want io.EOF", err)
+	}
+	if r.Malformed() != 1 {
+		t.Fatalf("malformed = %d, want 1 for an over-long final line", r.Malformed())
+	}
+}
+
+// The decoder's input is a live subprocess's stdout, so it is not a trusted
+// document: it can be interleaved, cut mid-line, or carry whatever a tool
+// printed. Its contract under all of that is narrow enough to state, and this
+// asserts the whole of it, since the shapes that break a hand-written table are
+// exactly the ones nobody thinks to write down.
+//
+// The tally is an equality rather than a bound. A bound is satisfied by a
+// decoder that yields nothing at all, which is precisely the regression worth
+// catching, since every remaining assertion here is about what Next does NOT do.
+//
+// The precedent for fuzzing rather than adding more example rows is agyver:
+// five rounds of review-driven fixes to that parser were each contradicted by
+// measurement, and its fuzz target plus a 40-row table is what settled it.
+func FuzzNextSurvivesArbitraryStreams(f *testing.F) {
+	f.Add(sample)
+	f.Add("")
+	f.Add("\n\n\n")
+	f.Add("   ")
+	f.Add("not json")
+	f.Add(`{"event":"result","result":{`)
+	f.Add("{\"event\":\"init\"}\n\x00\xff\n{\"event\":\"result\"}")
+	f.Add(`{"event":"step_update","step_update":{"step_index":9,"text_delta":"x"}}`)
+	f.Add(`{"event":"init","init":{"tools":["a","b"]},"conversation_id":"c"}` + "\n")
+	f.Add(strings.Repeat("{", 5000))
+	f.Add(strings.Repeat("\n", 5000))
+	// Two seeds past the read buffer, so the corpus covers readLine's
+	// accumulation path deliberately rather than by the accident of one earlier
+	// seed being long: one of these decodes and one cannot.
+	f.Add(resultLine(strings.Repeat("x", 2*bufioDefaultBytes)))
+	f.Add(strings.Repeat("x", 2*bufioDefaultBytes) + "\n" + resultLine("after"))
+
+	f.Fuzz(func(t *testing.T, in string) {
+		r := NewReader(strings.NewReader(in))
+		events := 0
+		for {
+			ev, err := r.Next()
+			if err != nil {
+				// A strings.Reader has no failure mode but the end of its string, so
+				// any other error here is the decoder inventing one.
+				if !errors.Is(err, io.EOF) {
+					t.Fatalf("Next err = %v, want io.EOF on a strings.Reader", err)
+				}
+				break
+			}
+			events++
+			// Whatever decoded, reading the id off it must not panic: production
+			// calls this on every event before looking at the kind.
+			_ = ev.ConversationIDOf()
+			if events > len(in)+1 {
+				t.Fatalf("%d events from %d bytes: Next is not consuming input", events, len(in))
+			}
+		}
+		// Every line is decoded, counted malformed, or forgiven as padding, and
+		// never two of those, so the two tallies together account for exactly the
+		// lines that were not padding. An over-long line is never padding, whatever
+		// its bytes.
+		want := 0
+		for line := range strings.SplitSeq(in, "\n") {
+			if strings.TrimSpace(line) != "" || len(line) > maxLineBytes {
+				want++
+			}
+		}
+		if got := events + r.Malformed(); got != want {
+			t.Fatalf("events=%d + malformed=%d = %d, want one outcome for each of the %d non-padding line(s)",
+				events, r.Malformed(), got, want)
+		}
+	})
+}
+
+// Framing must be independent of payload: a text_delta is the model's own
+// output and can hold anything, including the newline this format delimits on
+// (JSON escapes it, so the line stays one line) and the read boundary.
+//
+// The events are padded and interleaved with a line known to be undecodable, so
+// what is asserted is where the decoder cuts the stream and what it refuses,
+// rather than encoding/json's ability to round-trip its own output.
+func FuzzFramingPreservesPayloads(f *testing.F) {
+	f.Add("pang\n", "21f0f78b-95b7-4aa5-a438-85a5078eac48")
+	f.Add("", "")
+	f.Add("line one\nline two\r\n{\"event\":\"result\"}\n", "c1")
+	f.Add(strings.Repeat("x", bufioDefaultBytes+7), "c2")
+	f.Add("\t \x00 ünïcødé 🐦", "c3")
+
+	f.Fuzz(func(t *testing.T, delta, conv string) {
+		// json.Marshal replaces invalid UTF-8 with U+FFFD, so a byte-for-byte
+		// comparison would fail on the encoder's behaviour, not the decoder's.
+		if !utf8.ValidString(delta) || !utf8.ValidString(conv) {
+			t.Skip("not valid UTF-8")
+		}
+		want := []Event{
+			{Kind: EventInit, ConversationID: conv, Init: &Init{Cwd: "/tmp/x"}},
+			{Kind: EventStepUpdate, StepUpdate: &StepUpdate{
+				ConversationID: conv, StepIndex: 3, StepType: StepTypeAgentResponse, TextDelta: delta,
+			}},
+			{Kind: EventResult, Result: &Result{ConversationID: conv, Status: StatusSuccess, Response: delta}},
+		}
+		const garbage = `{"event":"result",`
+		var stream strings.Builder
+		for _, ev := range want {
+			b, err := json.Marshal(ev)
+			if err != nil {
+				t.Fatalf("marshalling the fixture: %v", err)
+			}
+			if len(b) > maxLineBytes {
+				t.Skip("past the retention cap, where dropping the line is the contract")
+			}
+			stream.WriteString("\n")
+			stream.Write(b)
+			stream.WriteString("\n" + garbage + "\n")
+		}
+
+		r := NewReader(strings.NewReader(stream.String()))
+		got := readAll(t, r)
+		if r.Malformed() != len(want) {
+			t.Fatalf("malformed = %d, want one per interleaved garbage line (%d)", r.Malformed(), len(want))
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("decoded events differ from the ones written:\n got %+v\nwant %+v", got, want)
+		}
+	})
+}
+
+// initWithToolList is agy's init event as it really arrives, carrying the tool
+// list this package deliberately declines to decode. The sample capture above is
+// trimmed to one tool, which understates that decision by a factor of the tool
+// count, so the benchmark measures both shapes.
+func initWithToolList(n int) string {
+	tools := make([]string, n)
+	for i := range tools {
+		tools[i] = fmt.Sprintf(`"tool_number_%02d"`, i)
+	}
+	return `{"event":"init","conversation_id":"21f0f78b-95b7-4aa5-a438-85a5078eac48",` +
+		`"init":{"cwd":"/tmp/x","tools":[` + strings.Join(tools, ",") +
+		`],"permission_mode":"request-review"}}` + "\n"
+}
+
+// BenchmarkNext measures the per-line decode cost over the three line shapes
+// that take different paths: short lines returned from bufio's buffer and
+// decoded in place, an init event whose tool list is skipped rather than
+// decoded, and a line past the read buffer that has to be accumulated into the
+// Reader's scratch.
+//
+// The decoded count is asserted, because the loop's terminating error is
+// otherwise indistinguishable from a decoder that returns io.EOF immediately,
+// which benchmarks as a hundredfold improvement. Each iteration also constructs
+// a Reader, whose read buffer is inside the reported B/op; that is amortized
+// over the fixture's lines but it is not nothing.
+func BenchmarkNext(b *testing.B) {
+	for _, bm := range []struct {
+		name   string
+		stream string
+		events int
+	}{
+		{"short lines", strings.Repeat(sample, 64), 4 * 64},
+		{"init with a full tool list", strings.Repeat(initWithToolList(60), 64), 64},
+		{"lines past the read buffer", strings.Repeat(resultLine(strings.Repeat("x", 5*bufioDefaultBytes)), 64), 64},
+	} {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(bm.stream)))
+			for b.Loop() {
+				r := NewReader(strings.NewReader(bm.stream))
+				n := 0
+				for {
+					if _, err := r.Next(); err != nil {
+						if !errors.Is(err, io.EOF) {
+							b.Fatalf("Next: %v", err)
+						}
+						break
+					}
+					n++
+				}
+				if n != bm.events {
+					b.Fatalf("decoded %d events, want %d", n, bm.events)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes the `streamjson` items of #96 (three efficiency findings and the fuzz-target item) and of #109 (both doc-precision items and the end-of-stream test gap).

## What changed

`Next` copied every line twice on its way to the decoder, `string(line)` and then `[]byte(trimmed)`, and `readLine` allocated a fresh accumulation buffer per line. `bytes.TrimSpace` returns a subslice and `json.Unmarshal` takes a `[]byte`, so both copies go; `readLine` now hands back bufio's own buffer when the whole line arrived in one read, and reuses one scratch buffer for the lines that did not. `Init.Tools` is deleted rather than decoded, being the one part of the payload whose cost scales with the input: a string per tool, on every run, for a value nothing reads.

Measured against `main`, three fixtures, six runs each on an M4 Pro:

| fixture | main | this branch |
|---|---|---|
| short lines (256) | 325.7 kB, 4610 allocs, 404 µs | 152.7 kB, 3715 allocs, 386 µs |
| init event with 60 tools (64) | 481.8 kB, 5314 allocs, 466 µs | 34.4 kB, 835 allocs, 291 µs |
| 20 KiB lines (64) | 7.44 MB, 1090 allocs, 4.52 ms | 1.39 MB, 711 allocs, 3.98 ms |

## One of #96's proposals measured out wrong

#96 also proposed raising bufio's 4096-byte buffer, arguing that the lines this stream carries routinely exceed it. Measured, that is not worth doing: at 64 KiB it is within noise of the default on both time and allocation count at every line length up to 256 KiB, because `json.Unmarshal` is 99% of the per-line cost, while adding its own size to the resident footprint of every running job. An earlier revision of this branch raised it; the measurement is why it does not. `NewReader`'s doc now records the result so the next person does not repeat it.

## Correctness at the cap

`readLine` counted the newline against `maxLineBytes`, so the real payload cap was `maxLineBytes-1` and a line of exactly the cap was dropped as over-long. It also kept the terminator on the accumulation path, which pushed the retained line one byte past the cap and forced a regrow of the whole buffer for a payload ending on a read boundary. `Next` tested the blank case before the truncated one, so an over-long line of whitespace was skipped as padding without being counted, which `Malformed`'s own doc says does not happen, and it trimmed before testing for truncation, scanning 8 MiB it was about to discard. A truncated line now releases the scratch rather than pinning it for the life of the job, which is what `maxLineBytes` exists to prevent.

The `if room > 0` guard in the overflow branch is gone rather than tested: appending an empty slice is a no-op, and `room` cannot go negative because neither arm that grows the buffer can take it past the cap. That was verified rather than argued, with a differential fuzz against a reference implementation over 11 adversarial readers and 7 cap/buffer configurations: 36,052,065 executions, zero mismatches. The branch turns out to be reachable after all, though not by fixture size as #96 assumed. `bufio.NewReaderSize` returns a caller's already-larger `*bufio.Reader` unmodified, so chunks that do not divide the cap straddle it; a test now does exactly that and reaches the branch with `room = 88608`.

## Tests

Two fuzz targets, #96's oldest open item. One drives `Next` over arbitrary bytes and asserts it terminates, invents no error, and accounts for every line, as an equality rather than a bound, since a bound is satisfied by a decoder that yields nothing. The other builds a stream from arbitrary payloads interleaved with padding and undecodable lines and compares whole events. 21M and 657k executions clean.

Every new assertion was verified against the mutation it exists to catch. Three took more than one attempt and are worth naming, because the first versions passed against a broken decoder:

- **The memory bound had no test at all.** Deleting the clamp on the chunk that crosses the cap left the whole suite green while a 40 MiB stream was retained in full.
- **The zero-copy fast path is invisible to ordinary assertions**, since a copy decodes to exactly the same event. Capacity comparisons kill only a copy into a cold buffer, and watching the bytes change kills only a copy into a fresh one; the test now pins where the returned slice ends, which no copy reproduces.
- **The read-error contract was unpinned in all three of its arms.** Replacing every deferred `return Event{}, err` with `io.EOF` left the suite green, reporting a torn pipe as a clean end of stream, which is exactly what the doc promises cannot happen.

The aliasing question the in-place decode raises was settled by direct memory probes at every consumer, and the canary test verified by giving `Result.Response` an `UnmarshalJSON` that keeps its argument, which corrupts an already-decoded event exactly as the doc warns.

Package coverage 97.7% -> 100%. `golangci-lint` clean, suite green under `-race`.

## Review

Pre-push gate, three rounds: seven parallel review agents plus an Antigravity peer review on the input diff, then a report-only pass over each fix wave. 35 findings, no Critical and no High at any round. Two of this branch's own claims were refuted and corrected rather than defended: the read-buffer size above, and a comment asserting `room` is always exactly 0, which a caller-supplied reader disproves.

Findings not fixed here are batched in #110: a pre-existing non-termination if a wrapped reader's own error is `bufio.ErrBufferFull` (unreachable from the production caller), the per-line `Event` heap escape, and the measurement showing `GOEXPERIMENT=jsonv2` would remove 3.3x what this changeset does once it ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved processing efficiency for streamed JSON event data by reducing unnecessary memory allocations.

* **Reliability**
  * Improved handling of long, truncated, malformed, stalled, and incomplete event streams.
  * Ensured subsequent events continue to be processed correctly after oversized or invalid entries.
  * Preserved decoded event data reliably across ongoing stream reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->