### PR TITLE
jobstore: retry contended job-dir reads and writes on Windows (#96)

### DIFF
--- a/internal/jobstore/contention.go
+++ b/internal/jobstore/contention.go
@@ -56,10 +56,11 @@ const (
 // rather than the standard library, so it is precedent, not an API to reach for.
 //
 // The budget bounds one operation, so a caller in a loop multiplies it. The
-// largest multiplier is RestoreAndCollect, which reads meta.json and the
-// exit-code sentinel for every job dir at startup, blocks on it and fails
-// closed. The usual reason a job dir reads short there is a missing file, which
-// is never retried, so this costs nothing in the ordinary case.
+// largest multiplier is the startup scan, which reads meta.json for every job
+// dir and the exit-code sentinel for those whose meta parsed. A contended read
+// there is logged and skipped rather than fatal; only the directory scan itself
+// fails startup closed. And the usual reason a job dir reads short is a missing
+// file, which is never retried, so this costs nothing in the ordinary case.
 //
 // Considered and not taken: os.Root.Rename reaches a different rename entirely,
 // NtSetInformationFile with FILE_RENAME_POSIX_SEMANTICS

--- a/internal/jobstore/contention.go
+++ b/internal/jobstore/contention.go
@@ -1,0 +1,126 @@
+package jobstore
+
+import (
+	"os"
+	"time"
+)
+
+// Retry budget for a contended job-dir file, spent only when contended reports
+// the failure transient (Windows only; see contention_windows.go).
+//
+// The last attempt is not followed by a sleep, so ONE operation waits at most
+// 1+2+4+8+16+32+50+50+50 = 213ms across nine waits before returning the tenth
+// attempt's error. That bounds a single call, not a run: the supervisor
+// republishes progress.json once per observable step change, so a destination
+// that stays contended costs this much per event rather than once.
+//
+// Both halves of the schedule are load-bearing. The doubling is what stops a
+// hopeless operation spinning; the cap is what stops the tail of the budget
+// being one long wait.
+const (
+	contendedAttempts     = 10
+	contendedBackoffStart = 1 * time.Millisecond
+	contendedBackoffCap   = 50 * time.Millisecond
+)
+
+// retryContended runs op, retrying while the platform reports the file it
+// touches as held by another process right now rather than genuinely unusable.
+//
+// Off Windows contended is always false, so op runs exactly once and this is a
+// plain call. Windows is the reason it exists, and the reason is not exotic.
+//
+// Every file in a job dir except out and err is published by writing a temp
+// file and renaming it into place (writeFileAtomic). On Windows that replace
+// needs DELETE access to the destination, which the OS refuses while any handle
+// to it is open without FILE_SHARE_DELETE, and Go's os.Open does not request
+// that share mode: os.Open reaches syscall.Open (os/file_windows.go:158), which
+// sets FILE_SHARE_READ|FILE_SHARE_WRITE (syscall_windows.go:395). os.Rename is
+// MoveFileEx(from, to, MOVEFILE_REPLACE_EXISTING)
+// (internal/syscall/windows/syscall_windows.go:366). All three read in go1.26.5.
+//
+// So a reader and a writer of one job-dir file can each fail because of the
+// other, and both directions happen in ordinary use:
+//
+//   - meta.json. StartJob rewrites it to record the supervisor's pid while the
+//     supervisor it just spawned reads it (LoadDir). This is the expensive
+//     direction: LoadDir's error aborts the job before it starts.
+//   - progress.json. consumeStream republishes it on each observable step
+//     change, while Status reads it on every poll of a running job and
+//     awaitConversationID reads it every 50ms.
+//
+// The Go command's own tree hardens both sides of this same hazard for the same
+// reason: cmd/internal/robustio wraps Rename ("on Windows retries errors that
+// may occur if the file is concurrently read or overwritten") and ReadFile ("on
+// Windows retries errors that may occur if the file is concurrently replaced"),
+// both citing go.dev/issue/31247 and go.dev/issue/32188. It is the Go command
+// rather than the standard library, so it is precedent, not an API to reach for.
+//
+// The budget bounds one operation, so a caller in a loop multiplies it. The
+// largest multiplier is RestoreAndCollect, which reads meta.json and the
+// exit-code sentinel for every job dir at startup, blocks on it and fails
+// closed. The usual reason a job dir reads short there is a missing file, which
+// is never retried, so this costs nothing in the ordinary case.
+//
+// Considered and not taken: os.Root.Rename reaches a different rename entirely,
+// NtSetInformationFile with FILE_RENAME_POSIX_SEMANTICS
+// (internal/syscall/windows.Renameat), which might avoid the collision rather
+// than retry it. Renameat's FILE_SHARE_DELETE is on the open of the SOURCE, so
+// it would be the POSIX-semantics flag rather than the share mode doing the
+// work there. It also needs an *os.Root per job dir, which the package-level
+// dir-based helpers here do not have, and whether it clears a violation against
+// a destination someone else holds open is NOT MEASURED. Retrying is the
+// cheaper answer until someone can measure that.
+func retryContended(op func() error) error {
+	return retryWhile(op, contended, time.Sleep)
+}
+
+// renameReplace publishes a temp file over its destination, retrying while the
+// destination is contended. See retryContended.
+func renameReplace(src, dst string) error {
+	return retryContended(func() error { return os.Rename(src, dst) })
+}
+
+// readReplaced reads a job-dir file that writeFileAtomic publishes by rename,
+// retrying while a concurrent replace makes it briefly unopenable.
+//
+// Absence is never retried, which is where the predicate deliberately diverges
+// from robustio's (that one also treats ERROR_FILE_NOT_FOUND as ephemeral). A
+// missing file is a load-bearing answer for three of the four callers: no
+// result payload, no exit-code sentinel, no progress yet. Store.ExitCode is the
+// one that would hurt, since it is polled throughout a running job precisely
+// when the sentinel is absent by definition, so retrying absence would spend
+// the whole budget on the hot path of every poll.
+func readReplaced(path string) ([]byte, error) {
+	var b []byte
+	err := retryContended(func() error {
+		var rerr error
+		b, rerr = os.ReadFile(path)
+		return rerr
+	})
+	return b, err
+}
+
+// retryWhile is retryContended's loop with its three environment dependencies
+// passed in. They are parameters rather than package-level vars a test could
+// swap because a var would be mutable process-wide state existing only for
+// tests; passing them keeps every branch, including the Windows-only ones,
+// drivable on every platform and drivable without waiting.
+//
+// The last error is returned unwrapped so a caller's errors.Is still reaches
+// the *os.LinkError or *fs.PathError underneath. ReadResultDir relies on that:
+// it separates fs.ErrNotExist from a real read failure, and the two mean
+// opposite things there.
+func retryWhile(op func() error, retryable func(error) bool, sleep func(time.Duration)) error {
+	backoff := contendedBackoffStart
+	for attempt := 1; ; attempt++ {
+		err := op()
+		if err == nil || attempt >= contendedAttempts || !retryable(err) {
+			return err
+		}
+		sleep(backoff)
+		backoff *= 2
+		if backoff > contendedBackoffCap {
+			backoff = contendedBackoffCap
+		}
+	}
+}

--- a/internal/jobstore/contention_notwindows.go
+++ b/internal/jobstore/contention_notwindows.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package jobstore
+
+// contended is always false off Windows: rename(2) swaps a directory entry and
+// open(2) resolves to an inode, and another process holding the old file open
+// blocks neither. A failure here is a real one (a missing directory, a full or
+// read-only filesystem, a cross-device path), so retrying would only delay the
+// report.
+//
+// TestContendedIsAlwaysFalse asserts this function's own answer;
+// TestWriteFileAtomicReplacesAnOpenFile pins the kernel behaviour that makes it
+// the right answer.
+//
+// The constraint is !windows rather than the unix/_other.go split used
+// elsewhere in this repo, and the filename says so rather than saying _other:
+// jobstore is platform-agnostic, so a unix tag would leave js/wasm and plan9
+// with no contended at all, and an _other.go here would read as the
+// unsupported-platform stub that name means in the other packages.
+func contended(error) bool { return false }

--- a/internal/jobstore/contention_notwindows_test.go
+++ b/internal/jobstore/contention_notwindows_test.go
@@ -1,0 +1,104 @@
+//go:build !windows
+
+package jobstore
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestContendedIsAlwaysFalse asserts the predicate's own answer off Windows.
+//
+// It exists because nothing else can kill a mutation of it: flipping
+// contention_notwindows.go to return true changes no observable behaviour in
+// any other test, since retryWhile only consults the predicate after an error
+// and every other unix test's operation succeeds first. Without this, the "the
+// loop runs once" claim in contention.go rests on reading the source.
+func TestContendedIsAlwaysFalse(t *testing.T) {
+	dir := t.TempDir()
+	// A real failure, wrapped exactly as os.Rename and os.ReadFile wrap theirs,
+	// rather than a bare sentinel: the Windows twin matches on the wrapped
+	// errno, so the unix side should be asked the same shape of question.
+	renameErr := os.Rename(filepath.Join(dir, "missing"), filepath.Join(dir, "dst"))
+	if renameErr == nil {
+		t.Fatal("renaming a missing file should have failed")
+	}
+	if _, ok := errors.AsType[*os.LinkError](renameErr); !ok {
+		t.Fatalf("os.Rename error = %T, want *os.LinkError", renameErr)
+	}
+	_, readErr := os.ReadFile(filepath.Join(dir, "missing"))
+	if !errors.Is(readErr, fs.ErrNotExist) {
+		t.Fatalf("os.ReadFile error = %v, want fs.ErrNotExist", readErr)
+	}
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"rename failure", renameErr},
+		{"read failure", readErr},
+		{"arbitrary error", errors.New("something else")},
+	} {
+		if contended(tc.err) {
+			t.Errorf("contended(%s) = true, want false: off Windows no error is worth retrying", tc.name)
+		}
+	}
+}
+
+// TestWriteFileAtomicReplacesAnOpenFile pins the kernel premise contended rests
+// on off Windows: rename(2) swaps the directory entry without regard to who
+// holds the old file open, so there is nothing here for a retry to wait for.
+//
+// It also pins the other half of what makes the replace safe. A reader that
+// opened the file before the write keeps reading the version it opened, so a
+// manager already mid-read of progress.json gets a consistent old snapshot
+// rather than a torn mix of both. That is the property the temp-plus-rename
+// exists for, and nothing else asserted it.
+func TestWriteFileAtomicReplacesAnOpenFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteProgressDir(dir, Progress{StepIndex: 1, StepType: "before"}); err != nil {
+		t.Fatal(err)
+	}
+	// Opened the way the manager's poll opens it, and deliberately still open
+	// across the write below.
+	f, err := os.Open(ProgressPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("closing the held reader: %v", err)
+		}
+	}()
+
+	if err := WriteProgressDir(dir, Progress{StepIndex: 2, StepType: "after"}); err != nil {
+		t.Fatalf("replacing a file held open by a reader must succeed on unix: %v", err)
+	}
+
+	// The path now names the new file, read back through the retrying reader
+	// production uses.
+	got, ok := ReadProgressDir(dir)
+	if !ok {
+		t.Fatal("progress unreadable after the replace")
+	}
+	if got.StepIndex != 2 || got.StepType != "after" {
+		t.Errorf("progress at the path = %+v, want the replacement (2, after)", got)
+	}
+
+	// The handle opened beforehand still names the old one, whole.
+	b, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var held Progress
+	if err := json.Unmarshal(b, &held); err != nil {
+		t.Fatalf("the reader that opened before the replace saw undecodable bytes (%q): %v", b, err)
+	}
+	if held.StepIndex != 1 || held.StepType != "before" {
+		t.Errorf("reader opened before the replace saw %+v, want the snapshot it opened (1, before)", held)
+	}
+}

--- a/internal/jobstore/contention_test.go
+++ b/internal/jobstore/contention_test.go
@@ -1,0 +1,159 @@
+package jobstore
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// errContended stands in for the platform errno meaning "another process holds
+// this file right now". A sentinel rather than the real ERROR_SHARING_VIOLATION
+// keeps every branch of the loop drivable on every platform: contended is false
+// off Windows, so a test feeding it a real errno would exercise the retry on
+// exactly one of the three OSes CI runs.
+var errContended = errors.New("file contended")
+
+// errDenied is a failure no retry can fix, so the loop must report it at once.
+var errDenied = errors.New("read-only filesystem")
+
+// retryCall records one drive of retryWhile: how many times it ran the
+// operation, and every duration it was told to sleep for.
+type retryCall struct {
+	attempts int
+	sleeps   []time.Duration
+}
+
+// drive runs retryWhile against an operation that returns results in order,
+// treating only errContended as retryable and recording sleeps instead of
+// taking them. Once results run out the last one repeats, so a caller testing
+// the budget need not spell out contendedAttempts entries.
+//
+// It caps the operation at three times the budget and then hard-fails, so a
+// regression removing the attempt ceiling shows up as this assertion rather
+// than as a test binary spinning until the package timeout.
+func drive(t *testing.T, results ...error) (*retryCall, error) {
+	t.Helper()
+	if len(results) == 0 {
+		t.Fatal("drive needs at least one result; with none the operation has nothing to return")
+	}
+	rc := &retryCall{}
+	err := retryWhile(
+		func() error {
+			rc.attempts++
+			if rc.attempts > 3*contendedAttempts {
+				t.Fatalf("operation retried %d times with no ceiling; contendedAttempts is %d", rc.attempts, contendedAttempts)
+			}
+			if rc.attempts <= len(results) {
+				return results[rc.attempts-1]
+			}
+			return results[len(results)-1]
+		},
+		func(err error) bool { return errors.Is(err, errContended) },
+		func(d time.Duration) { rc.sleeps = append(rc.sleeps, d) },
+	)
+	return rc, err
+}
+
+// An operation that works is one syscall and no waiting: the budget must be
+// spent only on failures.
+func TestRetryWhileDoesNotSleepWhenTheFirstAttemptSucceeds(t *testing.T) {
+	rc, err := drive(t, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if rc.attempts != 1 {
+		t.Errorf("attempts = %d, want 1", rc.attempts)
+	}
+	if len(rc.sleeps) != 0 {
+		t.Errorf("slept %v on a successful operation, want no waiting", rc.sleeps)
+	}
+}
+
+// The point of the whole file: a file contended now and free shortly after must
+// end up read or replaced, not reported as an error.
+func TestRetryWhileSucceedsOnceTheFileIsReleased(t *testing.T) {
+	rc, err := drive(t, errContended, errContended, errContended, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil once the file was released", err)
+	}
+	if rc.attempts != 4 {
+		t.Errorf("attempts = %d, want 4", rc.attempts)
+	}
+	// One wait per retry, never one after the attempt that succeeded.
+	if len(rc.sleeps) != 3 {
+		t.Errorf("sleeps = %v, want one per retry (3)", rc.sleeps)
+	}
+}
+
+// A failure the retry cannot fix must cost one syscall and no delay. Without
+// the retryable check the caller would wait out the entire budget before being
+// told its filesystem is read-only.
+func TestRetryWhileReportsANonRetryableErrorAtOnce(t *testing.T) {
+	rc, err := drive(t, errDenied)
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("err = %v, want errDenied", err)
+	}
+	if rc.attempts != 1 {
+		t.Errorf("attempts = %d, want 1: a non-retryable error must not be retried", rc.attempts)
+	}
+	if len(rc.sleeps) != 0 {
+		t.Errorf("slept %v before reporting a non-retryable error", rc.sleeps)
+	}
+}
+
+// A file that never frees up has to give up, and give up returning the
+// underlying error rather than something a caller's errors.Is cannot match.
+func TestRetryWhileGivesUpAfterTheBudget(t *testing.T) {
+	rc, err := drive(t, errContended)
+	if !errors.Is(err, errContended) {
+		t.Fatalf("err = %v, want the last operation error (errContended)", err)
+	}
+	if rc.attempts != contendedAttempts {
+		t.Errorf("attempts = %d, want contendedAttempts (%d)", rc.attempts, contendedAttempts)
+	}
+	if len(rc.sleeps) != contendedAttempts-1 {
+		t.Errorf("sleeps = %d, want contendedAttempts-1 (%d): the last attempt must not be followed by a wait",
+			len(rc.sleeps), contendedAttempts-1)
+	}
+}
+
+// The schedule itself, spelled out in literals rather than in terms of the
+// constants it is meant to pin. Naming contendedBackoffCap in the wanted values
+// would make the last three entries a tautology that survives changing the cap;
+// spelling 50ms means changing the cap turns this red.
+func TestRetryWhileBackoffDoublesUpToTheCap(t *testing.T) {
+	rc, err := drive(t, errContended)
+	if !errors.Is(err, errContended) {
+		t.Fatalf("err = %v, want errContended", err)
+	}
+	want := []time.Duration{
+		1 * time.Millisecond,
+		2 * time.Millisecond,
+		4 * time.Millisecond,
+		8 * time.Millisecond,
+		16 * time.Millisecond,
+		32 * time.Millisecond,
+		50 * time.Millisecond,
+		50 * time.Millisecond,
+		50 * time.Millisecond,
+	}
+	if len(rc.sleeps) != len(want) {
+		t.Fatalf("sleeps = %v, want %v", rc.sleeps, want)
+	}
+	for i, d := range want {
+		if rc.sleeps[i] != d {
+			t.Errorf("sleep %d = %v, want %v (full schedule %v)", i, rc.sleeps[i], d, rc.sleeps)
+		}
+	}
+	// The exact figure contention.go's doc comment claims. Asserting the total
+	// as well as the elements is what keeps that comment honest: a constant
+	// change that altered the sum is caught here even if someone also updated
+	// the element list to match.
+	var total time.Duration
+	for _, d := range rc.sleeps {
+		total += d
+	}
+	if wantTotal := 213 * time.Millisecond; total != wantTotal {
+		t.Errorf("worst-case wait for one operation = %v, want %v (the figure contention.go documents)", total, wantTotal)
+	}
+}

--- a/internal/jobstore/contention_windows.go
+++ b/internal/jobstore/contention_windows.go
@@ -1,0 +1,36 @@
+package jobstore
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// contended reports whether a failed job-dir operation is worth retrying: the
+// file is held by someone else right now, rather than genuinely unusable.
+//
+// These are the errnos the Go command's own tree retries for this hazard.
+// cmd/internal/robustio/robustio_windows.go's isEphemeralError matches
+// ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND and ERROR_SHARING_VIOLATION, citing
+// go.dev/issue/31247 and go.dev/issue/32188. ERROR_FILE_NOT_FOUND is
+// deliberately left out here; readReplaced says why absence has to stay a fast
+// answer.
+//
+// ERROR_ACCESS_DENIED is the ambiguous one. A destination carrying
+// FILE_ATTRIBUTE_READONLY, or a DACL of its own denying DELETE, is denied
+// permanently, and nothing here can tell that apart from a momentary hold. It
+// is included because cmd/internal/robustio includes it, and because the cost of
+// being wrong is bounded by the budget rather than open-ended; not because the
+// denial is known to be transient.
+//
+// NOT MEASURED: which of the two a held destination actually produces on a real
+// Windows host. Covering both is what keeps the predicate from depending on
+// that answer.
+//
+// os.Rename wraps the errno in *os.LinkError and os.ReadFile in *fs.PathError;
+// errors.Is unwraps either. Both constants are declared syscall.Errno in
+// x/sys/windows, so the comparison is against the same type os returns, and
+// os/os_windows_test.go matches ERROR_SHARING_VIOLATION this same way.
+func contended(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_ACCESS_DENIED)
+}

--- a/internal/jobstore/contention_windows_test.go
+++ b/internal/jobstore/contention_windows_test.go
@@ -1,0 +1,350 @@
+package jobstore
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestContendedClassifiesTheWrappedErrnos is the predicate's own table.
+//
+// Without it nothing distinguishes contended from "retry everything": both race
+// tests below produce a sharing violation, so replacing this function's body
+// with `return true` leaves them green. The rows that carry their weight are
+// the negative ones, and fs.ErrNotExist most of all: readReplaced's whole
+// design rests on absence being answered immediately rather than retried for
+// 213ms on every poll of a running job.
+func TestContendedClassifiesTheWrappedErrnos(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The shape os.Rename returns when the destination is held open.
+			name: "sharing violation wrapped by os.Rename",
+			err:  &os.LinkError{Op: "rename", Old: "a", New: "b", Err: windows.ERROR_SHARING_VIOLATION},
+			want: true,
+		},
+		{
+			// The shape os.ReadFile returns; the arm the race tests never reach.
+			name: "access denied wrapped by os.ReadFile",
+			err:  &fs.PathError{Op: "open", Path: "p", Err: windows.ERROR_ACCESS_DENIED},
+			want: true,
+		},
+		{
+			name: "sharing violation unwrapped",
+			err:  windows.ERROR_SHARING_VIOLATION,
+			want: true,
+		},
+		{
+			// Deliberately NOT retried, unlike robustio's predicate. See readReplaced.
+			name: "file absent",
+			err:  &fs.PathError{Op: "open", Path: "p", Err: windows.ERROR_FILE_NOT_FOUND},
+			want: false,
+		},
+		{
+			name: "fs.ErrNotExist",
+			err:  fs.ErrNotExist,
+			want: false,
+		},
+		{
+			name: "arbitrary error",
+			err:  errors.New("something else"),
+			want: false,
+		},
+	} {
+		if got := contended(tc.err); got != tc.want {
+			t.Errorf("contended(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRetryContendedOutlastsAnOpenReader is the writer half of the race this
+// package retries for, exercised against the real OS rather than a sentinel.
+//
+// It asserts two things at once, and both matter:
+//
+//   - The first os.Rename over a destination another handle holds open really
+//     does fail here. os.Open asks for FILE_SHARE_READ|FILE_SHARE_WRITE and not
+//     FILE_SHARE_DELETE, so MoveFileEx cannot get the DELETE access it needs.
+//     Reaching a second attempt is what proves the failure happened; if this OS
+//     ever stops behaving that way the test says so instead of quietly passing.
+//   - contended classifies that real errno as retryable, since the loop only
+//     goes round again when it returns true.
+//
+// The handle is released from inside the operation, immediately after the
+// attempt it is meant to defeat. That ordering is the point: no timing margin,
+// and the retry has something to succeed at the moment it runs. time.Sleep is
+// real rather than a no-op so the remaining attempts span the same wall time
+// production gives them; with a no-op the test would be strictly LESS tolerant
+// of a scanner on a CI runner than the code it guards.
+func TestRetryContendedOutlastsAnOpenReader(t *testing.T) {
+	dir := t.TempDir()
+	dst := ProgressPath(dir)
+	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src := dst + ".tmp"
+	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Held open the way the manager's status poll holds progress.json.
+	held, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Safety net for the path where the operation below never runs; the
+	// operation closes it on the first attempt, and a double close is a
+	// harmless already-closed error.
+	defer func() { _ = held.Close() }()
+
+	attempts := 0
+	err = retryWhile(
+		func() error {
+			attempts++
+			rerr := os.Rename(src, dst)
+			if attempts == 1 {
+				// Release only after the contended attempt has already failed,
+				// so the retry is what succeeds rather than a lucky interleaving.
+				_ = held.Close()
+			}
+			return rerr
+		},
+		contended,
+		time.Sleep,
+	)
+	if err != nil {
+		t.Fatalf("rename over a reader-held destination failed after %d attempts: %v", attempts, err)
+	}
+	// Not equality: a scanner can lose attempt 2 as well, and the retry would
+	// still have done its job on attempt 3. What must hold is that attempt 1
+	// failed, which is the whole premise.
+	if attempts < 2 {
+		t.Errorf("attempts = %d, want at least 2: the first rename must fail against the open handle "+
+			"and a retry must be what replaces the file", attempts)
+	}
+	b, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "new" {
+		t.Errorf("destination = %q, want the replacement %q", b, "new")
+	}
+}
+
+// TestRetryContendedOutlastsAnExclusiveHolder is the reader half of the same
+// race. A concurrent replace can leave a job-dir file briefly unopenable, which
+// is why readReplaced retries and why the standard library's robustio.ReadFile
+// exists at all.
+//
+// The stimulus is a handle opened with no sharing at all, which is the
+// deterministic way to make any other open fail with ERROR_SHARING_VIOLATION.
+// It stands in for the replace window rather than reproducing it, because the
+// replace window cannot be held open on demand; what it proves is the part that
+// matters and that no other test reaches, namely that a real read-side errno is
+// classified as retryable and that the retry then succeeds.
+func TestRetryContendedOutlastsAnExclusiveHolder(t *testing.T) {
+	dir := t.TempDir()
+	path := ProgressPath(dir)
+	if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The sync.Once inside release is load-bearing, not tidiness: Windows
+	// recycles handle values, so closing twice could close something unrelated
+	// that os.ReadFile opened in between. The deferred call covers the path
+	// where the operation below never runs.
+	release := openExclusive(t, path)
+	defer release()
+
+	var b []byte
+	attempts := 0
+	err := retryWhile(
+		func() error {
+			attempts++
+			var rerr error
+			b, rerr = os.ReadFile(path)
+			if attempts == 1 {
+				// Release only after the contended attempt has already failed.
+				release()
+			}
+			return rerr
+		},
+		contended,
+		time.Sleep,
+	)
+	if err != nil {
+		t.Fatalf("reading a file held exclusively failed after %d attempts: %v", attempts, err)
+	}
+	if attempts < 2 {
+		t.Errorf("attempts = %d, want at least 2: the first read must fail against the exclusive handle", attempts)
+	}
+	if string(b) != "payload" {
+		t.Errorf("content = %q, want %q", b, "payload")
+	}
+}
+
+// openExclusive opens path with no sharing at all, so every other open of it
+// fails with ERROR_SHARING_VIOLATION until the returned func runs. It is the
+// deterministic way to hold a job-dir file against a reader.
+func openExclusive(t *testing.T, path string) func() {
+	t.Helper()
+	p16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, err := windows.CreateFile(p16, windows.GENERIC_READ, 0, nil,
+		windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	if err != nil {
+		t.Fatalf("opening %s exclusively: %v", path, err)
+	}
+	var once sync.Once
+	return func() { once.Do(func() { _ = windows.CloseHandle(h) }) }
+}
+
+// TestJobDirReadersSpendTheBudgetOnAContendedFile pins the wiring of all four
+// job-dir readers to readReplaced.
+//
+// It exists because nothing else pins it on any platform. Off Windows contended
+// is constant-false, so readReplaced and os.ReadFile are indistinguishable by
+// construction; on Windows the handshake tests above drive retryWhile directly
+// rather than going through these callers. Reverting all four call sites to a
+// bare os.ReadFile therefore left the entire suite green, which is how a later
+// edit would undo this silently.
+//
+// The stimulus is held for the whole read rather than released partway, so the
+// assertion needs no timing margin: a reader wired to the retry exhausts the
+// budget and fails after ~213ms, while one wired straight to os.ReadFile fails
+// in microseconds. The threshold sits far below the budget and far above a
+// single failed open, so neither a fast nor a loaded runner can cross it.
+func TestJobDirReadersSpendTheBudgetOnAContendedFile(t *testing.T) {
+	const id = "j"
+	for _, tc := range []struct {
+		name  string
+		file  string
+		stage func(t *testing.T, dir string)
+		// read reports whether the reader returned an answer. Every one of these
+		// reports failure differently, which is itself the reason to drive them
+		// through their real signatures rather than readReplaced directly.
+		read func(s *Store, dir string) bool
+	}{
+		{
+			name:  "ReadProgressDir",
+			file:  ProgressFile,
+			stage: func(t *testing.T, dir string) { mustStage(t, WriteProgressDir(dir, Progress{StepIndex: 1})) },
+			read:  func(_ *Store, dir string) bool { _, ok := ReadProgressDir(dir); return ok },
+		},
+		{
+			name:  "ReadResultDir",
+			file:  ResultFile,
+			stage: func(t *testing.T, dir string) { mustStage(t, WriteResultDir(dir, []byte(`{"status":"ok"}`))) },
+			read:  func(_ *Store, dir string) bool { b, err := ReadResultDir(dir); return err == nil && b != nil },
+		},
+		{
+			name:  "LoadDir",
+			file:  MetaFile,
+			stage: func(t *testing.T, dir string) {}, // Store.Create already wrote meta.json
+			read:  func(_ *Store, dir string) bool { _, err := LoadDir(dir); return err == nil },
+		},
+		{
+			name:  "Store.ExitCode",
+			file:  ExitCodeFile,
+			stage: func(t *testing.T, dir string) { mustStage(t, WriteExitCodeDir(dir, 0)) },
+			read:  func(s *Store, _ string) bool { _, ok := s.ExitCode(id); return ok },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New(t.TempDir())
+			dir, err := s.Create(Meta{ID: id})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.stage(t, dir)
+
+			release := openExclusive(t, filepath.Join(dir, tc.file))
+			defer release()
+
+			start := time.Now()
+			ok := tc.read(s, dir)
+			elapsed := time.Since(start)
+
+			if ok {
+				t.Fatalf("%s answered while %s was held exclusively; the stimulus did not take, "+
+					"so this test proves nothing", tc.name, tc.file)
+			}
+			if floor := 100 * time.Millisecond; elapsed < floor {
+				t.Errorf("%s gave up on a contended %s after %v, want at least %v: it is reading through "+
+					"os.ReadFile directly rather than readReplaced", tc.name, tc.file, elapsed, floor)
+			}
+		})
+	}
+}
+
+// mustStage fails the test if a fixture write failed.
+func mustStage(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWriteFileAtomicSurvivesAnOpenReader is the writer race one layer up,
+// through the function production actually calls: the supervisor republishing
+// progress.json while the manager holds it open must not lose the write.
+//
+// It cannot use the handshake the tests above use, because writeFileAtomic owns
+// its own rename and exposes no seam, which is exactly why the layer above is
+// worth a separate test. The release is therefore timed, at a fraction of the
+// 213ms budget.
+//
+// The channel check afterwards is a NECESSARY condition, not proof: it catches
+// the write finishing before the handle was released, which would mean the test
+// never met contention at all. It cannot prove the converse, since a runner
+// slow enough to spend 20ms inside CreateTemp and Sync would release the handle
+// before the first rename and still pass. The deterministic proof that the
+// retry works lives in the two handshake tests above; this one is the
+// integration check that writeFileAtomic is wired to it.
+func TestWriteFileAtomicSurvivesAnOpenReader(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteProgressDir(dir, Progress{StepIndex: 1, StepType: "before"}); err != nil {
+		t.Fatal(err)
+	}
+	held, err := os.Open(ProgressPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(20 * time.Millisecond)
+		_ = held.Close()
+	}()
+	// Joins the goroutine before t.TempDir's own cleanup removes the directory,
+	// since cleanups run last-registered-first.
+	t.Cleanup(func() { <-released })
+
+	if err := WriteProgressDir(dir, Progress{StepIndex: 2, StepType: "after"}); err != nil {
+		t.Fatalf("progress rewrite lost to a reader holding the file open: %v", err)
+	}
+	select {
+	case <-released:
+	default:
+		t.Error("the write completed while the reader still held the file, so it never met contention; " +
+			"this test proved nothing about the retry")
+	}
+	got, ok := ReadProgressDir(dir)
+	if !ok {
+		t.Fatal("progress unreadable after the replace")
+	}
+	if got.StepIndex != 2 || got.StepType != "after" {
+		t.Errorf("progress = %+v, want the replacement (2, after)", got)
+	}
+}

--- a/internal/jobstore/contention_windows_test.go
+++ b/internal/jobstore/contention_windows_test.go
@@ -191,9 +191,11 @@ func TestRetryContendedOutlastsAnExclusiveHolder(t *testing.T) {
 	}
 }
 
-// openExclusive opens path with no sharing at all, so every other open of it
-// fails with ERROR_SHARING_VIOLATION until the returned func runs. It is the
-// deterministic way to hold a job-dir file against a reader.
+// openExclusive opens path with no sharing at all, so any other open asking for
+// read, write or delete access fails with ERROR_SHARING_VIOLATION until the
+// returned func runs. It is the deterministic way to hold a job-dir file against
+// a reader. An attribute-only query such as os.Stat is exempt from the
+// share-mode check and still succeeds; nothing here depends on it failing.
 func openExclusive(t *testing.T, path string) func() {
 	t.Helper()
 	p16, err := windows.UTF16PtrFromString(path)
@@ -227,9 +229,10 @@ func openExclusive(t *testing.T, path string) func() {
 func TestJobDirReadersSpendTheBudgetOnAContendedFile(t *testing.T) {
 	const id = "j"
 	for _, tc := range []struct {
-		name  string
-		file  string
-		stage func(t *testing.T, dir string)
+		name string
+		file string
+		// stage puts the file in place; nil when Store.Create already wrote it.
+		stage func(dir string) error
 		// read reports whether the reader returned an answer. Every one of these
 		// reports failure differently, which is itself the reason to drive them
 		// through their real signatures rather than readReplaced directly.
@@ -238,25 +241,24 @@ func TestJobDirReadersSpendTheBudgetOnAContendedFile(t *testing.T) {
 		{
 			name:  "ReadProgressDir",
 			file:  ProgressFile,
-			stage: func(t *testing.T, dir string) { mustStage(t, WriteProgressDir(dir, Progress{StepIndex: 1})) },
+			stage: func(dir string) error { return WriteProgressDir(dir, Progress{StepIndex: 1}) },
 			read:  func(_ *Store, dir string) bool { _, ok := ReadProgressDir(dir); return ok },
 		},
 		{
 			name:  "ReadResultDir",
 			file:  ResultFile,
-			stage: func(t *testing.T, dir string) { mustStage(t, WriteResultDir(dir, []byte(`{"status":"ok"}`))) },
+			stage: func(dir string) error { return WriteResultDir(dir, []byte(`{"status":"ok"}`)) },
 			read:  func(_ *Store, dir string) bool { b, err := ReadResultDir(dir); return err == nil && b != nil },
 		},
 		{
-			name:  "LoadDir",
-			file:  MetaFile,
-			stage: func(t *testing.T, dir string) {}, // Store.Create already wrote meta.json
-			read:  func(_ *Store, dir string) bool { _, err := LoadDir(dir); return err == nil },
+			name: "LoadDir",
+			file: MetaFile,
+			read: func(_ *Store, dir string) bool { _, err := LoadDir(dir); return err == nil },
 		},
 		{
 			name:  "Store.ExitCode",
 			file:  ExitCodeFile,
-			stage: func(t *testing.T, dir string) { mustStage(t, WriteExitCodeDir(dir, 0)) },
+			stage: func(dir string) error { return WriteExitCodeDir(dir, 0) },
 			read:  func(s *Store, _ string) bool { _, ok := s.ExitCode(id); return ok },
 		},
 	} {
@@ -266,7 +268,11 @@ func TestJobDirReadersSpendTheBudgetOnAContendedFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			tc.stage(t, dir)
+			if tc.stage != nil {
+				if err := tc.stage(dir); err != nil {
+					t.Fatal(err)
+				}
+			}
 
 			release := openExclusive(t, filepath.Join(dir, tc.file))
 			defer release()
@@ -284,14 +290,6 @@ func TestJobDirReadersSpendTheBudgetOnAContendedFile(t *testing.T) {
 					"os.ReadFile directly rather than readReplaced", tc.name, tc.file, elapsed, floor)
 			}
 		})
-	}
-}
-
-// mustStage fails the test if a fixture write failed.
-func mustStage(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/internal/jobstore/perms_unix_test.go
+++ b/internal/jobstore/perms_unix_test.go
@@ -49,6 +49,17 @@ func TestCreateAndWriteExitCodeUsePrivatePerms(t *testing.T) {
 	} else if got := ei.Mode().Perm(); got != 0o600 {
 		t.Errorf("exit_code perm = %o, want 600", got)
 	}
+	// The cancel sentinel holds nothing sensitive, but it is a job-dir file and
+	// the contract is uniform: every writer goes through writeFileAtomic, so a
+	// change that loosened the mode there would have to loosen this too.
+	if err := WriteCancelDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	if ci, err := os.Stat(filepath.Join(dir, "cancel")); err != nil {
+		t.Fatal(err)
+	} else if got := ci.Mode().Perm(); got != 0o600 {
+		t.Errorf("cancel perm = %o, want 600", got)
+	}
 }
 
 func TestUpdateMetaPreservesPrivatePerms(t *testing.T) {

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -114,7 +114,7 @@ func WriteProgressDir(dir string, p Progress) error {
 // absent or undecodable: progress is a hint, never a correctness gate, so a
 // caller treats a failed read as "nothing known yet" rather than an error.
 func ReadProgressDir(dir string) (Progress, bool) {
-	b, err := os.ReadFile(ProgressPath(dir))
+	b, err := readReplaced(ProgressPath(dir))
 	if err != nil {
 		return Progress{}, false
 	}
@@ -142,7 +142,7 @@ func WriteResultDir(dir string, b []byte) error {
 // written" would silently downgrade a complete answer to a partial one and tell
 // the caller their result may be truncated when it is on disk and whole.
 func ReadResultDir(dir string) ([]byte, error) {
-	b, err := os.ReadFile(ResultPath(dir))
+	b, err := readReplaced(ResultPath(dir))
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
@@ -163,7 +163,7 @@ func CancelPath(dir string) string { return filepath.Join(dir, CancelFile) }
 // lets it share Load's real read+unmarshal instead of re-implementing it.
 func LoadDir(dir string) (Meta, error) {
 	var m Meta
-	b, err := os.ReadFile(MetaPath(dir))
+	b, err := readReplaced(MetaPath(dir))
 	if err != nil {
 		return m, err
 	}
@@ -188,17 +188,36 @@ func WriteExitCodeDir(dir string, code int) error {
 	return writeFileAtomic(dir, ExitCodeFile, []byte(strconv.Itoa(code)))
 }
 
+// WriteCancelDir creates a job's cancel sentinel, the manager's Windows-only
+// route for asking a supervisor to stop (unix delivers SIGTERM instead, so this
+// has no caller there). Existence is the whole signal, so the file is empty.
+//
+// It goes through writeFileAtomic rather than hand-rolling a temp and a rename,
+// so the job dir has one atomic writer instead of two. Note that the contention
+// retry writeFileAtomic brings with it is not what motivates this: nothing ever
+// opens the sentinel, since the supervisor's poll only Stats it, so this
+// destination is the one that cannot be held by a reader.
+func WriteCancelDir(dir string) error {
+	return writeFileAtomic(dir, CancelFile, nil)
+}
+
 // writeFileAtomic writes b to dir/name via a uniquely-named temp file and a
 // rename, so a reader never observes a partially written file and a crash
 // mid-write leaves either the previous contents or none, never a torn mix. It
 // is the single implementation behind every job-directory write (meta, exit
-// code, progress, result), so none of them can drift into a non-atomic
-// shortcut.
+// code, progress, result, cancel), so none of them can drift into a non-atomic
+// shortcut. out and err are the only job-dir files it does not publish; the
+// supervisor appends to those as agy streams, so they are never replaced.
+//
+// The rename retries a destination another process holds open; see
+// retryContended for why that is reachable on Windows and nowhere else.
 //
 // 0600 throughout: these files record prompts, agy output and job metadata,
 // which often embed source code, so they must not be readable by other users on
-// a multi-user host. os.CreateTemp already creates 0600, so the explicit Chmod
-// only guards a future change to its default.
+// a multi-user host. os.CreateTemp opens at 0600 already (os/tempfile.go:49,
+// go1.26.5), but it does so BEFORE umask, so the explicit Chmod is what
+// restores the mode under a umask that would mask an owner bit, as well as
+// guarding a future change to that default.
 func writeFileAtomic(dir, name string, b []byte) error {
 	tmp, err := os.CreateTemp(dir, name+"-*.tmp")
 	if err != nil {
@@ -226,7 +245,7 @@ func writeFileAtomic(dir, name string, b []byte) error {
 		_ = os.Remove(tmpName)
 		return err
 	}
-	if err := os.Rename(tmpName, filepath.Join(dir, name)); err != nil {
+	if err := renameReplace(tmpName, filepath.Join(dir, name)); err != nil {
 		_ = os.Remove(tmpName)
 		return err
 	}
@@ -391,7 +410,7 @@ func (s *Store) ExitCode(id string) (int, bool) {
 	if !validJobID(id) {
 		return 0, false
 	}
-	b, err := os.ReadFile(ExitCodePath(s.jobDir(id)))
+	b, err := readReplaced(ExitCodePath(s.jobDir(id)))
 	if err != nil {
 		return 0, false
 	}

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -214,10 +214,10 @@ func WriteCancelDir(dir string) error {
 //
 // 0600 throughout: these files record prompts, agy output and job metadata,
 // which often embed source code, so they must not be readable by other users on
-// a multi-user host. os.CreateTemp opens at 0600 already (os/tempfile.go:49,
-// go1.26.5), but it does so BEFORE umask, so the explicit Chmod is what
-// restores the mode under a umask that would mask an owner bit, as well as
-// guarding a future change to that default.
+// a multi-user host. os.CreateTemp asks for 0600 (os/tempfile.go:49, go1.26.5),
+// but that request still passes through the process umask, so the file can land
+// tighter than 0600. The explicit Chmod sets the mode outright, which pins the
+// contract against both a umask and a future change to CreateTemp's default.
 func writeFileAtomic(dir, name string, b []byte) error {
 	tmp, err := os.CreateTemp(dir, name+"-*.tmp")
 	if err != nil {

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -187,6 +188,52 @@ func TestExitCodeSentinel(t *testing.T) {
 	code, ok := s.ExitCode("j")
 	if !ok || code != 0 {
 		t.Fatalf("ExitCode = %d,%v", code, ok)
+	}
+}
+
+// TestWriteCancelDirCreatesAnEmptySentinelWhereTheSupervisorLooks pins the
+// cancel sentinel's contract, which is unusual in that the file's existence is
+// the entire message: the manager writes it (Windows only, where there is no
+// signal to send) and the supervisor's poll does nothing but Stat CancelPath.
+//
+// Both properties asserted here are load-bearing. Writing it where CancelPath
+// reads is what makes the two processes agree, and a second Cancel of the same
+// job has to stay a success, because the manager's Cancel is reachable more than
+// once for one job and a caller reads an error as "the cancel did not happen".
+func TestWriteCancelDirCreatesAnEmptySentinelWhereTheSupervisorLooks(t *testing.T) {
+	s := New(t.TempDir())
+	dir, err := s.Create(Meta{ID: "j"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(CancelPath(dir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Stat before the write = %v, want the sentinel absent", err)
+	}
+	if err := WriteCancelDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(CancelPath(dir))
+	if err != nil {
+		t.Fatalf("sentinel not written where CancelPath reads: %v", err)
+	}
+	if len(b) != 0 {
+		t.Errorf("sentinel content = %q, want empty: existence is the whole signal", b)
+	}
+	// Replacing an existing sentinel must not fail, so a repeated cancel is not
+	// reported as an error.
+	if err := WriteCancelDir(dir); err != nil {
+		t.Errorf("second WriteCancelDir = %v, want nil", err)
+	}
+	// The temp file the atomic write goes through must not survive it, or the
+	// job dir accumulates one per cancel.
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range ents {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file %q after the atomic write", e.Name())
+		}
 	}
 }
 

--- a/internal/manager/cancel_windows.go
+++ b/internal/manager/cancel_windows.go
@@ -1,38 +1,24 @@
 package manager
 
 import (
-	"os"
-
 	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
 )
 
 // requestCancel writes the cancel sentinel file the supervisor polls for. Windows
 // has no POSIX signal to deliver to an arbitrary process, so the manager and
 // supervisor communicate the cancel through the shared on-disk job dir instead.
-// The supervisor only checks for the file's existence, so no content or atomic
-// write is needed; the file persists until the job dir is removed, so a cancel
-// requested before the supervisor starts polling is never lost.
+// The supervisor only checks for the file's existence, so no content is needed;
+// the file persists until the job dir is removed, so a cancel requested before
+// the supervisor starts polling is never lost.
+//
+// jobstore owns the write, as it does for every job-dir file it defines a
+// writer for. That keeps the sentinel on the one atomic-write path (temp file
+// plus rename, so a future content-reading consumer can never see a half-written
+// file) rather than hand-rolling a second one here.
 func (m *Manager) requestCancel(meta jobstore.Meta) error {
 	dir, err := m.store.Dir(meta.ID)
 	if err != nil {
 		return err
 	}
-	// Create the sentinel atomically (temp file + rename), matching the rest of the
-	// job-dir contract (meta.json, exit_code). The supervisor only checks the file's
-	// existence, so an empty file is already a valid signal; the rename additionally
-	// keeps any future content-reading consumer from ever seeing a half-written file.
-	tmp, err := os.CreateTemp(dir, "cancel-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	if err := os.Rename(tmpName, jobstore.CancelPath(dir)); err != nil {
-		_ = os.Remove(tmpName)
-		return err
-	}
-	return nil
+	return jobstore.WriteCancelDir(dir)
 }

--- a/internal/supervisor/supervisor_windows_test.go
+++ b/internal/supervisor/supervisor_windows_test.go
@@ -148,7 +148,9 @@ func TestRunCancelViaSentinel(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if err := os.WriteFile(jobstore.CancelPath(dir), nil, 0o600); err != nil {
+	// Through the canonical writer the manager uses, so this test cannot drift
+	// from the shape requestCancel actually produces.
+	if err := jobstore.WriteCancelDir(dir); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/supervisor/waitcancel_windows_test.go
+++ b/internal/supervisor/waitcancel_windows_test.go
@@ -1,7 +1,6 @@
 package supervisor
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -19,7 +18,9 @@ func TestWaitForCancelFiresOnSentinel(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	if err := os.WriteFile(jobstore.CancelPath(dir), nil, 0o600); err != nil {
+	// Through the canonical writer the manager uses, so this test cannot drift
+	// from the shape requestCancel actually produces.
+	if err := jobstore.WriteCancelDir(dir); err != nil {
 		t.Fatal(err)
 	}
 	select {


### PR DESCRIPTION
Closes three hardening items from #96, plus the reader-side half of the same hazard that the pre-push review turned up.

## The bug

Every file in a job dir except `out` and `err` is published by writing a temp file and renaming it into place. On Windows that replace needs DELETE access to the destination, which the OS refuses while any handle to it is open without `FILE_SHARE_DELETE`, and Go's `os.Open` does not request that share mode. `os.Open` reaches `syscall.Open` (`os/file_windows.go:158`), which sets `FILE_SHARE_READ|FILE_SHARE_WRITE` (`syscall_windows.go:395`, passed to `createFile` unmodified), and `os.Rename` is `MoveFileEx(from, to, MOVEFILE_REPLACE_EXISTING)` (`internal/syscall/windows/syscall_windows.go:366`). All read against go1.26.5.

So a reader and a writer of one job-dir file can each fail because of the other, and both directions happen in ordinary use:

- **`meta.json` is the expensive one.** `StartJob` rewrites it to record the supervisor's pid while the supervisor it just spawned reads it. Whichever side loses, the job dies at startup: the rename failure takes `abortSpawn` ("record supervisor pid"), and `LoadDir`'s error aborts the run before agy is exec'd.
- **`progress.json` is the frequent one.** `consumeStream` republishes it on each observable step change while `Status` reads it on every poll of a running job and `awaitConversationID` reads it every 50ms. The write is best-effort, so a collision silently drops a progress update.

## The change

Both sides retry a contended file on a bounded budget: ten attempts, backoff doubling from 1ms to a 50ms cap, 213ms of waiting in the worst case for one operation. Off Windows the predicate is constant-false and the loop runs once, since neither `rename(2)` nor `open(2)` is blocked by another process holding the old file open.

The Go command's own tree hardens this same hazard the same way in `cmd/internal/robustio`, wrapping both `Rename` and `ReadFile` and citing go.dev/issue/31247 and go.dev/issue/32188. One deliberate divergence: `robustio`'s predicate also treats `ERROR_FILE_NOT_FOUND` as ephemeral and this one does not. Absence is a load-bearing answer for three of the four readers (no result payload, no exit-code sentinel, no progress yet), and `Store.ExitCode` is polled throughout a running job precisely when the sentinel is absent by definition, so retrying absence would spend the whole budget on the hot path of every poll.

The cancel sentinel stops hand-rolling its own temp and rename and becomes `jobstore.WriteCancelDir`, so the job dir has one atomic writer instead of two. Two supervisor tests that staged the sentinel by hand now use it as well.

## Verification, and its one real gap

I develop on macOS and **cannot execute the Windows tests**. CI's `windows-latest` job runs the full suite (without `-race`) and is the real verification for everything Windows-specific here; everything below marked local is darwin.

Local: full suite green including `-race`; `golangci-lint` v2.12.2 clean; gofmt clean; darwin, linux and windows all build and vet; the Windows test binaries cross-compile.

15 mutations of the production lines were each confirmed to turn a named test red. Two survive on darwin by construction (`readReplaced` reverted to `os.ReadFile`, `renameReplace` reverted to `os.Rename`), because off Windows the predicate is constant-false and the two are indistinguishable. Only the Windows job can kill those.

The Windows tests release the contending handle from **inside** the operation, immediately after the attempt it is meant to defeat, so they assert the retry with no timing margin rather than racing a sleep. They also fail loudly rather than passing quietly if the OS premise is wrong: reaching a second attempt is what proves the first one failed, so if `MoveFileEx` ever stops behaving this way the test says so.

## Measured, and deliberately not changed

The retry costs **+1.23 ns/op and +0 allocs** against a 4.82 ms fsync-bound write (1 part in 3.9 million), measured on an M4 Pro with both arms interleaved in one binary. The closure does not escape and `renameReplace` inlines into `writeFileAtomic`. A struct-with-methods alternative benchmarked *worse*, so the parameter-injection shape stands.

Three things were considered and rejected with evidence rather than filed, to keep them from becoming backlog:

- **`os.Root.Rename`** reaches `NtSetInformationFile` with `FILE_RENAME_POSIX_SEMANTICS`, which might avoid the collision rather than retry it. It needs an `*os.Root` per job dir that the package-level dir-based helpers do not have, and whether it clears a violation against a destination someone else holds open is NOT MEASURED. Recorded in the code so the next reader does not re-derive it.
- **The `name + "-*.tmp"` allocation** in `writeFileAtomic`: measured at ~24 B of a 1.281 KiB, 4.82 ms call, four orders of magnitude below the noise floor.
- **The gate-key hold** in `StartJob` can grow by up to 213ms on Windows when `meta.json` is contended. Bounded, far under every deadline in the repo, and the previous behaviour (fast failure) was worse.

## Review

Seven parallel review agents plus a Gemini cross-check ran over this before push, then a report-only reviewer over the fix wave itself. The findings were overwhelmingly prose rather than behaviour, which is what this repo's authoring rules predict: false or overclaiming comments, each disproved by a grep or a source read. Those are fixed in place.

One Gemini finding is worth recording because it was confidently wrong: it rated as CRITICAL that `errors.Is` could never match, on the grounds that `windows.Errno` and `syscall.Errno` are distinct types, which would have made the whole retry inert. `windows.Errno` is a type *alias* (`aliases.go:12`), both constants are declared directly as `syscall.Errno` (`zerrors_windows.go:158,185`), the stdlib uses this exact idiom at `os/os_windows_test.go:1344`, and its suggested patch would not have compiled, since `syscall` does not export `ERROR_SHARING_VIOLATION` at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of job progress, result, metadata, exit-code, and cancellation file operations on Windows.
  - Automatically retries transient file contention with capped backoff, helping operations succeed while files are open.
  - Preserves atomic file replacement behavior and prevents incomplete or stale file reads.
  - Standardized creation of cancellation signals with secure permissions and cleanup of temporary files.

- **Tests**
  - Added comprehensive Windows and non-Windows coverage for contention, retries, atomic replacement, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->