### PR TITLE
feat(tools): expose --mode, --agent, --sandbox run options as pass-throughs (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Or add to your MCP client config:
 
 ## Tools
 
-- `agy_run(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?)` -> `{ job_id, conversation_id?, state }`
-- `agy_run_sync(prompt, model?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
+- `agy_run(prompt, model?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?)` -> `{ job_id, conversation_id?, state }`
+- `agy_run_sync(prompt, model?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
 - `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage? }`
 - `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
@@ -112,10 +112,11 @@ them without consulting this file. The constraints worth knowing up front: `conv
 and `continue_latest` are mutually exclusive (setting `continue_latest` true alongside a
 `conversation_id` is an error); `timeout` is a Go duration and a value above 24h is rejected
 outright, and on expiry the
-`agy` process tree is killed and the job ends in state `failed`; `wait` defaults to 2m and is
-silently clamped to 10m, and it bounds only the inline wait, never the job itself. `agy_cancel`
-is asynchronous, so it usually returns `running` and the job settles to `cancelled` a moment
-later.
+`agy` process tree is killed and the job ends in state `failed`; `mode`, when set, must be
+`accept-edits` or `plan`, and any other value is rejected before the run starts; `wait` defaults
+to 2m and is silently clamped to 10m, and it bounds only the inline wait, never the job itself.
+`agy_cancel` is asynchronous, so it usually returns `running` and the job settles to `cancelled`
+a moment later.
 
 A fresh `agy_run` (no `conversation_id`, no `continue_latest`) reports the conversation agy
 created for it. agy names the conversation in the `init` event of its stream, which arrives

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -94,6 +94,9 @@ func New(c config.Config) *Manager {
 type StartRequest struct {
 	Prompt         string
 	Model          string   // optional; falls back to cfg.DefaultModel
+	Mode           string   // optional; --mode <accept-edits|plan>, agy's agent execution mode
+	Agent          string   // optional; --agent <name>, selects a specific agy agent
+	Sandbox        bool     // optional; --sandbox, runs agy with terminal restrictions
 	Dirs           []string // repeated --add-dir
 	ConversationID string   // optional; --conversation <id>
 	JSONSchema     string   // optional; --json-schema <inline schema or path>, constrains the final stream-json result
@@ -877,6 +880,9 @@ const (
 	dangerouslySkipPermissionsFlag = "--dangerously-skip-permissions"
 	printTimeoutFlag               = "--print-timeout"
 	modelFlag                      = "--model"
+	modeFlag                       = "--mode"
+	agentFlag                      = "--agent"
+	sandboxFlag                    = "--sandbox"
 	addDirFlag                     = "--add-dir"
 	conversationFlag               = "--conversation"
 	jsonSchemaFlag                 = "--json-schema"
@@ -896,6 +902,15 @@ func buildAgyArgs(req StartRequest) []string {
 	}
 	if req.Model != "" {
 		args = append(args, modelFlag, req.Model)
+	}
+	if req.Mode != "" {
+		args = append(args, modeFlag, req.Mode)
+	}
+	if req.Agent != "" {
+		args = append(args, agentFlag, req.Agent)
+	}
+	if req.Sandbox {
+		args = append(args, sandboxFlag)
 	}
 	for _, d := range req.Dirs {
 		args = append(args, addDirFlag, d)

--- a/internal/manager/start_test.go
+++ b/internal/manager/start_test.go
@@ -10,12 +10,16 @@ import (
 )
 
 // TestBuildAgyArgs pins the agy command line: the fixed flags, then --model,
-// repeated --add-dir, --conversation, --json-schema, and finally -p with the
-// prompt, with the optional flags omitted when their fields are empty.
+// --mode, --agent, --sandbox, repeated --add-dir, --conversation, --json-schema,
+// and finally -p with the prompt, with the optional flags omitted when their
+// fields are empty (and --sandbox omitted when false).
 func TestBuildAgyArgs(t *testing.T) {
 	got := buildAgyArgs(StartRequest{
 		Prompt:         "review this",
 		Model:          "Gemini 3.1 Pro (High)",
+		Mode:           "plan",
+		Agent:          "reviewer",
+		Sandbox:        true,
 		Dirs:           []string{"/a", "/b"},
 		ConversationID: "cid-123",
 		JSONSchema:     `{"type":"object"}`,
@@ -26,6 +30,9 @@ func TestBuildAgyArgs(t *testing.T) {
 		"--print-timeout", "20m0s",
 		"--output-format", "stream-json",
 		"--model", "Gemini 3.1 Pro (High)",
+		"--mode", "plan",
+		"--agent", "reviewer",
+		"--sandbox",
 		"--add-dir", "/a", "--add-dir", "/b",
 		"--conversation", "cid-123",
 		"--json-schema", `{"type":"object"}`,

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -21,6 +21,9 @@ import (
 type runInput struct {
 	Prompt         string   `json:"prompt" jsonschema:"the complete task for the delegated agent: what to do, the context needed to do it, and the output wanted back; the agent cannot see this conversation, so the prompt must stand alone"`
 	Model          string   `json:"model,omitempty" jsonschema:"agy model name; omit to use the server's default model, or agy's own default when the server sets none. Call list_models for the accepted values"`
+	Mode           string   `json:"mode,omitempty" jsonschema:"agy agent execution mode for this run (agy --mode): accept-edits or plan. Omit to use agy's default mode"`
+	Agent          string   `json:"agent,omitempty" jsonschema:"name of a specific agy agent to run for this session (agy --agent); omit to use agy's default agent"`
+	Sandbox        bool     `json:"sandbox,omitempty" jsonschema:"run the agent with agy's sandbox (terminal restrictions) enabled (agy --sandbox); off by default"`
 	Dirs           []string `json:"dirs,omitempty" jsonschema:"extra directories to grant the agent beyond cwd (agy --add-dir), e.g. a spec or a sibling repo. The agent can read and write there exactly as under cwd, so this widens the blast radius; prefer absolute paths"`
 	ConversationID string   `json:"conversation_id,omitempty" jsonschema:"continue this specific conversation instead of starting fresh, so earlier context need not be restated; take it from a previous run's conversation_id or from list_sessions. Mutually exclusive with continue_latest"`
 	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd instead of starting fresh. Mutually exclusive with conversation_id: setting this true together with a conversation_id is an error, though leaving it false alongside one is fine"`
@@ -33,6 +36,14 @@ type runInput struct {
 // --print-timeout and the supervisor's hard-kill deadline, so a typo like "1000h"
 // cannot leave a hung job uncollectable for weeks.
 const maxJobTimeout = 24 * time.Hour
+
+// agy --mode accepts exactly these agent execution modes. toStartRequest
+// validates against them so a bad value fails at the tool boundary with a clear
+// message rather than reaching agy, which agy-mcp cannot surface as cleanly.
+const (
+	agyModeAcceptEdits = "accept-edits"
+	agyModePlan        = "plan"
+)
 
 // ToolAgyRunSync is the agy_run_sync tool name, exported so out-of-package
 // callers (the hook-wait suppression gate) can match it against a hook payload's
@@ -110,12 +121,18 @@ var (
 )
 
 // toStartRequest converts the wire input into a manager start request,
-// validating the timeout.
+// validating the mode and timeout.
 func (in runInput) toStartRequest() (manager.StartRequest, error) {
 	req := manager.StartRequest{
 		Prompt: in.Prompt, Model: in.Model, Dirs: in.Dirs,
 		ConversationID: in.ConversationID, ContinueLatest: in.ContinueLatest, Cwd: in.Cwd,
 		JSONSchema: in.JSONSchema,
+		Mode:       in.Mode,
+		Agent:      in.Agent,
+		Sandbox:    in.Sandbox,
+	}
+	if in.Mode != "" && in.Mode != agyModeAcceptEdits && in.Mode != agyModePlan {
+		return manager.StartRequest{}, fmt.Errorf("invalid mode %q: want %s or %s", in.Mode, agyModeAcceptEdits, agyModePlan)
 	}
 	if in.Timeout != "" {
 		d, err := time.ParseDuration(in.Timeout)

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -136,3 +136,63 @@ func TestToStartRequestPassesJSONSchema(t *testing.T) {
 		t.Fatalf("JSONSchema = %q, want it threaded through unchanged as %q", req.JSONSchema, schema)
 	}
 }
+
+// TestToStartRequestPassesRunOptions: the mode/agent/sandbox inputs are threaded
+// into the start request so buildAgyArgs can forward them to agy. A dropped field
+// here would silently ignore a caller's run-shaping request.
+func TestToStartRequestPassesRunOptions(t *testing.T) {
+	t.Parallel()
+	req, err := runInput{Prompt: "x", Mode: "plan", Agent: "reviewer", Sandbox: true}.toStartRequest()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Mode != "plan" {
+		t.Errorf("Mode = %q, want plan", req.Mode)
+	}
+	if req.Agent != "reviewer" {
+		t.Errorf("Agent = %q, want reviewer", req.Agent)
+	}
+	if !req.Sandbox {
+		t.Errorf("Sandbox = %v, want true", req.Sandbox)
+	}
+}
+
+// TestToStartRequestValidatesMode: mode is an agy enum (accept-edits, plan), so a
+// bad value must fail fast at the tool boundary with a message that quotes the bad
+// value and names the accepted values, rather than reaching agy. An empty mode is
+// valid and means "omit the flag". Validation is exact, so a wrong case is rejected.
+func TestToStartRequestValidatesMode(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, mode string
+		wantErr    bool
+	}{
+		{name: "empty is ok", mode: "", wantErr: false},
+		{name: "accept-edits ok", mode: "accept-edits", wantErr: false},
+		{name: "plan ok", mode: "plan", wantErr: false},
+		{name: "unknown rejected", mode: "planning", wantErr: true},
+		{name: "wrong case rejected", mode: "Plan", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := runInput{Prompt: "x", Mode: tc.mode}.toStartRequest()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("mode %q was accepted, want a rejection", tc.mode)
+				}
+				if !strings.Contains(err.Error(), tc.mode) ||
+					!strings.Contains(err.Error(), "accept-edits") ||
+					!strings.Contains(err.Error(), "plan") {
+					t.Fatalf("err = %v, want it to quote %q and name the accepted values", err, tc.mode)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("mode %q was rejected, want accepted: %v", tc.mode, err)
+			}
+			if req.Mode != tc.mode {
+				t.Fatalf("Mode = %q, want %q", req.Mode, tc.mode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements #124 for three of its four flags. Adds optional `mode`, `agent`, and `sandbox` inputs to `agy_run` and `agy_run_sync` that forward agy's `--mode` / `--agent` / `--sandbox`, each appended to the agy command line only when set:

- `mode` -> `--mode <accept-edits|plan>`, validated against agy's accepted values at the tool boundary (`toStartRequest`) so a bad value fails fast with a message naming the accepted values, rather than reaching agy where the error is harder to surface.
- `agent` -> `--agent <name>`, forwarded verbatim (free string).
- `sandbox` (bool) -> `--sandbox` when true (a bare flag; agy runs with terminal restrictions). It only adds restrictions and does not touch the always-on `--dangerously-skip-permissions`.

Forwarded the same way as `model` and `conversation_id`. The flags persist in the job's stored args (`meta.Args`) and the supervisor replays them on restore, so no supervisor change is needed. `agy_run_sync` gets all three (and the mode validation) for free via `runSyncInput` embedding `runInput`.

### Why `--effort` is deferred (not in this PR)

Issue #124 also lists `--effort`, but the agy 1.1.10 changelog fixes `--effort` (and `--model`) "being ignored ... in headless `-p` runs", so on agy 1.1.8/1.1.9 (both within the current `agyver.Required` 1.1.8 floor) `--effort` is a silent no-op in the headless mode agy-mcp always uses. Wiring it now would ship the version-dependent footgun issue #122 is about. It needs the floor raised to agy 1.1.10, a separate policy decision. `--mode`, `--agent`, and `--sandbox` all work in headless `-p` at the 1.1.8 floor (`--sandbox` headless propagation was fixed in agy 1.0.6, `--agent` added 1.1.1, `--mode` present since ~1.1.0 with no headless bug recorded). Flag presence and enum values confirmed against agy 1.1.10 `--help`.

## Related Issues

Relates to #124 (implements `mode`/`agent`/`sandbox`; `--effort` deferred pending an agy-floor decision, tracked on the issue).

## Test Plan

- [x] Built test-first (RED then GREEN): `TestToStartRequestPassesRunOptions`, `TestToStartRequestValidatesMode` (empty/accept-edits/plan valid; unknown and wrong-case rejected), and `TestBuildAgyArgs` extended for the new flags and their omission.
- [x] `go build`, `go vet`, ruleguard compile, golangci-lint v2.12.2 (0 issues), full suite with `-race -count=1` (all 11 packages).
- [x] Pre-push gate (6 review agents + Gemini cross-check): converged clean, one doc-comment accuracy fix applied.
- [x] `--mode`/`--agent`/`--sandbox` and the `accept-edits`/`plan` enum verified against agy 1.1.10 `--help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional mode, agent, and sandbox settings for delegated runs.
  * Supported modes are `accept-edits` and `plan`.
  * Added validation to reject unsupported mode values before execution.
  * Updated run and synchronous run documentation with the new options.

* **Tests**
  * Added coverage for option forwarding and mode validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->