### PR TITLE
jobstore: fsync the job dir so a completed job's writes survive a crash (#96)

### DIFF
--- a/internal/jobstore/contention_notwindows.go
+++ b/internal/jobstore/contention_notwindows.go
@@ -2,6 +2,8 @@
 
 package jobstore
 
+import "os"
+
 // contended is always false off Windows: rename(2) swaps a directory entry and
 // open(2) resolves to an inode, and another process holding the old file open
 // blocks neither. A failure here is a real one (a missing directory, a full or
@@ -18,3 +20,24 @@ package jobstore
 // with no contended at all, and an _other.go here would read as the
 // unsupported-platform stub that name means in the other packages.
 func contended(error) bool { return false }
+
+// fsyncDir fsyncs dir itself, so a rename INTO dir (writeFileAtomicDurable) is
+// flushed and not just the renamed file's data. The standard POSIX durable-rename
+// recipe is fsync(temp), rename, fsync(dir); writeFileAtomic already does the
+// first two. This is a plain fsync, the same guarantee tmp.Sync gives the data
+// (on darwin full media durability would need F_FULLFSYNC), so the directory
+// entry ends up exactly as durable as the file's data, no more. The directory is
+// opened read-only and Synced; there is nothing to write to it.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	// Report Sync's error ahead of Close's: a failed directory fsync is the
+	// durability failure the caller needs to hear about, and Close would mask it.
+	if serr := d.Sync(); serr != nil {
+		_ = d.Close()
+		return serr
+	}
+	return d.Close()
+}

--- a/internal/jobstore/contention_notwindows_test.go
+++ b/internal/jobstore/contention_notwindows_test.go
@@ -102,3 +102,23 @@ func TestWriteFileAtomicReplacesAnOpenFile(t *testing.T) {
 		t.Errorf("reader opened before the replace saw %+v, want the snapshot it opened (1, before)", held)
 	}
 }
+
+// TestFsyncDir exercises fsyncDir's two outcomes off Windows: a real directory
+// syncs without error, and a path that cannot be opened as a directory returns
+// the open error rather than calling Sync on a nil handle. The durability it buys
+// (the rename surviving a crash) cannot be observed without crash injection,
+// which Go tests do not do; the durable writers reach fsyncDir end-to-end through
+// writeFileAtomicDurable, so the rest of the suite passing is what pins that it
+// succeeds on a real job dir.
+func TestFsyncDir(t *testing.T) {
+	if err := fsyncDir(t.TempDir()); err != nil {
+		t.Fatalf("fsyncDir on a real directory: %v", err)
+	}
+	// A missing path cannot be opened, so the open error is returned; without that
+	// check the code would call Sync on a nil handle and get "invalid argument"
+	// instead of fs.ErrNotExist.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := fsyncDir(missing); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("fsyncDir on a missing path = %v, want fs.ErrNotExist", err)
+	}
+}

--- a/internal/jobstore/contention_windows.go
+++ b/internal/jobstore/contention_windows.go
@@ -34,3 +34,13 @@ import (
 func contended(err error) bool {
 	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_ACCESS_DENIED)
 }
+
+// fsyncDir is a no-op on Windows: there is no supported way to flush a directory
+// handle (FlushFileBuffers requires a file handle and rejects a directory), so
+// this platform cannot make the rename crash-durable the way the POSIX fsync
+// does. NTFS journaling keeps the directory metadata CONSISTENT across a crash
+// (the entry is never torn), which is not the same as flushing a just-made
+// rename, so writeFileAtomicDurable simply forfeits the extra durability here,
+// exactly as its best-effort fsync does on a POSIX filesystem that cannot fsync a
+// directory.
+func fsyncDir(string) error { return nil }

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -263,7 +263,7 @@ func writeFileAtomic(dir, name string, b []byte) error {
 
 // writeFileAtomicDurable publishes b with writeFileAtomic and then fsyncs the
 // directory, so the rename survives a crash and not just the file's data. It is
-// for the write-once files whose loss would misreport a job afterwards: meta.json
+// for the low-frequency files whose loss would misreport a job afterwards: meta.json
 // (its absence orphans the dir), result.json (its absence downgrades a complete
 // answer to partial), and the exit_code sentinel (whose absence misreports a
 // finished job's outcome).

--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -129,7 +130,7 @@ func ReadProgressDir(dir string) (Progress, bool) {
 // are the marshalled stream-json result event; jobstore owns the file, not its
 // schema, so the payload passes through opaque.
 func WriteResultDir(dir string, b []byte) error {
-	return writeFileAtomic(dir, ResultFile, b)
+	return writeFileAtomicDurable(dir, ResultFile, b)
 }
 
 // ReadResultDir returns a job's terminal result payload. A missing file yields
@@ -185,7 +186,7 @@ func LoadDir(dir string) (Meta, error) {
 // contract: the sentinel is not sensitive, but a uniform owner-only mode is
 // simpler to reason about.
 func WriteExitCodeDir(dir string, code int) error {
-	return writeFileAtomic(dir, ExitCodeFile, []byte(strconv.Itoa(code)))
+	return writeFileAtomicDurable(dir, ExitCodeFile, []byte(strconv.Itoa(code)))
 }
 
 // WriteCancelDir creates a job's cancel sentinel, the manager's Windows-only
@@ -211,6 +212,14 @@ func WriteCancelDir(dir string) error {
 //
 // The rename retries a destination another process holds open; see
 // retryContended for why that is reachable on Windows and nowhere else.
+//
+// The rename itself is NOT crash-durable: tmp.Sync flushes the file's data, but
+// a crash right after the rename can still lose the new directory entry. The
+// write-once files whose loss would misreport a job close that gap with
+// writeFileAtomicDurable; the per-step progress file and the cancel sentinel stay
+// here (a directory fsync on the progress hot path would cost more than a hint
+// whose loss reads as "nothing known yet", and a lost cancel is a recoverable
+// control signal).
 //
 // 0600 throughout: these files record prompts, agy output and job metadata,
 // which often embed source code, so they must not be readable by other users on
@@ -248,6 +257,32 @@ func writeFileAtomic(dir, name string, b []byte) error {
 	if err := renameReplace(tmpName, filepath.Join(dir, name)); err != nil {
 		_ = os.Remove(tmpName)
 		return err
+	}
+	return nil
+}
+
+// writeFileAtomicDurable publishes b with writeFileAtomic and then fsyncs the
+// directory, so the rename survives a crash and not just the file's data. It is
+// for the write-once files whose loss would misreport a job afterwards: meta.json
+// (its absence orphans the dir), result.json (its absence downgrades a complete
+// answer to partial), and the exit_code sentinel (whose absence misreports a
+// finished job's outcome).
+//
+// The directory fsync is BEST EFFORT. The file is already published by the time
+// it runs, so a failure must not fail the write: a filesystem that cannot fsync a
+// directory (some FUSE / network mounts return EINVAL) would otherwise turn a
+// successful write into an error, and Create/UpdateMeta would then wipe a fresh
+// job dir or tear down a running supervisor over a durability miss on a file that
+// is already on disk. Losing the fsync only forfeits crash durability, so it is
+// logged (a real I/O error stays visible) and swallowed; the write still
+// succeeds. On mainstream local filesystems the fsync succeeds and durability is
+// achieved.
+func writeFileAtomicDurable(dir, name string, b []byte) error {
+	if err := writeFileAtomic(dir, name, b); err != nil {
+		return err
+	}
+	if err := fsyncDir(dir); err != nil {
+		log.Printf("jobstore: directory fsync for %q failed; %s is atomic but not crash-durable: %v", dir, name, err)
 	}
 	return nil
 }
@@ -351,7 +386,7 @@ func writeMetaAtomic(dir string, m Meta) error {
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(dir, MetaFile, b)
+	return writeFileAtomicDurable(dir, MetaFile, b)
 }
 
 // Remove deletes a job's directory and everything in it.


### PR DESCRIPTION
Closes #96's item 16. `writeFileAtomic` flushed the temp file's data (`tmp.Sync`) but never fsynced the containing directory, so the rename that publishes a file was not crash-durable: a power loss right after the rename could lose the new directory entry even though the data reached disk. That is the standard POSIX durable-rename gap (the recipe is fsync(temp), rename, fsync(dir); only the first two were done).

`writeFileAtomicDurable` publishes the file with the unchanged `writeFileAtomic` and then fsyncs the directory. The write-once files whose loss would misreport a completed job go through it: `meta.json` (its absence orphans the dir), `result.json` (its absence downgrades a complete answer to partial), and the `exit_code` sentinel. `progress.json` stays on the plain path (it is rewritten many times per run, so a directory fsync on that hot path would cost far more than a hint whose loss reads as "nothing known yet"), as does the `cancel` sentinel (a lost cancel is a recoverable control signal). `fsyncDir` is platform-split alongside `contended`: POSIX opens the dir read-only and Syncs it; Windows is a no-op (a directory handle cannot be flushed there, and NTFS journaling only keeps the metadata consistent, not flushed).

The directory fsync is best effort. The file is already published by the time it runs, so a failure only forfeits crash durability and must not fail the write; otherwise a filesystem that cannot fsync a directory (some FUSE / network mounts return `EINVAL`) would turn a successful write into an error, and `Create`/`UpdateMeta` would then wipe a fresh job dir or tear down a running supervisor over a durability miss on a file already on disk. The error is logged (a real I/O error stays visible) and swallowed; on mainstream local filesystems the fsync succeeds and durability is achieved.

**Verification:** `go test ./... -race` and `golangci-lint run ./...` clean; `GOOS=windows` and `GOOS=linux` builds clean. Crash-durability itself is not unit-testable without fault injection, so `TestFsyncDir` pins the helper's open-error branch and the existing durable-writer tests exercise `fsyncDir` on real job dirs end-to-end.

A pre-push gate (six review agents plus a final report-only pass over the fix wave) caught one real Medium: routing `Create`/`UpdateMeta` through a strict directory fsync would have failed job creation on directory-fsync-hostile filesystems where the plain write previously succeeded. That is why the fsync is best effort here, which keeps the change a pure improvement with no regression on any filesystem. The remaining review findings were comment overclaims (an NTFS-durability claim, a darwin "stable storage" claim, and the `exit_code` outcome wording), all corrected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved durability of job metadata, results, and exit-code updates during unexpected system failures.
  * Added platform-specific handling to safely synchronize stored data after updates.
  * Synchronization issues are logged while allowing successfully published writes to remain available.
  * Reduced the risk of losing completed job information after crashes or power interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->