### PR TITLE
manager: hoist the conversation-id wait out of StartJob into agy_run (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ created for it. agy names the conversation in the `init` event of its stream, wh
 about a second after the process starts, so `agy_run` waits briefly (up to 2s) for it and
 returns a real `conversation_id`. If the wait expires the field comes back empty and
 `agy_status` supplies it moments later; either way the thread can be continued.
+`agy_run_sync` does not pay that wait: it takes its `conversation_id` from the status it
+is already polling. That is also what makes its `wait` cap honest, because the
+conversation-id wait used to run before the inline wait's deadline was set, so a short
+`wait` could be overrun by up to the 2s budget. The trade is that a `wait` shorter than
+agy's init latency now returns an empty `conversation_id`, which `agy_status` supplies.
 
 **Fresh runs are not serialized.** Any number of them can run in one directory at the same
 time, bounded only by the global concurrency cap. Earlier versions refused a second fresh run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,13 +21,11 @@ type Config struct {
 	JobTTL         time.Duration // age after which finished jobs are GC'd
 	HTTPToken      string        // optional bearer token for HTTP mode; empty = unauthenticated
 
-	// ConversationIDWait bounds how long StartJob blocks waiting for agy to name the
-	// conversation it created, so a fresh run can report a real conversation id
-	// instead of an empty one. It is the largest of the bounded waits StartJob
-	// performs before returning (the agy version gate is the other, and is
-	// cached after the first success), so it is a field rather than a constant:
-	// a test with a fake supervisor that never writes a progress file would
-	// otherwise pay the full budget on every start. Zero disables the wait.
+	// ConversationIDWait bounds how long Manager.AwaitConversationID blocks waiting
+	// for agy to name the conversation it created, so a fresh agy_run can report a
+	// real conversation id instead of an empty one. It is a field rather than a
+	// constant so that a test whose fake supervisor records no conversation id
+	// does not pay the full budget on every agy_run. Zero disables the wait.
 	ConversationIDWait time.Duration
 
 	// ConversationCacheFile overrides where agy's conversation cache
@@ -48,7 +46,7 @@ func baseConfig() Config {
 	}
 }
 
-// DefaultConversationIDWait is how long StartJob waits for agy's init event to name the
+// DefaultConversationIDWait is how long agy_run waits for agy's init event to name the
 // conversation. agy emits it before any model work but after its own startup,
 // which includes launching whatever MCP servers it is configured with, so the
 // budget is generous relative to the roughly one second observed against a warm

--- a/internal/jobstore/contention.go
+++ b/internal/jobstore/contention.go
@@ -46,7 +46,7 @@ const (
 //     direction: LoadDir's error aborts the job before it starts.
 //   - progress.json. consumeStream republishes it on each observable step
 //     change, while Status reads it on every poll of a running job and
-//     awaitConversationID reads it every 50ms.
+//     AwaitConversationID reads it every 50ms.
 //
 // The Go command's own tree hardens both sides of this same hazard for the same
 // reason: cmd/internal/robustio wraps Rename ("on Windows retries errors that

--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -195,13 +194,7 @@ func TestStartJobRunsFreshSameCwdRunsConcurrently(t *testing.T) {
 	// Reap the whole supervisor group (bash + the sleeping fake agy) promptly,
 	// regardless of how the test exits; the fake supervisor does not forward
 	// signals, so Cancel alone would leave the sleep running.
-	t.Cleanup(func() {
-		// Guard the PID: syscall.Kill(-0, ...) would signal the test runner's own
-		// process group, and a negative target needs a real group leader.
-		if meta, lerr := m.store.Load(job1.ID); lerr == nil && meta.PID > 0 {
-			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
-		}
-	})
+	killJob(t, m, job1.ID)
 
 	job2, err := m.StartJob(StartRequest{Prompt: "second", Cwd: dir + "/"})
 	if err != nil {
@@ -210,11 +203,7 @@ func TestStartJobRunsFreshSameCwdRunsConcurrently(t *testing.T) {
 	if job2.ID == job1.ID {
 		t.Fatal("the two runs must be distinct jobs")
 	}
-	t.Cleanup(func() {
-		if meta, lerr := m.store.Load(job2.ID); lerr == nil && meta.PID > 0 {
-			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
-		}
-	})
+	killJob(t, m, job2.ID)
 }
 
 // TestStartJobSerializesSameConversation pins what the gate still enforces: two
@@ -236,11 +225,7 @@ func TestStartJobSerializesSameConversation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first StartJob: %v", err)
 	}
-	t.Cleanup(func() {
-		if meta, lerr := m.store.Load(job1.ID); lerr == nil && meta.PID > 0 {
-			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
-		}
-	})
+	killJob(t, m, job1.ID)
 
 	_, err = m.StartJob(StartRequest{Prompt: "second", Cwd: dir, ConversationID: conv})
 	if err == nil || !strings.Contains(err.Error(), "already running on conversation") {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -44,9 +44,9 @@ type Manager struct {
 	readAgyVersion func(context.Context, string) (string, error)
 
 	// Timing fields (not package globals) so tests stay isolated and can run in
-	// parallel. conversationIDWait bounds StartJob's wait for agy's init event;
-	// restoredPollInterval paces the liveness watcher for jobs whose supervisor
-	// outlived a manager restart.
+	// parallel. conversationIDWait bounds AwaitConversationID's wait for agy's
+	// init event; restoredPollInterval paces the liveness watcher for jobs whose
+	// supervisor outlived a manager restart.
 	conversationIDWait   time.Duration
 	restoredPollInterval time.Duration
 
@@ -211,24 +211,43 @@ func readAgyVersion(ctx context.Context, agy string) (string, error) {
 // progress file. Its budget is config.ConversationIDWait.
 const conversationIDPoll = 50 * time.Millisecond
 
-// awaitConversationID polls a freshly spawned job's progress file until the
-// supervisor records the conversation id agy reported, the job turns out to be
-// over, or the budget expires. It returns "" when no id arrived, which is not an
-// error: the id is still delivered by the next Status read.
+// AwaitConversationID reports the conversation a run belongs to. A run that
+// already names one (a continuation) returns it at once; a fresh one polls the
+// job's progress file until the supervisor records the id agy reported, the job
+// turns out to be over, or the budget expires. It returns "" when no id arrived,
+// which is not an error: the id is still delivered by the next Status read.
 //
-// The budget is the only place agy_run is not return-immediately, so it exits at
+// It is deliberately not part of StartJob. Only agy_run needs the id in its own
+// response, because it returns before the run produces anything else; agy_run_sync
+// takes it off the Status it already polls. While StartJob did the wait, agy_run_sync
+// paid it before its own inline-wait deadline was set (run_sync.go computes that
+// deadline from the time StartJob returns), so a call that outran the deadline overran
+// its documented wait cap by roughly the budget. A call whose run ends inside the wait
+// saw no saving at all, because the wait overlapped the run rather than preceding it.
+//
+// The budget is why agy_run is not return-immediately (the agy version gate is the
+// other bounded wait, and only until it succeeds once), so it exits at
 // the first opportunity rather than always sleeping it out. A terminal job is
 // one such opportunity: the supervisor writes the progress file while decoding
 // the stream and the exit-code sentinel only at the very end, so a visible
 // sentinel with no recorded id means none is coming (the run died before agy's
 // init event, or never started at all).
-func (m *Manager) awaitConversationID(id, dir string) string {
+func (m *Manager) AwaitConversationID(job Job) string {
+	if job.ConversationID != "" {
+		return job.ConversationID
+	}
+	// A job id this manager did not issue has no conversation to wait for, which is
+	// the same answer an expired budget gives.
+	dir, err := m.store.Dir(job.ID)
+	if err != nil {
+		return ""
+	}
 	deadline := time.Now().Add(m.conversationIDWait)
 	for {
 		if p, ok := jobstore.ReadProgressDir(dir); ok && p.ConversationID != "" {
 			return p.ConversationID
 		}
-		if _, terminal := m.store.ExitCode(id); terminal {
+		if _, terminal := m.store.ExitCode(job.ID); terminal {
 			// Re-read before giving up. The supervisor writes the progress file
 			// before the sentinel, so a job that finished between the two reads
 			// above has its id on disk even though the first read missed it;
@@ -249,7 +268,7 @@ func (m *Manager) awaitConversationID(id, dir string) string {
 //
 // The gate key alone cannot answer this. A fresh run keys on nothing (agy has
 // not named its conversation yet at admission time), but the supervisor records
-// that name in progress.json within about a second, and StartJob hands it to the
+// that name in progress.json within about a second, and agy_run reports it to the
 // caller. Without this scan a caller could take a still-running fresh run's id,
 // pass it straight back as conversation_id, and be admitted under a conv key
 // nobody holds, putting two agy sessions on one conversation: exactly the
@@ -515,16 +534,11 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 		m.releaseKey(key)
 	}()
 
-	// A run that already knows its conversation reports it immediately. A fresh
-	// one waits briefly for agy's init event to name the conversation it created,
-	// so the caller can continue the thread without first polling for an id. The
-	// wait is bounded and its expiry is not an error: agy_status reports the id
-	// as soon as the event lands.
-	convID := req.ConversationID
-	if convID == "" {
-		convID = m.awaitConversationID(id, dir)
-	}
-	return Job{ID: id, ConversationID: convID, State: StateRunning}, nil
+	// The conversation id is not resolved here. A continuation already carries it;
+	// a fresh run is named by agy's init event a moment later, and waiting for that
+	// is AwaitConversationID's job, paid only by the caller that reports the id in
+	// its own response.
+	return Job{ID: id, ConversationID: req.ConversationID, State: StateRunning}, nil
 }
 
 // abortSpawn tears down a supervisor that was started but cannot be recorded as

--- a/internal/manager/testhelpers_test.go
+++ b/internal/manager/testhelpers_test.go
@@ -58,10 +58,13 @@ func newManager(t *testing.T, opts managerOpts) *Manager {
 		version = agyver.Required.String()
 	}
 	m.readAgyVersion = testutil.FakeVersion(version)
-	// Keep the fresh-run conversation-id wait short: these tests use fake
-	// supervisors, whose progress file records no conversation id unless a fake
-	// agy supplies one, so the real 2s budget would be spent in full on every
-	// StartJob.
+	// Pin the conversation-id wait at zero. It already is: this Config is a
+	// literal, and config.DefaultConversationIDWait is applied only by
+	// config.baseConfig, which Resolve and ResolveWait call and this helper does
+	// not. Writing it down keeps a future switch to a resolved config here from
+	// silently handing every test a real budget, against fake supervisors whose
+	// progress file records no conversation id unless a fake agy supplies one. A
+	// test that exercises the wait sets its own budget.
 	m.conversationIDWait = 0
 	return m
 }

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -57,7 +57,10 @@ func TestWaitTerminalReturnsDoneJob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	testutil.WaitFor(t, 3*time.Second, func() bool {
+	// 5s, the package's usual bound for this shape. It waits on a spawned supervisor
+	// and a forked fake agy, so the deadline is bounded by machine load rather than
+	// by anything under test, and at 3s it flaked on a loaded full-suite run.
+	testutil.WaitFor(t, 5*time.Second, func() bool {
 		st, err := m.Status(job.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -230,17 +233,9 @@ func TestStatusReportsConversationIDWhileRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	// Cancel signals the supervisor pid only, and the fake supervisor does not
-	// forward signals, so the sleeping fake agy would outlive the test and race
-	// t.TempDir teardown. Kill the whole group, as the sibling fixture in
-	// job_posix_test.go does.
-	t.Cleanup(func() {
-		if meta, lerr := m.store.Load(job.ID); lerr == nil && meta.PID > 0 {
-			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
-		}
-	})
+	killJob(t, m, job.ID)
 
-	testutil.WaitFor(t, 3*time.Second, func() bool {
+	testutil.WaitFor(t, 5*time.Second, func() bool {
 		st, err := m.Status(job.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -302,44 +297,174 @@ func TestStatusFailsOnInBandError(t *testing.T) {
 	}
 }
 
-// StartJob returning a fresh run's conversation id is the headline behaviour of
-// the change, and every other test forces its budget to zero, so gutting
-// awaitConversationID to return "" left the suite green. Drive it with a real
-// budget instead.
-func TestStartJobReturnsFreshConversationIDWithinBudget(t *testing.T) {
-	fake := testutil.FakeAgy{Stdout: "OK", Sleep: 30 * time.Second, ConversationID: "77777777-6666-5555-4444-333322221111"}
+// killJob arranges for a still-running job's process group to be SIGKILLed when
+// the test ends, so a fake agy does not outlive its test and keep writing into a
+// TempDir state dir that is being removed. Cancel is not an alternative: it
+// signals the supervisor pid alone and the fake supervisor forwards nothing, so
+// the fake agy it runs in the foreground survives.
+//
+// The PID guard is load-bearing rather than defensive: syscall.Kill(-0, ...)
+// would signal the test runner's own process group. The Kill error is discarded
+// because ESRCH, for a group that has already exited, is the ordinary case; the
+// pid is read from disk, so a recycled one is possible in principle and unguarded
+// here, which is tolerable only because this is test-only cleanup.
+//
+// Like the inline cleanups it replaced, it signals and returns without waiting for
+// the group to die, which is enough for the purpose.
+func killJob(t *testing.T, m *Manager, id string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if meta, err := m.store.Load(id); err == nil && meta.PID > 0 {
+			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
+		}
+	})
+}
+
+// StartJob must not resolve a conversation id. It used to, and agy_run_sync
+// discarded the result. Resolving it is AwaitConversationID's job now.
+//
+// The fixture is what makes this falsifiable: the fake supervisor stages an id in
+// progress.json before agy starts, so a StartJob that still waited would find one
+// and hand it back, and the empty value is the proof the wait is gone. An
+// id-less fixture would report empty either way.
+// TestAgyRunSyncDoesNotPayTheConversationIDBudget covers the latency half.
+func TestStartJobDoesNotResolveAConversationID(t *testing.T) {
+	fake := testutil.FakeAgy{Stdout: "OK", Sleep: 30 * time.Second, ConversationID: "88888888-7777-6666-5555-444433332222"}
 	m := waitManager(t, fake)
-	m.conversationIDWait = 5 * time.Second // the production behaviour, not the zeroed test default
+	m.conversationIDWait = 30 * time.Second // a wait left in StartJob would have room to find the id
 
 	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	t.Cleanup(func() {
-		if meta, lerr := m.store.Load(job.ID); lerr == nil && meta.PID > 0 {
-			_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
-		}
-	})
-	if job.ConversationID != fake.ConvID() {
-		t.Fatalf("StartJob conversation_id = %q, want %q from agy's init event", job.ConversationID, fake.ConvID())
+	killJob(t, m, job.ID)
+	if job.ConversationID != "" {
+		t.Fatalf("StartJob conversation_id = %q, want empty: a fresh run is named by AwaitConversationID, not here", job.ConversationID)
+	}
+}
+
+// The budget has to actually expire. Moving the wait out of StartJob cost this
+// branch the coverage it had by accident, since every fresh-run test used to
+// traverse it; without this test, neutering the deadline check leaves both
+// packages green. What it would break is agy_run, whose whole contract is to
+// return promptly: a wait that cannot expire blocks it for the length of the run.
+func TestAwaitConversationIDGivesUpWhenTheBudgetExpires(t *testing.T) {
+	// Never names a conversation and outlives the budget many times over, so
+	// neither early exit can fire and only the deadline can end the wait.
+	fake := testutil.FakeAgy{Stdout: "OK", Sleep: 30 * time.Second, NoConversationID: true}
+	m := waitManager(t, fake)
+	const budget = 300 * time.Millisecond
+	m.conversationIDWait = budget
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	killJob(t, m, job.ID)
+	start := time.Now()
+	got := m.AwaitConversationID(job)
+	elapsed := time.Since(start)
+	if got != "" {
+		t.Fatalf("AwaitConversationID = %q, want empty: this run never names a conversation", got)
+	}
+	// Both bounds are load-bearing, and neither alone pins the deadline.
+	//
+	// The lower one separates "the budget ran out" from "an early exit fired",
+	// since only the former reaches the deadline at all.
+	//
+	// The upper one is what catches a deadline that never fires. Without it the
+	// wait simply runs on until the fake agy exits and the terminal-job branch
+	// ends it, returning the same empty id after ~30s, which clears the lower
+	// bound trivially and passes. Measured that way: 30.55s.
+	if elapsed < budget {
+		t.Fatalf("AwaitConversationID returned in %s, inside the %s budget: an early exit fired, so the deadline was never reached", elapsed, budget)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("AwaitConversationID took %s against a %s budget: the deadline never fired and some later exit ended the wait", elapsed, budget)
+	}
+}
+
+// A job id the store refuses resolves to no conversation, rather than spending
+// the budget polling the empty path Dir returns alongside its error. This is the
+// only test that reaches that branch: the continuation test passes an id this
+// manager never issued too, but short-circuits on the id it carries before Dir
+// is ever called.
+func TestAwaitConversationIDRejectsAnUnusableJobID(t *testing.T) {
+	m := newManager(t, managerOpts{})
+	m.conversationIDWait = 30 * time.Second
+
+	start := time.Now()
+	got := m.AwaitConversationID(Job{ID: "../escape"})
+	elapsed := time.Since(start)
+	if got != "" {
+		t.Fatalf("AwaitConversationID = %q, want empty for a job id the store rejects", got)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("AwaitConversationID polled for %s on a job id the store rejects", elapsed)
+	}
+}
+
+// AwaitConversationID returning a fresh run's conversation id is the headline
+// behaviour of the stream-json change, and the shared test manager leaves its
+// budget at zero, so gutting it to return "" left the suite green. Drive it with
+// a real budget instead.
+func TestAwaitConversationIDReturnsFreshIDWithinBudget(t *testing.T) {
+	fake := testutil.FakeAgy{Stdout: "OK", Sleep: 30 * time.Second, ConversationID: "77777777-6666-5555-4444-333322221111"}
+	m := waitManager(t, fake)
+	m.conversationIDWait = 5 * time.Second // a real budget, not the zero the shared helper leaves
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	killJob(t, m, job.ID)
+	if got := m.AwaitConversationID(job); got != fake.ConvID() {
+		t.Fatalf("AwaitConversationID = %q, want %q from agy's init event", got, fake.ConvID())
 	}
 }
 
 // A run that is already over when the wait starts must return at once rather
 // than sleeping out the whole budget for an id that is never coming.
-func TestStartJobConversationWaitStopsAtTerminalJob(t *testing.T) {
-	// No Agy config, so the fake supervisor writes no progress file at all, and
-	// it exits immediately.
+func TestAwaitConversationIDStopsAtTerminalJob(t *testing.T) {
+	// No Agy config, so the only progress file the fake supervisor stages is the
+	// marker, which carries no conversation id, and it exits immediately.
 	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: "x", Exit: 0})
 	sup := testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"})
 	m := newManager(t, managerOpts{agyPath: agy, supervisorExe: sup, defaultTimeout: time.Minute, maxConcurrency: 4, withCacheFile: true})
 	m.conversationIDWait = 30 * time.Second // long enough that sleeping it out would fail the test
 
-	start := time.Now()
-	if _, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()}); err != nil {
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
-	if elapsed := time.Since(start); elapsed > 10*time.Second {
-		t.Fatalf("StartJob took %s; a terminal job must end the conversation-id wait early", elapsed)
+	start := time.Now()
+	got := m.AwaitConversationID(job)
+	elapsed := time.Since(start)
+	if got != "" {
+		t.Fatalf("AwaitConversationID = %q, want empty: this run reports no id", got)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("AwaitConversationID took %s; a terminal job must end the wait early", elapsed)
+	}
+}
+
+// A continuation already carries the id, so the wait must never start: polling
+// for a value that is already in hand would spend the budget on a job dir that
+// may not even be readable yet.
+func TestAwaitConversationIDShortCircuitsAContinuation(t *testing.T) {
+	// No agy and no supervisor: this test starts no job, it only asks about one.
+	m := newManager(t, managerOpts{})
+	m.conversationIDWait = 30 * time.Second
+
+	const convID = "11111111-2222-3333-4444-555555555555"
+	start := time.Now()
+	// No such job dir, so a wait that did start would poll out its whole budget.
+	got := m.AwaitConversationID(Job{ID: "no-such-job", ConversationID: convID})
+	elapsed := time.Since(start)
+	if got != convID {
+		t.Fatalf("AwaitConversationID = %q, want %q handed straight back", got, convID)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("AwaitConversationID took %s for an id it was given", elapsed)
 	}
 }

--- a/internal/mcptools/run_sync_posix_test.go
+++ b/internal/mcptools/run_sync_posix_test.go
@@ -9,11 +9,13 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/agy-mcp/v2/internal/config"
+	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
 	"github.com/tphakala/agy-mcp/v2/internal/manager"
 	"github.com/tphakala/agy-mcp/v2/internal/testutil"
 )
@@ -27,7 +29,19 @@ const testConversationID = "abcdabcd-1234-5678-9abc-def012345678"
 // conversation cache is a test-owned empty file: it is no longer where a run's
 // id comes from, only where continue_latest and list_sessions look, so pointing
 // it away from the real agy cache is all that is needed.
+//
+// The conversation-id budget is left at zero, which no test needs to opt out of
+// unless it is about the budget itself: only agy_run spends it, and no test here
+// asserts on a fresh run's conversation_id at a moment when the supervisor may
+// not have staged it yet.
 func newTestManager(t *testing.T, fake testutil.FakeAgy) (mgr *manager.Manager, stateDir string) {
+	t.Helper()
+	return newTestManagerWithIDWait(t, fake, 0)
+}
+
+// newTestManagerWithIDWait is newTestManager with a real conversation-id budget,
+// for the tests that pin which tool pays it.
+func newTestManagerWithIDWait(t *testing.T, fake testutil.FakeAgy, idWait time.Duration) (mgr *manager.Manager, stateDir string) {
 	t.Helper()
 	if fake.ConversationID == "" && !fake.NoConversationID {
 		fake.ConversationID = testConversationID
@@ -41,6 +55,7 @@ func newTestManager(t *testing.T, fake testutil.FakeAgy) (mgr *manager.Manager, 
 	stateDir = t.TempDir()
 	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
 		DefaultTimeout: time.Minute, MaxConcurrency: 4,
+		ConversationIDWait:    idWait,
 		ConversationCacheFile: cachePath}
 	return manager.New(c), stateDir
 }
@@ -306,6 +321,81 @@ func TestAgyRunSyncReturnsConversationID(t *testing.T) {
 	}
 	if usage["total_tokens"] != float64(15) {
 		t.Fatalf("usage.total_tokens = %v, want 15", usage["total_tokens"])
+	}
+}
+
+// killJobGroup arranges for a still-running job's process group to be SIGKILLed
+// when the test ends, so a fake agy does not outlive its test and keep writing
+// into a TempDir state dir that is being removed.
+//
+// Cancelling the job does not achieve this, which is why this kills the group
+// directly: agy_cancel signals the supervisor pid alone (proc.Signal is explicitly
+// "a single pid, not its group"), and the fake supervisor traps nothing, so it
+// dies at once and orphans the fake agy it was running in the foreground. The
+// manager package's killJob exists for the same reason. Registering a Cleanup
+// rather than calling this at the end of a test body also means it runs on the
+// t.Fatalf paths, which is where a leaked job is most likely.
+func killJobGroup(t *testing.T, stateDir, jobID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		// No readable meta means no pid to signal: the job either never recorded
+		// one or is already gone. ESRCH on an exited group is the ordinary case,
+		// so the Kill error is discarded.
+		meta, err := jobstore.LoadDir(filepath.Join(stateDir, "jobs", jobID))
+		if err != nil || meta.PID <= 0 {
+			return
+		}
+		_ = syscall.Kill(-meta.PID, syscall.SIGKILL)
+	})
+}
+
+// agy_run_sync must not pay the conversation-id budget. It discards the value:
+// its own conversation_id comes off the Status it polls anyway, which
+// TestAgyRunSyncReturnsConversationID pins. While the wait lived in StartJob,
+// agy_run_sync paid it before its own inline-wait deadline was even set, so a
+// call that outran the deadline overran its documented wait cap by the budget.
+func TestAgyRunSyncDoesNotPayTheConversationIDBudget(t *testing.T) {
+	// Names no conversation, so no id can end the wait early, and outlives the
+	// 100ms cap by far, so the call is decided by the cap rather than by the run
+	// finishing. The run does end before the 30s budget would, through the
+	// terminal-job exit; what this measures is that the budget is not on the path
+	// at all, not that it runs to its full length.
+	mgr, stateDir := newTestManagerWithIDWait(t, testutil.FakeAgy{
+		Stdout: "LATE OK", Exit: 0, Sleep: 20 * time.Second, NoConversationID: true,
+	}, 30*time.Second)
+	cs := connect(t, mgr, nil)
+
+	start := time.Now()
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run_sync",
+		Arguments: map[string]any{"prompt": "review", "wait": "100ms"},
+	})
+	elapsed := time.Since(start)
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run_sync: err=%v res=%+v", err, res)
+	}
+	sc := structMap(t, res.StructuredContent)
+	jobID, _ := sc["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+	killJobGroup(t, stateDir, jobID)
+	// Checked first, because it is the property under test and its message names
+	// the cause. A wait left on this path also drags the run past the cap, which
+	// trips the state assertion below with a less useful diagnosis.
+	// Generous against a stalled runner, and still far below what this call takes
+	// with the wait restored: measured at 20.5s, where the run's own end releases
+	// it through the terminal-job exit before the 30s budget could.
+	if elapsed > 5*time.Second {
+		t.Fatalf("agy_run_sync took %s for a 100ms wait; it is paying the conversation-id budget", elapsed)
+	}
+	// Pin the overrun shape too, so the elapsed bound cannot be satisfied by a
+	// handler that never waited, never started the job, or ignored the cap.
+	if sc["state"] != manager.StateRunning {
+		t.Fatalf("state = %v, want running: the 100ms cap must expire on a 20s run", sc["state"])
+	}
+	if note, _ := sc["note"].(string); note == "" {
+		t.Fatal("expected an overrun note alongside the running state")
 	}
 }
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -149,7 +149,7 @@ type statusOutput struct {
 	Elapsed        string `json:"elapsed" jsonschema:"wall-clock time the job has run, frozen at completion once terminal"`
 	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set on any terminal state whose text could be recovered, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first. A running job carries none even once it has produced text, so collect the result once the state is terminal"`
 	Error          string `json:"error,omitempty" jsonschema:"why the job failed; present only when state is failed"`
-	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread"`
+	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread. Empty until agy names a fresh run's conversation, which takes about a second, so agy_status, agy_wait and agy_run_sync all report none when asked inside that window; ask again once the run is under way"`
 	// Partial marks a result that is not a verified final answer; see
 	// manager.Status.Partial.
 	Partial bool `json:"partial,omitempty" jsonschema:"true when result is not the verified final answer, so treat it as incomplete. It follows from where the text came from: true when the text was reconstructed from the streamed events, because agy never reported a terminal result or the one it reported carried no text, and true when agy reported a terminal result that was not a success, so its text is only what the run had produced when it stopped. A response agy itself marked successful is never partial, even on a job that was then cancelled or killed"`
@@ -276,7 +276,12 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		if err != nil {
 			return nil, runOutput{}, err
 		}
-		return nil, runOutput{JobID: job.ID, ConversationID: job.ConversationID, State: job.State}, nil
+		// agy_run returns before the job produces anything else, so this is the one
+		// tool that has to wait for agy to name a fresh conversation. The tools that
+		// report a run's conversation fill it from a Status read, which costs nothing
+		// extra because they were reading the status anyway. (list_sessions reports
+		// conversation ids too, but those come from agy's own cache, not from a run.)
+		return nil, runOutput{JobID: job.ID, ConversationID: mgr.AwaitConversationID(job), State: job.State}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{

--- a/internal/mcptools/tools_posix_test.go
+++ b/internal/mcptools/tools_posix_test.go
@@ -53,6 +53,39 @@ func TestListSessionsOverMCP(t *testing.T) {
 	}
 }
 
+// agy_run is the one tool that spends the conversation-id budget: it returns
+// before the run has produced anything a caller could read the id from, so
+// without the wait a fresh run's conversation_id would come back empty and the
+// caller would have to poll for it. This is the only test that pins that, and the
+// shared helper leaves the budget at zero, so dropping the call would otherwise
+// go unnoticed.
+func TestAgyRunReportsFreshConversationIDWithinBudget(t *testing.T) {
+	const uuid = "13131313-2424-3535-4646-575757575757"
+	// Sleeps past the assertion, so the id has to come from the progress file of a
+	// job that is still running, not from a finished one's result.
+	mgr, stateDir := newTestManagerWithIDWait(t, testutil.FakeAgy{
+		Stdout: "LATE OK", Exit: 0, Sleep: 20 * time.Second, ConversationID: uuid,
+	}, 30*time.Second)
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "agy_run",
+		Arguments: map[string]any{"prompt": "review"},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("agy_run: err=%v res=%+v", err, res)
+	}
+	sc := structMap(t, res.StructuredContent)
+	jobID, _ := sc["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("empty job id")
+	}
+	killJobGroup(t, stateDir, jobID)
+	if sc["conversation_id"] != uuid {
+		t.Fatalf("conversation_id = %v, want %q from the id the supervisor recorded", sc["conversation_id"], uuid)
+	}
+}
+
 func TestAgyRunAndStatusOverMCP(t *testing.T) {
 	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "REVIEW OK", Exit: 0})
 	cs := connect(t, mgr, nil)

--- a/internal/testutil/fakesupervisor.go
+++ b/internal/testutil/fakesupervisor.go
@@ -17,8 +17,8 @@ import (
 // directory as $2, writes the job's out (and err/exit_code) files there, and,
 // on Linux only, sets its comm to the script basename so the liveness comm
 // fallback sees the same value the real supervisor would report. On macOS,
-// identity is pinned by process start time instead, so the fake — a real
-// spawned process — needs no comm trick there.
+// identity is pinned by process start time instead, so the fake (a real spawned
+// process) needs no comm trick there.
 type FakeSupervisor struct {
 	// AgyPath, when set, makes the script run that (fake) agy binary with
 	// `-p x`, capturing stderr to <dir>/err and recording agy's real exit code.

--- a/waitfixtures_posix_test.go
+++ b/waitfixtures_posix_test.go
@@ -41,11 +41,10 @@ func startRunningJobForWait(t *testing.T, sleep time.Duration, convLabel string,
 		CacheJSON: fmt.Sprintf(`{%q:%q}`, cwd, convLabel),
 	})
 	stateDir := t.TempDir()
-	// ConversationIDWait 0: this fake supervisor writes no progress file, so StartJob
-	// would sleep out the whole default budget on every start, which for a short
-	// fake agy is long enough for the job to finish before StartJob even returns.
+	// No ConversationIDWait: this fixture starts jobs through StartJob, which does
+	// not wait for a conversation id, so the budget never applies here.
 	c := config.Config{AgyPath: agy, SupervisorExe: sup, StateDir: stateDir,
-		DefaultTimeout: time.Minute, MaxConcurrency: 4, ConversationIDWait: 0,
+		DefaultTimeout: time.Minute, MaxConcurrency: 4,
 		ConversationCacheFile: cachePath}
 	mgr := manager.New(c)
 


### PR DESCRIPTION
## Summary

`StartJob` blocked every fresh run in `awaitConversationID`, up to `config.ConversationIDWait`, before returning. `agy_run_sync` discarded the result: it uses only `job.ID`, and its own `conversation_id` comes off the `Status` it already polls. The wait now lives in the `agy_run` handler, the one caller that reports the id in its own response, as the exported `Manager.AwaitConversationID`.

**What this is worth is not what #96 claimed.** Measured end to end with both trees built from source, three interleaved rounds each, on darwin/arm64:

| shape | before | after |
|---|---|---|
| 20s run, caller `wait: 200ms` | 2.52 / 2.54 / 2.52 s | 0.52 / 0.53 / 0.53 s |
| 5s run, caller `wait: 2m` | 5.67 / 5.53 / 5.53 s | 5.84 / 5.75 / 5.76 s |

An ordinary call saves nothing. The old wait ran concurrently with the job, and `run_sync` computes its inline deadline from the time `StartJob` returns, so the budget was absorbed by a run that was going to outlast it anyway. The real win is a contract fix: `serverInstructions` and the `wait` schema both promise `agy_run_sync` is bounded by its `wait` argument, and before this a call could overrun that cap by the whole budget. I have corrected the framing on #96 rather than leave the wrong rationale standing.

### One behaviour change, named rather than buried

An `agy_run_sync` whose `wait` expires before agy has named the conversation now reports an empty `conversation_id` where `StartJob`'s wait would have filled it. Reaching it needs a `wait` shorter than agy's init latency (roughly a second) against a 2m default, `agy_status` still supplies the id, and `statusOutput`'s schema now documents the window. Flagging it in case you would rather keep a wait on that path.

### Tests

Three of the four new tests exist because mutation testing showed the branch was uncovered, not because this change touched it: the budget actually expiring, the store refusing a job id, and `StartJob` returning no id for a fresh run. The budget test needs an upper bound as well as a lower one, and that is the subtle part: with only the lower bound, deleting the deadline check still passed, because the wait ran on until the fake agy exited at 30s and cleared the bound trivially. Moving the wait out of `StartJob` had removed that branch's only coverage, which was incidental, since every fresh-run test used to traverse it.

Four byte-identical inline cleanups that SIGKILL a job's process group are folded into a `killJob` helper, and mcptools grows the same helper for the same reason: `agy_cancel` signals the supervisor pid alone (`proc.Signal` is "a single pid, not its group") and the fake supervisor forwards nothing, so cancelling it orphans the fake agy it runs in the foreground. Registering the kill as a `t.Cleanup` also makes it run on the `t.Fatalf` paths, which is where a leaked job is most likely.

The two shortest `testutil.WaitFor` deadlines in the manager package go from 3s to 5s, matching every sibling of the same shape. Both wait on a spawned supervisor and a forked fake agy, so they are bounded by machine load rather than by anything under test, and one of them flaked under a loaded full-suite run.

## Related Issues

Relates to #96. Closes the deferred `agy_run_sync` / `awaitConversationID` hoist, the last item that issue named as worth doing first.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/manager/ ./internal/mcptools/` green
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Mutation matrix: six of seven mutants are killed by a named test. The seventh, the terminal re-read discarding an id it recovered, is not reachable from a test: the first progress read short-circuits before it, and there is no seam to force the race, since `jobstore.ReadProgressDir` is a package function rather than a method on the injectable store interface.
- [x] No stray `fake-agy` processes survive a full suite run, verified with `pgrep` before and after

## Open question

`AwaitConversationID` still takes no `context.Context`, although the `agy_run` handler now has one in scope and unused. A client that cancels `agy_run` still parks the handler for up to the budget. That is a behaviour change on an exported signature, so I left it out of this PR rather than fold it in quietly. Happy to do it as a small follow-up if you want it.
