### PR TITLE
test: close the live #109 gaps (fixture dedup, typo control, err-file coverage)

### DIFF
--- a/internal/supervisor/stream_test.go
+++ b/internal/supervisor/stream_test.go
@@ -61,23 +61,33 @@ func TestConsumeStreamHappyPath(t *testing.T) {
 	}
 }
 
-// Only agent_response deltas make up the response. Tool calls and checkpoints
-// carry progress but must not be mixed into the answer.
+// Only agent_response deltas make up the response. A step of any other type
+// carries progress but must not be mixed into the answer.
 func TestConsumeStreamOnlyAppendsAgentResponse(t *testing.T) {
+	// The excluded step is placed LAST so progress records it: its text must be
+	// dropped BECAUSE its type was decoded and recognised as non-agent_response,
+	// not because the line failed to decode.
 	stream := `{"event":"init","conversation_id":"c-1"}
-{"event":"step_update","step_update":{"step_index":0,"step_type":"tool_call","text_delta":"SHOULD NOT APPEAR"}}
-{"event":"step_update","step_update":{"step_index":1,"step_type":"agent_response","text_delta":"kept"}}
-{"event":"step_update","step_update":{"step_index":2,"step_type":"checkpoint","text_delta":"NOR THIS"}}
+{"event":"step_update","step_update":{"step_index":0,"step_type":"agent_response","text_delta":"kept"}}
+{"event":"step_update","step_update":{"step_index":1,"step_type":"tool_call","text_delta":"SHOULD NOT APPEAR"}}
 `
-	_, out, oc := consume(t, stream)
+	dir, out, oc := consume(t, stream)
 	if got := out.String(); got != "kept" {
 		t.Fatalf("out = %q, want only the agent_response text", got)
 	}
-	// Positive control. Without it a typo in either "must not appear" line makes
-	// this pass for the wrong reason: an undecodable line is skipped, so its text
-	// never reaches out and the absence assertions hold vacuously.
+	// Positive control. Without it a typo in the excluded line makes this pass for
+	// the wrong reason: an undecodable line is skipped, so its text never reaches
+	// out and the absence check holds vacuously.
 	if oc.malformed != 0 {
-		t.Fatalf("malformed = %d, want 0; a skipped line would satisfy the absence checks without proving anything", oc.malformed)
+		t.Fatalf("malformed = %d, want 0; a skipped line would satisfy the absence check without proving anything", oc.malformed)
+	}
+	// Step-recognition control. The trailing tool_call is the last step, so it is
+	// what progress holds. Renaming its step_type key leaves the line decodable
+	// with an empty StepType, which still excludes its text but empties this
+	// assertion, so the exclusion is proven to follow from a recognised type
+	// rather than from a decode failure the count above already rules out.
+	if p := readProgress(t, dir); p.StepType != "tool_call" {
+		t.Fatalf("progress.StepType = %q, want tool_call; the excluded step must have decoded and been recognised", p.StepType)
 	}
 }
 

--- a/internal/supervisor/supervisor_posix_test.go
+++ b/internal/supervisor/supervisor_posix_test.go
@@ -3,6 +3,7 @@
 package supervisor
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,12 +12,14 @@ import (
 	"time"
 
 	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
+	"github.com/tphakala/agy-mcp/v2/internal/streamjson"
 	"github.com/tphakala/agy-mcp/v2/internal/testutil"
 )
 
-// These tests drive Run, which only supervises on Linux (process groups, signal
-// forwarding). They are _linux-gated; the pure tests (resolveExitCode,
-// effectiveTimeout) stay in supervisor_test.go so they run everywhere.
+// These tests drive Run, which supervises on Linux and macOS (process groups,
+// signal forwarding); the file is gated linux || darwin. The pure tests
+// (resolveExitCode, effectiveTimeout) stay in supervisor_test.go so they run
+// everywhere.
 
 // TestSupervisorEscalatesToSIGKILL: when agy ignores SIGTERM, the supervisor
 // must escalate to SIGKILL after the grace window. A tiny injected grace
@@ -64,5 +67,57 @@ func TestSupervisorSpawnFailureWrites127(t *testing.T) {
 	code, _ := os.ReadFile(jobstore.ExitCodePath(dir))
 	if got := strings.TrimSpace(string(code)); got != strconv.Itoa(jobstore.ExitSpawnFail) {
 		t.Fatalf("exit_code = %q, want %d (spawn failure)", got, jobstore.ExitSpawnFail)
+	}
+}
+
+// TestSupervisorRecordsSkippedLinesInErrFile drives a malformed agy stream
+// through the real supervisor and asserts that the "skipped N unreadable
+// line(s)" note persist emits reaches the job's err file, and that the valid
+// result after the malformed line still survives. Everywhere else that note is
+// asserted only against an in-memory buffer, so this is the one end-to-end check
+// that stream corruption is actually surfaced on disk.
+func TestSupervisorRecordsSkippedLinesInErrFile(t *testing.T) {
+	dir := t.TempDir()
+	// A fake agy that emits one undecodable line followed by a valid terminal
+	// result. WriteFakeAgy only renders well-formed streams, so this run is staged
+	// by hand: the script ignores its own args and prints a fixed stream, which the
+	// supervisor execs and decodes from its stdout.
+	agy := filepath.Join(t.TempDir(), "malformed-agy")
+	script := "#!/usr/bin/env bash\n" +
+		"printf '%s\\n' 'this is not a json event'\n" +
+		`printf '%s\n' '{"event":"result","result":{"conversation_id":"c-1","status":"SUCCESS","response":"ok"}}'` + "\n" +
+		"exit 0\n"
+	if err := os.WriteFile(agy, []byte(script), 0o755); err != nil {
+		t.Fatalf("write malformed agy: %v", err)
+	}
+	writeMeta(t, dir, jobstore.Meta{
+		ID: "j", AgyPath: agy, Args: []string{"-p", "x"},
+		StartedAt: time.Now(), Timeout: time.Minute,
+	})
+
+	if err := run(dir, 200*time.Millisecond, drainGrace); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	errBytes, rerr := os.ReadFile(jobstore.ErrPath(dir))
+	if rerr != nil {
+		t.Fatalf("read err file: %v", rerr)
+	}
+	if !strings.Contains(string(errBytes), "skipped 1 unreadable line") {
+		t.Fatalf("err file = %q, want it to report the one skipped line", errBytes)
+	}
+
+	// The valid result after the malformed line must still have been decoded and
+	// written: corruption early in the stream must not discard the answer.
+	res, rerr := jobstore.ReadResultDir(dir)
+	if rerr != nil || res == nil {
+		t.Fatalf("result payload missing after a malformed line: err=%v", rerr)
+	}
+	var r streamjson.Result
+	if err := json.Unmarshal(res, &r); err != nil {
+		t.Fatalf("result payload: %v", err)
+	}
+	if r.Response != "ok" {
+		t.Fatalf("result response = %q, want ok", r.Response)
 	}
 }

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -102,6 +102,27 @@ func (cfg FakeAgy) ConvID() string {
 	return defaultFakeConversationID
 }
 
+// result renders the terminal result this run produces, applying the status
+// defaulting that the stream's result event and result.json share. streamLines
+// embeds it in the result event and ResultJSON marshals it directly, so routing
+// both through here keeps them from drifting: fakesupervisor.go stages ResultJSON
+// as the payload the real supervisor would derive from streamLines' result event,
+// and nothing else enforces that the two agree.
+func (cfg FakeAgy) result() streamjson.Result {
+	status := cfg.Status
+	if status == "" {
+		status = streamjson.StatusSuccess
+	}
+	return streamjson.Result{
+		ConversationID: cfg.ConvID(),
+		Status:         status,
+		Response:       cfg.Stdout,
+		Error:          cfg.ResultError,
+		NumTurns:       1,
+		Usage:          &streamjson.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+	}
+}
+
 // streamLines renders the configured run as agy's stream-json output, which
 // WriteFakeAgy stages as the script's stdout payload. It is unexported because the
 // only consumer is in this file. One candidate does exist if anyone wants it back:
@@ -109,10 +130,6 @@ func (cfg FakeAgy) ConvID() string {
 func (cfg FakeAgy) streamLines(t *testing.T) string {
 	t.Helper()
 	convID := cfg.ConvID()
-	status := cfg.Status
-	if status == "" {
-		status = streamjson.StatusSuccess
-	}
 
 	events := []streamjson.Event{{
 		Kind:           streamjson.EventInit,
@@ -129,17 +146,8 @@ func (cfg FakeAgy) streamLines(t *testing.T) string {
 		},
 	}}
 	if !cfg.OmitResult {
-		events = append(events, streamjson.Event{
-			Kind: streamjson.EventResult,
-			Result: &streamjson.Result{
-				ConversationID: convID,
-				Status:         status,
-				Response:       cfg.Stdout,
-				Error:          cfg.ResultError,
-				NumTurns:       1,
-				Usage:          &streamjson.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
-			},
-		})
+		res := cfg.result()
+		events = append(events, streamjson.Event{Kind: streamjson.EventResult, Result: &res})
 	}
 
 	var sb strings.Builder
@@ -158,18 +166,7 @@ func (cfg FakeAgy) streamLines(t *testing.T) string {
 // derive from this run's stream and write to the job's result.json.
 func (cfg FakeAgy) ResultJSON(t *testing.T) string {
 	t.Helper()
-	status := cfg.Status
-	if status == "" {
-		status = streamjson.StatusSuccess
-	}
-	b, err := json.Marshal(streamjson.Result{
-		ConversationID: cfg.ConvID(),
-		Status:         status,
-		Response:       cfg.Stdout,
-		Error:          cfg.ResultError,
-		NumTurns:       1,
-		Usage:          &streamjson.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
-	})
+	b, err := json.Marshal(cfg.result())
 	if err != nil {
 		t.Fatalf("marshal fake agy result: %v", err)
 	}


### PR DESCRIPTION
Closes the still-live items of #109. Most of that issue turned out to be stale: its decode-failure-at-end-of-stream test, `Next`'s whitespace over-long doc, and the `readLine` cap off-by-one all landed in #111 already. Three items were genuinely still open, and this PR is scoped to those.

**What changed (all test-only; no production logic):**

- `internal/testutil/fakeagy.go`: `streamLines` and `ResultJSON` each duplicated the whole `streamjson.Result` literal (status defaulting, fixed `Usage`, `NumTurns`), and nothing enforced that they stay in lockstep. `fakesupervisor.go` stages `ResultJSON` as the payload the real supervisor would derive from `streamLines`' result event, so a `NumTurns`/`Usage` change in one would silently stage a result the fake agy never emitted. Both now route through a shared `FakeAgy.result()`, so they cannot drift.

- `internal/supervisor/stream_test.go`: `TestConsumeStreamOnlyAppendsAgentResponse` only had the `malformed == 0` control, which a decodable `step_type`-key typo survives (the line still decodes with an empty `StepType`, so its text is excluded for the wrong reason). The excluded `tool_call` step is now last and the test asserts `progress.StepType == "tool_call"`, so the exclusion is proven to follow from a recognised type rather than a decode failure. Verified: the new control goes red under exactly that mutation.

- `internal/supervisor/supervisor_posix_test.go`: new `TestSupervisorRecordsSkippedLinesInErrFile` drives a malformed agy stream through the real supervisor into the job's `err` file, so `persist`'s "skipped N unreadable line(s)" note is asserted on disk and not only against an in-memory buffer, and the valid result after the malformed line is shown to survive.

**Item mapping for #109:**

- Done here: fixture result-literal dedup; the decodable-typo mutation control; the end-to-end malformed-stream err-file coverage.
- Already fixed in #111: the streamjson decode-failure-at-EOF test, the `Next` whitespace over-long doc, the `readLine` cap off-by-one.
- Left for a follow-up (low value or needs a decision): the `fakesupervisor.go` cache-branch dedup (residual is a 3-line absolute-vs-`$dir` mismatch that cannot cleanly use `copyPayload`); the `CachePath`/`CacheJSON` drop-vs-document decision; and the progress-rewrite dedup test, which needs a production test seam (a clock or write counter) to assert a suppressed rewrite. I will update the issue with this mapping.

**Verification:** `go test ./... -race` and `golangci-lint run` both clean. Each new/changed test was sabotaged to confirm it goes red under the production line it pins. A pre-push gate (parallel review agents plus a Gemini cross-check) ran clean apart from two Low comment corrections, both applied: a stale file header that claimed the supervisor tests are Linux-only when they run on macOS too, and an inline comment that misattributed arg-ignoring to the supervisor rather than the fake script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed supervisor output so invalid lines are reported clearly while subsequent valid results are still preserved.
  * Ensured tool-call steps are excluded from displayed agent responses and recorded accurately in progress updates.

* **Tests**
  * Expanded cross-platform coverage for Linux and macOS.
  * Improved consistency of simulated job results across streaming and structured output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->