### PR TITLE
feat(tools): expose --json-schema to enforce structured output on a run (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Or add to your MCP client config:
 
 ## Tools
 
-- `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?)` -> `{ job_id, conversation_id?, state }`
-- `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
+- `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?)` -> `{ job_id, conversation_id?, state }`
+- `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
 - `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage? }`
 - `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -96,6 +96,7 @@ type StartRequest struct {
 	Model          string   // optional; falls back to cfg.DefaultModel
 	Dirs           []string // repeated --add-dir
 	ConversationID string   // optional; --conversation <id>
+	JSONSchema     string   // optional; --json-schema <inline schema or path>, constrains the final stream-json result
 	ContinueLatest bool     // resolve cwd's latest conversation before the run
 	Cwd            string   // optional; defaults to process cwd
 	Timeout        time.Duration
@@ -878,6 +879,7 @@ const (
 	modelFlag                      = "--model"
 	addDirFlag                     = "--add-dir"
 	conversationFlag               = "--conversation"
+	jsonSchemaFlag                 = "--json-schema"
 	outputFormatFlag               = "--output-format"
 	// streamJSONFormat is the only format agy-mcp drives. It is what makes the
 	// conversation id observable mid-run (the init event carries it) and what
@@ -900,6 +902,9 @@ func buildAgyArgs(req StartRequest) []string {
 	}
 	if req.ConversationID != "" {
 		args = append(args, conversationFlag, req.ConversationID)
+	}
+	if req.JSONSchema != "" {
+		args = append(args, jsonSchemaFlag, req.JSONSchema)
 	}
 	args = append(args, "-p", req.Prompt)
 	return args

--- a/internal/manager/start_test.go
+++ b/internal/manager/start_test.go
@@ -10,14 +10,15 @@ import (
 )
 
 // TestBuildAgyArgs pins the agy command line: the fixed flags, then --model,
-// repeated --add-dir, --conversation, and finally -p with the prompt, with the
-// optional flags omitted when their fields are empty.
+// repeated --add-dir, --conversation, --json-schema, and finally -p with the
+// prompt, with the optional flags omitted when their fields are empty.
 func TestBuildAgyArgs(t *testing.T) {
 	got := buildAgyArgs(StartRequest{
 		Prompt:         "review this",
 		Model:          "Gemini 3.1 Pro (High)",
 		Dirs:           []string{"/a", "/b"},
 		ConversationID: "cid-123",
+		JSONSchema:     `{"type":"object"}`,
 		Timeout:        20 * time.Minute,
 	})
 	want := []string{
@@ -27,6 +28,7 @@ func TestBuildAgyArgs(t *testing.T) {
 		"--model", "Gemini 3.1 Pro (High)",
 		"--add-dir", "/a", "--add-dir", "/b",
 		"--conversation", "cid-123",
+		"--json-schema", `{"type":"object"}`,
 		"-p", "review this",
 	}
 	if !slices.Equal(got, want) {

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -26,6 +26,7 @@ type runInput struct {
 	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd instead of starting fresh. Mutually exclusive with conversation_id: setting this true together with a conversation_id is an error, though leaving it false alongside one is fine"`
 	Cwd            string   `json:"cwd,omitempty" jsonschema:"absolute path of the directory the agent runs in and may edit files under; also scopes continue_latest. Fresh runs sharing a cwd run concurrently. A relative path is resolved against the server's working directory, which is not necessarily yours, so pass an absolute one. Symlinks are resolved. Defaults to the server's own working directory"`
 	Timeout        string   `json:"timeout,omitempty" jsonschema:"max wall-clock duration for the whole run (Go duration, e.g. 20m); a value over 24h is rejected. On expiry the agy process tree is killed and the job ends in state failed. Omit to use the server's default"`
+	JSONSchema     string   `json:"json_schema,omitempty" jsonschema:"optional JSON Schema to enforce on the run's structured result: pass either an inline schema string or a path to a schema file, and agy constrains the final result to it (in stream-json mode the schema applies to the terminal result event). Omit for an unconstrained free-text result. Useful when the result is consumed programmatically, e.g. extraction, classification, or structured summaries"`
 }
 
 // maxJobTimeout caps a client-supplied per-job timeout. It bounds both the agy
@@ -114,6 +115,7 @@ func (in runInput) toStartRequest() (manager.StartRequest, error) {
 	req := manager.StartRequest{
 		Prompt: in.Prompt, Model: in.Model, Dirs: in.Dirs,
 		ConversationID: in.ConversationID, ContinueLatest: in.ContinueLatest, Cwd: in.Cwd,
+		JSONSchema: in.JSONSchema,
 	}
 	if in.Timeout != "" {
 		d, err := time.ParseDuration(in.Timeout)

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -120,3 +120,19 @@ func TestToStartRequestAcceptsTimeoutAtLimit(t *testing.T) {
 		t.Fatalf("timeout at the limit should be accepted: req=%+v err=%v", req, err)
 	}
 }
+
+// TestToStartRequestPassesJSONSchema: the json_schema input is threaded verbatim
+// into the start request (agy-mcp does not parse or validate it, agy owns schema
+// semantics), so buildAgyArgs can forward it as --json-schema. A dropped field
+// here would silently ignore a caller's schema request.
+func TestToStartRequestPassesJSONSchema(t *testing.T) {
+	t.Parallel()
+	const schema = `{"type":"object","required":["verdict"]}`
+	req, err := runInput{Prompt: "x", JSONSchema: schema}.toStartRequest()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.JSONSchema != schema {
+		t.Fatalf("JSONSchema = %q, want it threaded through unchanged as %q", req.JSONSchema, schema)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #123. Adds an optional `json_schema` input to `agy_run` and `agy_run_sync` that forwards agy's `--json-schema` flag, so a caller can enforce a JSON Schema (an inline schema string or a path to a schema file) on a run's structured result. agy-mcp always drives agy with `--output-format stream-json`, where the schema applies to the terminal `result` event. When `json_schema` is omitted, nothing changes.

The value is forwarded verbatim: agy-mcp does not parse or validate the schema, leaving agy the single source of truth for schema semantics, the same way `model` and `conversation_id` are passed through. The flag is appended in `buildAgyArgs`, persists in the job's stored args (`meta.Args`), and the supervisor replays it on restore, so no supervisor change is needed. No version-floor change: `--json-schema` is available at the current agy 1.1.8 floor, which the version gate already enforces.

## Related Issues

Closes #123.

## Test Plan

- [x] `TestBuildAgyArgs` extended: asserts `--json-schema <value>` appears between `--conversation` and `-p`; the minimal case pins that an empty field omits the flag.
- [x] `TestToStartRequestPassesJSONSchema` (new): the wire input is threaded verbatim into the start request.
- [x] `go build ./...`, `go vet ./...`, ruleguard compile, golangci-lint v2.12.2 (0 issues), full suite with `-race -count=1` (all 11 packages).
- [x] Verified against agy 1.1.10 that `--json-schema` takes an inline schema or a path and, for stream-json, applies to the final result event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional JSON Schema support for `agy_run` and `agy_run_sync`.
  * Runs can now produce structured results validated against an inline or file-based schema.
  * Updated tool documentation to reflect the new parameter.

* **Tests**
  * Added coverage verifying JSON Schema values are passed through and applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->