### PR TITLE
manager/jobstore: durably create the shared state root via MkdirAllDurable

### DIFF
--- a/internal/jobstore/store.go
+++ b/internal/jobstore/store.go
@@ -311,18 +311,22 @@ func missingAncestors(dir string) []string {
 	return missing
 }
 
-// mkdirAllDurable creates dir and any missing ancestors with perm, then fsyncs the
-// parent of each directory it had to create so the CREATION of the job dir (its
-// entry in the parent) survives a crash, not just the files later written into it.
-// Plain os.MkdirAll leaves those new directory entries only in the parent's page
-// cache, so a power loss right after Create can lose the whole job dir, taking the
-// just-written meta.json with it (issue #118).
+// MkdirAllDurable creates dir and any missing ancestors with perm, then fsyncs the
+// parent of each directory it had to create so the CREATION of dir (its entry in
+// its parent) survives a crash, not just the files later written into it. Plain
+// os.MkdirAll leaves those new directory entries only in the parent's page cache,
+// so a power loss right after it can lose the whole newly created tree: a job dir
+// and its meta.json (issue #118), or the shared state root (issue #119).
+//
+// Both the job store (Store.Create) and the manager's cross-process lock dir create
+// directories through this, so whichever of them first creates the shared state
+// root does so durably, not just the deeper dir it was aiming at.
 //
 // The parent fsyncs are best-effort, in the same spirit as writeFileAtomicDurable's
 // own dir fsync: a directory-fsync-hostile filesystem logs and continues rather
-// than failing job creation. On mainstream local filesystems every fsync succeeds
-// and the dir creation is crash-durable.
-func mkdirAllDurable(dir string, perm os.FileMode) error {
+// than failing the create. On mainstream local filesystems every fsync succeeds and
+// the dir creation is crash-durable.
+func MkdirAllDurable(dir string, perm os.FileMode) error {
 	// Capture which ancestors are missing before creating them; MkdirAll does not
 	// report what it made. missing is deepest first, so slices.Backward fsyncs the
 	// parents from the root down: each new dir's entry is made durable in its parent
@@ -397,10 +401,10 @@ func (s *Store) Create(m Meta) (string, error) {
 	dir := s.jobDir(m.ID)
 	// 0700: job dirs hold prompts and full agy output (which often embed source
 	// code), so they must not be readable by other users on a multi-user host.
-	// mkdirAllDurable (not a bare os.MkdirAll) fsyncs each newly created ancestor's
+	// MkdirAllDurable (not a bare os.MkdirAll) fsyncs each newly created ancestor's
 	// parent so the CREATION of the job dir survives a crash, matching the file-write
 	// durability writeMetaAtomic gives meta.json below (issue #118).
-	if err := mkdirAllDurable(dir, 0o700); err != nil {
+	if err := MkdirAllDurable(dir, 0o700); err != nil {
 		return "", err
 	}
 	// Write meta.json with the same temp+rename pattern UpdateMeta uses, so a crash

--- a/internal/jobstore/store_test.go
+++ b/internal/jobstore/store_test.go
@@ -291,7 +291,7 @@ func TestListAndRemove(t *testing.T) {
 }
 
 // TestMissingAncestorsStopsAtFirstExisting pins missingAncestors, the pre-scan
-// mkdirAllDurable relies on to learn which parent dirs need an fsync after
+// MkdirAllDurable relies on to learn which parent dirs need an fsync after
 // MkdirAll (MkdirAll does not report what it created). The walk must list every
 // not-yet-existing ancestor, deepest first, and stop at the first one that
 // already exists so an fsync never runs against a dir Create did not make.
@@ -315,7 +315,7 @@ func TestMissingAncestorsStopsAtFirstExisting(t *testing.T) {
 
 // TestCreateBuildsAndLoadsThroughMissingStateRoot exercises Create's durable-dir
 // path when several ancestors are missing: a state root nested two levels deep,
-// so mkdirAllDurable must create <root>, <root>/jobs and the job dir, then run its
+// so MkdirAllDurable must create <root>, <root>/jobs and the job dir, then run its
 // parent-fsync loop over more than one new dir. The parent fsyncs themselves are
 // not observable from a test (fsync has no user-visible effect absent a crash), so
 // this asserts only the functional contract the durable path must preserve: a
@@ -333,5 +333,31 @@ func TestCreateBuildsAndLoadsThroughMissingStateRoot(t *testing.T) {
 	}
 	if _, err := s.Load("job1"); err != nil {
 		t.Fatalf("Load after Create: %v", err)
+	}
+}
+
+// TestMkdirAllDurableCreatesMissingTree pins the exported durable-mkdir helper,
+// now shared by Store.Create and the manager's cross-process lock dir (issue #119):
+// it must build a fully missing directory tree and return nil, and be idempotent on
+// a path that already exists (a second call returns nil). The parent fsyncs are
+// not observable from a test (they have no effect absent a crash), so this pins the
+// functional contract only; missingAncestors' own test pins which parents get synced.
+func TestMkdirAllDurableCreatesMissingTree(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "a", "b", "c")
+	if err := MkdirAllDurable(target, 0o700); err != nil {
+		t.Fatalf("MkdirAllDurable(missing tree): %v", err)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("target not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target = %v, want a directory", info.Mode())
+	}
+	// Idempotent: a second call on an already-existing path returns nil (a smoke check
+	// of the exported contract; the fsync-skip itself is not test-observable).
+	if err := MkdirAllDurable(target, 0o700); err != nil {
+		t.Fatalf("MkdirAllDurable(existing): %v", err)
 	}
 }

--- a/internal/manager/keylock.go
+++ b/internal/manager/keylock.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
 )
 
 // crossLock provides per-key cross-process advisory locking via flock(2), so the
@@ -81,7 +83,13 @@ func (c *crossLock) tryLock(key string) (bool, error) {
 	if _, held := c.fds[key]; held {
 		return false, fmt.Errorf("crosslock: key %q already held by this process", key)
 	}
-	if err := os.MkdirAll(c.dir, 0o700); err != nil {
+	// MkdirAllDurable, not a bare os.MkdirAll: when this is the first path to create
+	// the shared state root (a keyed job before any Create, admit runs before Create),
+	// it fsyncs the root's own directory entry so a crash cannot lose it (issue #119).
+	// It shares the job store's durable-create logic; on a directory-fsync-hostile
+	// filesystem the fsyncs are logged and swallowed, so it still succeeds like a
+	// bare MkdirAll.
+	if err := jobstore.MkdirAllDurable(c.dir, 0o700); err != nil {
 		return false, fmt.Errorf("create locks dir: %w", err)
 	}
 	f, err := os.OpenFile(c.lockPath(key), os.O_RDWR|os.O_CREATE, 0o600)

--- a/internal/manager/keylock_posix_test.go
+++ b/internal/manager/keylock_posix_test.go
@@ -144,6 +144,7 @@ func TestCrossLockTryLockBuildsMissingStateRoot(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("tryLock through missing state root = (%v, %v), want (true, nil)", ok, err)
 	}
+	defer c.unlock("conv:x") // release the held fd, so the test leaves no lock behind
 	if _, err := os.Stat(c.lockPath("conv:x")); err != nil {
 		t.Fatalf("lock file missing after tryLock: %v", err)
 	}

--- a/internal/manager/keylock_posix_test.go
+++ b/internal/manager/keylock_posix_test.go
@@ -129,3 +129,22 @@ func TestCrossLockFailsClosedOnUncreatableDir(t *testing.T) {
 		t.Fatalf("tryLock on an uncreatable locks dir = (%v, %v), want (false, error)", ok, err)
 	}
 }
+
+// TestCrossLockTryLockBuildsMissingStateRoot exercises tryLock when the state root
+// does not exist yet and is nested a couple of levels deep, so its MkdirAllDurable
+// call (issue #119) has to create <root>, <root>/locks and run the durable path
+// over more than one new ancestor before the flock. This is functional regression
+// coverage for the deeply-missing-root case the cross-lock success tests do not hit
+// (they root at an existing t.TempDir()); the parent fsyncs are not observable, so
+// it asserts only that the lock is acquired and its file exists.
+func TestCrossLockTryLockBuildsMissingStateRoot(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state", "nested") // does not exist yet
+	c := newCrossLock(stateDir)
+	ok, err := c.tryLock("conv:x")
+	if err != nil || !ok {
+		t.Fatalf("tryLock through missing state root = (%v, %v), want (true, nil)", ok, err)
+	}
+	if _, err := os.Stat(c.lockPath("conv:x")); err != nil {
+		t.Fatalf("lock file missing after tryLock: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #118. #118 made job-dir creation crash-durable, but the manager's cross-process lock path still created the shared state root non-durably. In `StartJob`, `admit(key)` runs before `store.Create`, so for the first keyed job on a fresh state dir, `crossLock.tryLock`'s `os.MkdirAll(<StateDir>/locks)` created `<StateDir>` itself with no fsync of its own directory entry; a crash in that window could lose the whole state dir even though `Create` fsynced everything below it.

This exports the durable-create helper as `jobstore.MkdirAllDurable` (body unchanged from #118) and routes `tryLock`'s locks-dir creation through it. Now whichever path (the locks dir or `Create`) first creates `<StateDir>` fsyncs its directory entry, so the state root's own creation is crash-durable regardless of whether the first job carried a conversation key. It is a drop-in for `os.MkdirAll`: same success/error contract, best-effort fsyncs that log and continue on a directory-fsync-hostile filesystem, and a no-op fsync on Windows.

## Related Issues

Closes #119.

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `golangci-lint run` clean (0 issues)
- [x] Added a direct `MkdirAllDurable` test and a cross-lock regression test for the deeply-missing-state-root path; both sabotage-verified. The fsyncs themselves are crash-only observable, noted honestly in the test comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating nested directories for job locks and state management.
  * Ensured directory creation remains durable across filesystem operations.
  * Lock acquisition now succeeds even when the required directory structure does not yet exist.

* **Tests**
  * Added coverage for nested directory creation, repeated calls, and lock acquisition in previously missing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->