### PR TITLE
test: drop the dead agyVersion seam, pin the fresh-run concurrency invariant (#96)

### DIFF
--- a/internal/manager/restore_posix_test.go
+++ b/internal/manager/restore_posix_test.go
@@ -80,10 +80,17 @@ func TestRestoreGateBlocksConflictingRun(t *testing.T) {
 	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd, ConversationID: liveConvID("live-1")}); err == nil {
 		t.Fatal("a run continuing the same conversation should be blocked by the restored live job's key")
 	}
-	// A fresh run in that same directory is not blocked: fresh runs no longer key
-	// on the cwd.
-	if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err != nil {
-		t.Fatalf("a fresh same-cwd run must not be blocked by a restored job: %v", err)
+	// Two fresh runs in that same directory must BOTH admit: fresh runs no longer
+	// key on the cwd, so nothing serializes them against the restored job or
+	// against each other. A single fresh run admitting proved nothing here, since a
+	// fresh run keys on "" and can never collide with the restored conv: key;
+	// running two in one directory is what pins that they are not serialized. If
+	// keyFor were changed back to keying fresh runs on the cwd, the second run
+	// would be refused with acquireKeyBusy and this loop would fail.
+	for i := range 2 {
+		if _, err := m.StartJob(StartRequest{Prompt: "x", Cwd: cwd}); err != nil {
+			t.Fatalf("fresh same-cwd run %d must not be blocked by a restored job or a sibling fresh run: %v", i+1, err)
+		}
 	}
 }
 

--- a/internal/manager/testhelpers_test.go
+++ b/internal/manager/testhelpers_test.go
@@ -21,7 +21,6 @@ type managerOpts struct {
 	defaultModel   string
 	jobTTL         time.Duration
 	withCacheFile  bool   // true -> m.cacheFile = a fresh t.TempDir()/last_conversations.json
-	agyVersion     string // "" -> a version that satisfies the gate; see newManager
 }
 
 // newManager builds a *Manager for tests, consolidating the suite's several
@@ -52,12 +51,9 @@ func newManager(t *testing.T, opts managerOpts) *Manager {
 	// Stub the version probe. The agyPath in these tests is usually a stand-in
 	// that cannot be executed at all, so without this every StartJob would fail
 	// in the gate rather than exercising what the test is about. A test that
-	// wants to exercise the gate itself sets agyVersion.
-	version := opts.agyVersion
-	if version == "" {
-		version = agyver.Required.String()
-	}
-	m.readAgyVersion = testutil.FakeVersion(version)
+	// exercises the gate itself stubs m.readAgyVersion directly (see
+	// versionManager in version_test.go).
+	m.readAgyVersion = testutil.FakeVersion(agyver.Required.String())
 	// Pin the conversation-id wait at zero. It already is: this Config is a
 	// literal, and config.DefaultConversationIDWait is applied only by
 	// config.baseConfig, which Resolve and ResolveWait call and this helper does


### PR DESCRIPTION
Closes the two still-live, safe items of #96. I re-derived all 24 items against current `main` first: 13 were already fixed by #106-#113, 2 are intentional by-design, and of the 9 that remain only these two are cleanly safe to change now. The rest are judgment tradeoffs or exported-API decisions, which I have mapped on the issue rather than touched here.

**What changed (test-only; no production code):**

- `managerOpts.agyVersion` was a dead test seam: documented as "a test that wants to exercise the gate itself sets agyVersion", but no test ever set it (`grep` confirms zero writers repo-wide), so `newManager` always stubbed `agyver.Required.String()` anyway. The version gate is covered independently by `version_test.go`'s `versionManager`, which stubs `m.readAgyVersion` directly (`agyBinaryChecked` at 100%). Delete the field and stub unconditionally.

- `TestRestoreGateBlocksConflictingRun` asserted that one fresh run in the restored job's cwd admits, which proved nothing: a fresh run keys on `""` and can never collide with the restored `conv:` key, so the assertion held even under the old cwd-keying it was meant to guard against. It now starts two fresh runs in the same cwd and asserts both admit, which is what actually pins "fresh runs no longer serialize on cwd". Verified by mutation: reintroducing `return "cwd:" + req.Cwd` in `keyFor` makes the second run refuse with `acquireKeyBusy` and the test goes red; the old single-run form stayed green under that same mutation.

**Verification:** `go test ./... -race` and `golangci-lint run ./...` clean; the strengthened test held over 30 race runs. A pre-push gate (six review agents across reuse, correctness, quality, integration, regression, and test-quality, plus a Gemini cross-check) ran clean with no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded restore-gate coverage to confirm multiple fresh jobs can run in the same directory while restored jobs remain appropriately blocked.
  * Updated test setup to provide a consistent required version, with version-gating tests overriding it when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->