### PR TITLE
chore(ci): ignore patch/minor bumps for floating first-party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,14 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # First-party GitHub-owned actions (the actions/* and github/* orgs) are pinned
+    # to floating major tags such as actions/checkout@v7 and github/codeql-action@v4,
+    # which already resolve to the latest patch at runtime. Ignore their patch and
+    # minor bumps so Dependabot stops proposing redundant exact-version pins that
+    # would break the floating-major convention; a major bump still comes through.
+    # Third-party actions are SHA-pinned and are intentionally left to Dependabot.
+    ignore:
+      - dependency-name: "actions/*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+      - dependency-name: "github/*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
## Summary

This repo pins first-party GitHub-owned actions (the `actions/*` and `github/*` orgs) to floating major tags (`actions/checkout@v7`, `actions/setup-go@v7`, `github/codeql-action@v4`), which already resolve to the latest patch at runtime, and reserves SHA-pinning for third-party actions (`golangci/golangci-lint-action`, `goreleaser/goreleaser-action`).

Dependabot does not know that convention, so it keeps opening PRs that pin those floating actions to an exact patch (for example #126: `codeql-action` 4 -> 4.37.4). Such a pin is a no-op at runtime and breaks the floating-major convention. This adds a Dependabot `ignore` for patch and minor version updates on the `actions/*` and `github/*` namespaces so those redundant pins stop, while a real major bump still comes through. SHA-pinned third-party actions are untouched and stay under Dependabot so their SHAs keep getting updated.

Supersedes #126 (which will be closed once this merges).

## Test Plan

- [x] `dependabot.yml` parses as valid YAML with the intended `ignore` structure
- [ ] After merge: confirm Dependabot re-evaluates and does not re-open a first-party action pin, while third-party SHA updates still flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to reduce proposals for minor and patch updates to select built-in GitHub Actions.
  * Major updates and third-party action updates continue to be considered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->