### PR TITLE
jobstore: fsync newly created ancestor dirs so job-dir creation is crash-durable

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -287,6 +288,60 @@ func writeFileAtomicDurable(dir, name string, b []byte) error {
 	return nil
 }
 
+// missingAncestors returns the ancestor directories of dir that do not exist yet,
+// deepest first (dir itself, then its parent, and so on), stopping at the first
+// ancestor that already exists. This is the set os.MkdirAll(dir) will have to
+// create, computed BEFORE the call because MkdirAll does not report which dirs it
+// made. A Stat that fails for a reason other than "does not exist" stops the walk:
+// MkdirAll will surface that error, and guessing which ancestors it created past an
+// unreadable one risks an fsync on a path this process never made.
+func missingAncestors(dir string) []string {
+	var missing []string
+	for p := filepath.Clean(dir); ; {
+		if _, err := os.Stat(p); err == nil || !errors.Is(err, fs.ErrNotExist) {
+			break // p already exists, or we cannot tell; stop climbing
+		}
+		missing = append(missing, p)
+		parent := filepath.Dir(p)
+		if parent == p {
+			break // reached the filesystem root
+		}
+		p = parent
+	}
+	return missing
+}
+
+// mkdirAllDurable creates dir and any missing ancestors with perm, then fsyncs the
+// parent of each directory it had to create so the CREATION of the job dir (its
+// entry in the parent) survives a crash, not just the files later written into it.
+// Plain os.MkdirAll leaves those new directory entries only in the parent's page
+// cache, so a power loss right after Create can lose the whole job dir, taking the
+// just-written meta.json with it (issue #118).
+//
+// The parent fsyncs are best-effort, in the same spirit as writeFileAtomicDurable's
+// own dir fsync: a directory-fsync-hostile filesystem logs and continues rather
+// than failing job creation. On mainstream local filesystems every fsync succeeds
+// and the dir creation is crash-durable.
+func mkdirAllDurable(dir string, perm os.FileMode) error {
+	// Capture which ancestors are missing before creating them; MkdirAll does not
+	// report what it made. missing is deepest first, so slices.Backward fsyncs the
+	// parents from the root down: each new dir's entry is made durable in its parent
+	// before the loop reaches the dir nested inside it. So a crash leaves a durable
+	// run from an existing ancestor down, never a flushed inner dir whose entry in
+	// its parent is not yet on disk.
+	missing := missingAncestors(dir)
+	if err := os.MkdirAll(dir, perm); err != nil {
+		return err
+	}
+	for _, d := range slices.Backward(missing) {
+		parent := filepath.Dir(d)
+		if err := fsyncDir(parent); err != nil {
+			log.Printf("jobstore: parent-dir fsync for %q failed; creation of %q is not crash-durable: %v", parent, d, err)
+		}
+	}
+	return nil
+}
+
 // ErrInvalidID is returned when a job id is not a safe path segment.
 var ErrInvalidID = errors.New("invalid job id")
 
@@ -342,7 +397,10 @@ func (s *Store) Create(m Meta) (string, error) {
 	dir := s.jobDir(m.ID)
 	// 0700: job dirs hold prompts and full agy output (which often embed source
 	// code), so they must not be readable by other users on a multi-user host.
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	// mkdirAllDurable (not a bare os.MkdirAll) fsyncs each newly created ancestor's
+	// parent so the CREATION of the job dir survives a crash, matching the file-write
+	// durability writeMetaAtomic gives meta.json below (issue #118).
+	if err := mkdirAllDurable(dir, 0o700); err != nil {
 		return "", err
 	}
 	// Write meta.json with the same temp+rename pattern UpdateMeta uses, so a crash

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -289,3 +289,49 @@ func TestListAndRemove(t *testing.T) {
 		t.Fatalf("after Remove, List = %v", ids)
 	}
 }
+
+// TestMissingAncestorsStopsAtFirstExisting pins missingAncestors, the pre-scan
+// mkdirAllDurable relies on to learn which parent dirs need an fsync after
+// MkdirAll (MkdirAll does not report what it created). The walk must list every
+// not-yet-existing ancestor, deepest first, and stop at the first one that
+// already exists so an fsync never runs against a dir Create did not make.
+func TestMissingAncestorsStopsAtFirstExisting(t *testing.T) {
+	base := t.TempDir() // already exists
+	target := filepath.Join(base, "a", "b", "c")
+	got := missingAncestors(target)
+	want := []string{
+		target,
+		filepath.Join(base, "a", "b"),
+		filepath.Join(base, "a"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("missingAncestors(%q) = %v, want %v", target, got, want)
+	}
+	// An already-existing directory has no missing ancestors, so nothing is synced.
+	if got := missingAncestors(base); len(got) != 0 {
+		t.Fatalf("missingAncestors(existing) = %v, want empty", got)
+	}
+}
+
+// TestCreateBuildsAndLoadsThroughMissingStateRoot exercises Create's durable-dir
+// path when several ancestors are missing: a state root nested two levels deep,
+// so mkdirAllDurable must create <root>, <root>/jobs and the job dir, then run its
+// parent-fsync loop over more than one new dir. The parent fsyncs themselves are
+// not observable from a test (fsync has no user-visible effect absent a crash), so
+// this asserts only the functional contract the durable path must preserve: a
+// loadable job dir with meta.json. missingAncestors' own test pins which parents
+// get synced.
+func TestCreateBuildsAndLoadsThroughMissingStateRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "state", "nested") // does not exist yet
+	s := New(root)
+	dir, err := s.Create(Meta{ID: "job1", BootID: "b"})
+	if err != nil {
+		t.Fatalf("Create through missing state root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, MetaFile)); err != nil {
+		t.Fatalf("meta.json missing after Create: %v", err)
+	}
+	if _, err := s.Load("job1"); err != nil {
+		t.Fatalf("Load after Create: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last durability gap in job creation. `Store.Create` did `os.MkdirAll(<state>/jobs/<id>)` and then only fsynced the job dir itself (via the `meta.json` atomic write), so the CREATION of the job dir was not crash-durable: a power loss right after `MkdirAll` could lose the whole just-created job dir along with the `meta.json` written into it.

This adds `mkdirAllDurable`, which records the not-yet-existing ancestors before `MkdirAll` (which does not report what it created) and then fsyncs the parent of each newly created directory, from the root down so a parent's entry for a child is on disk before that child's own entries. The fsyncs are best-effort, matching the existing `writeFileAtomicDurable`: a directory-fsync-hostile filesystem logs and continues rather than failing job creation. On Windows `fsyncDir` is already a no-op, so the path degrades cleanly to a plain `MkdirAll` there.

`missingAncestors` is factored out and unit-tested. The fsync itself is not observable from a test (it has no effect absent a crash), so the Create-level test pins only the functional contract (a loadable job dir through a missing state root) and its comment says so; `missingAncestors`' own test is what pins which parents get synced.

## Related Issues

Fixes #118. Follow-up #119 (Low, out of scope here) tracks a remaining cross-file boundary: the manager's locks path can create `<StateDir>` non-durably before the first keyed job's `Create`, so the state root's own directory entry is not always made durable.

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `golangci-lint run` clean (0 issues)
- [x] New `TestMissingAncestorsStopsAtFirstExisting` plus a Create-through-missing-state-root regression test; both sabotage-verified to fail without their production line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating nested job storage directories, including after unexpected crashes.
  * Ensured job metadata remains persistently saved and can be loaded successfully after creation.

* **Tests**
  * Added coverage for nested directory creation and metadata persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->