### PR TITLE
manager: make AwaitConversationID cancellable via context (#96)

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -214,8 +214,9 @@ const conversationIDPoll = 50 * time.Millisecond
 // AwaitConversationID reports the conversation a run belongs to. A run that
 // already names one (a continuation) returns it at once; a fresh one polls the
 // job's progress file until the supervisor records the id agy reported, the job
-// turns out to be over, or the budget expires. It returns "" when no id arrived,
-// which is not an error: the id is still delivered by the next Status read.
+// turns out to be over, the caller cancels ctx, or the budget expires. It returns
+// "" when no id arrived, which is not an error: the id is still delivered by the
+// next Status read.
 //
 // It is deliberately not part of StartJob. Only agy_run needs the id in its own
 // response, because it returns before the run produces anything else; agy_run_sync
@@ -232,7 +233,7 @@ const conversationIDPoll = 50 * time.Millisecond
 // the stream and the exit-code sentinel only at the very end, so a visible
 // sentinel with no recorded id means none is coming (the run died before agy's
 // init event, or never started at all).
-func (m *Manager) AwaitConversationID(job Job) string {
+func (m *Manager) AwaitConversationID(ctx context.Context, job Job) string {
 	if job.ConversationID != "" {
 		return job.ConversationID
 	}
@@ -260,7 +261,16 @@ func (m *Manager) AwaitConversationID(job Job) string {
 		if !time.Now().Before(deadline) {
 			return ""
 		}
-		time.Sleep(conversationIDPoll)
+		select {
+		case <-ctx.Done():
+			// The caller (the agy_run handler) has gone away, so stop polling rather
+			// than parking it for the rest of the budget. The id is not lost: it stays
+			// on disk in the progress file, so any later agy_status on this job returns
+			// it once agy names the conversation, the same recovery an expired budget
+			// relies on.
+			return ""
+		case <-time.After(conversationIDPoll):
+		}
 	}
 }
 

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -362,7 +362,7 @@ func TestAwaitConversationIDGivesUpWhenTheBudgetExpires(t *testing.T) {
 	}
 	killJob(t, m, job.ID)
 	start := time.Now()
-	got := m.AwaitConversationID(job)
+	got := m.AwaitConversationID(t.Context(), job)
 	elapsed := time.Since(start)
 	if got != "" {
 		t.Fatalf("AwaitConversationID = %q, want empty: this run never names a conversation", got)
@@ -394,7 +394,7 @@ func TestAwaitConversationIDRejectsAnUnusableJobID(t *testing.T) {
 	m.conversationIDWait = 30 * time.Second
 
 	start := time.Now()
-	got := m.AwaitConversationID(Job{ID: "../escape"})
+	got := m.AwaitConversationID(t.Context(), Job{ID: "../escape"})
 	elapsed := time.Since(start)
 	if got != "" {
 		t.Fatalf("AwaitConversationID = %q, want empty for a job id the store rejects", got)
@@ -418,7 +418,7 @@ func TestAwaitConversationIDReturnsFreshIDWithinBudget(t *testing.T) {
 		t.Fatalf("StartJob: %v", err)
 	}
 	killJob(t, m, job.ID)
-	if got := m.AwaitConversationID(job); got != fake.ConvID() {
+	if got := m.AwaitConversationID(t.Context(), job); got != fake.ConvID() {
 		t.Fatalf("AwaitConversationID = %q, want %q from agy's init event", got, fake.ConvID())
 	}
 }
@@ -438,7 +438,7 @@ func TestAwaitConversationIDStopsAtTerminalJob(t *testing.T) {
 		t.Fatalf("StartJob: %v", err)
 	}
 	start := time.Now()
-	got := m.AwaitConversationID(job)
+	got := m.AwaitConversationID(t.Context(), job)
 	elapsed := time.Since(start)
 	if got != "" {
 		t.Fatalf("AwaitConversationID = %q, want empty: this run reports no id", got)
@@ -459,12 +459,45 @@ func TestAwaitConversationIDShortCircuitsAContinuation(t *testing.T) {
 	const convID = "11111111-2222-3333-4444-555555555555"
 	start := time.Now()
 	// No such job dir, so a wait that did start would poll out its whole budget.
-	got := m.AwaitConversationID(Job{ID: "no-such-job", ConversationID: convID})
+	got := m.AwaitConversationID(t.Context(), Job{ID: "no-such-job", ConversationID: convID})
 	elapsed := time.Since(start)
 	if got != convID {
 		t.Fatalf("AwaitConversationID = %q, want %q handed straight back", got, convID)
 	}
 	if elapsed > 5*time.Second {
 		t.Fatalf("AwaitConversationID took %s for an id it was given", elapsed)
+	}
+}
+
+// A cancelled caller context must end the wait at once rather than polling out
+// the budget. The agy_run handler holds a live context; when the client abandons
+// the call there is no reason to keep parking it, and the id it would have
+// reported is delivered by the next agy_status read instead, so an early "" loses
+// nothing. Without the ctx.Done() case this run would poll the full budget.
+func TestAwaitConversationIDStopsOnContextCancellation(t *testing.T) {
+	// Never names a conversation and outlives the budget many times over, so
+	// neither the id-found nor the terminal branch can fire; only cancellation can
+	// end the wait.
+	fake := testutil.FakeAgy{Stdout: "OK", Sleep: 30 * time.Second, NoConversationID: true}
+	m := waitManager(t, fake)
+	m.conversationIDWait = 30 * time.Second // long enough that sleeping it out would fail the test
+
+	job, err := m.StartJob(StartRequest{Prompt: "hi", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	killJob(t, m, job.ID)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // already cancelled: the wait must return at its first poll boundary
+
+	start := time.Now()
+	got := m.AwaitConversationID(ctx, job)
+	elapsed := time.Since(start)
+	if got != "" {
+		t.Fatalf("AwaitConversationID = %q, want empty when the caller's context is cancelled", got)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("AwaitConversationID took %s against a %s budget: cancellation did not end the wait", elapsed, m.conversationIDWait)
 	}
 }

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -281,7 +281,7 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		// report a run's conversation fill it from a Status read, which costs nothing
 		// extra because they were reading the status anyway. (list_sessions reports
 		// conversation ids too, but those come from agy's own cache, not from a run.)
-		return nil, runOutput{JobID: job.ID, ConversationID: mgr.AwaitConversationID(job), State: job.State}, nil
+		return nil, runOutput{JobID: job.ID, ConversationID: mgr.AwaitConversationID(ctx, job), State: job.State}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{


### PR DESCRIPTION
Closes #96's item 24, which the issue flagged as a decision to make rather than default.

The `agy_run` handler holds a live request context but called `AwaitConversationID` without it, so a client that cancelled `agy_run` still parked the handler in the conversation-id poll loop for the rest of `ConversationIDWait` (up to ~2s).

`AwaitConversationID` now takes a `context.Context` and selects on `ctx.Done()` at the poll boundary, so a cancelled caller returns at once. Everything else is unchanged: for a live context the behaviour is byte-identical (the id-found, terminal-job, and deadline checks still run first, and `time.After(conversationIDPoll)` fires on the same 50ms cadence the old `time.Sleep` did). On cancellation it returns `""` exactly as an expired budget does, and the id still reaches the client through the next `agy_status` once agy names the conversation. Cancelling the handler's context ends only the wait, never the job: `StartJob` has already returned and the job runs under a detached supervisor that takes no context.

`manager` is an internal package, so the signature change reaches only the one production caller and the tests.

**Verification:** `go test ./... -race` and `golangci-lint run ./...` clean. Added `TestAwaitConversationIDStopsOnContextCancellation`, verified by mutation: reverting the `ctx.Done()` case to a plain poll sleep makes it park the full 30s budget and fail. A pre-push gate (six review agents across reuse, correctness, quality, integration, regression, and test-quality) ran clean apart from two of my own comment nits, both fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Waiting for a conversation ID now stops promptly when the request is canceled.
  * Canceled requests return an empty conversation ID instead of waiting for the full timeout period.
* **Tests**
  * Added coverage to verify immediate cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->