### PR TITLE
feat(agyver): raise agy floor to 1.1.10 and de-hardcode the version floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An MCP (Model Context Protocol) server that wraps the [Antigravity CLI](https://antigravity.google) (`agy`), so any MCP client (Claude Code, Cursor, Cline, and others) can run `agy` prompts, peer reviews, and follow-up turns as native tools.
 
-> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, cross-platform builds) and verified against a live agy (1.1.10; the floor is still 1.1.8).
+> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, cross-platform builds) and verified against a live agy (1.1.10), which is also the floor.
 
 ## Why
 
@@ -49,9 +49,9 @@ Two transports run the same core:
 
 ## Requirements
 
-- **agy 1.1.8 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation: 1.1.8 added `--output-format` to print mode, and agy-mcp drives every job through the `stream-json` format it introduced. Older builds are refused rather than degraded.
+- **agy 1.1.10 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation. Two things set it: 1.1.8 added `--output-format` to print mode and agy-mcp drives every job through the `stream-json` format it introduced, and 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in headless `-p` (`--model`, and `--effort` once wired) are honored rather than silently ignored (both per agy's changelog). Older builds are refused rather than degraded.
 
-  The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.8 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
+  The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.10 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
 
   A missing `agy` does not stop the server from starting. `initialize`, `tools/list`, and `list_sessions` never exec it, so the lookup is deferred: the server starts, logs a warning to stderr, serves discovery normally, and the tools that do need the binary (`agy_run`, `agy_run_sync`, `list_models`) fail per call with `agy not found on PATH; set AGY_MCP_AGY_PATH`. An `agy` installed later is picked up without restarting the server. An explicit `AGY_MCP_AGY_PATH` is treated differently: it is a claim about one specific binary, so a typo or a non-executable target still fails fast at startup.
 - Go 1.26+ to build.
@@ -63,7 +63,7 @@ Two transports run the same core:
 
 > Note: every job spawns a fresh `agy` process, which on startup launches whatever MCP servers are configured in agy's own `mcp_config.json`. Peer-review and automation runs usually do not need those servers, and a slow or hanging one adds latency to every job. agy 1.0.7+ bounds this with a per-server launch `timeout` (set `-1` to disable it). If startup is slow, give the unneeded servers a `timeout` in agy's `mcp_config.json`, or point agy at a trimmed config.
 >
-> Note (continuation): a follow-up turn runs `agy --conversation <id> -p <prompt>`, and the job result is the `response` field of agy's terminal `result` event. Verified against 1.1.8: a resumed run returns only the new turn and echoes the same conversation id, with `num_turns` incremented.
+> Note (continuation): a follow-up turn runs `agy --conversation <id> -p <prompt>`, and the job result is the `response` field of agy's terminal `result` event. Verified against 1.1.10: a resumed run returns only the new turn and echoes the same conversation id, with `num_turns` incremented.
 >
 > Note (auth): agy-mcp passes its own process environment through to every spawned `agy`, so agy's normal OAuth credentials are used by default. For headless or daemon deployments (HTTP mode, cron) where no browser is available, set `USE_ADC=1` in the server's environment to have agy authenticate via Google Application Default Credentials instead of the interactive sign-in flow (agy 1.0.11+). No agy-mcp flag or code change is needed; unset it to fall back to the other sign-in methods.
 
@@ -217,7 +217,7 @@ agy-mcp -http 127.0.0.1:8765 -http-token "$(openssl rand -hex 32)"
 
 ## Upgrading from v1
 
-v2 requires agy 1.1.8 and drives it through `--output-format stream-json`. The upgrade is safe to do in place, but two things are worth knowing.
+v2 requires agy 1.1.10 and drives it through `--output-format stream-json`. The upgrade is safe to do in place, but two things are worth knowing.
 
 **Stop the server before replacing the binary.** The supervisor is the same `agy-mcp` binary re-executed as `agy-mcp run-job <dir>`, so replacing it under a live v1 server pairs an old manager with a new supervisor. The supervisor detects that case and asks agy for the event stream anyway, so no result is lost, but a v1 manager and a v2 process sharing one `AGY_MCP_STATE_DIR` briefly disagree about cross-process locking, and a v1 run's conversation id can be misattributed in that window.
 
@@ -226,7 +226,7 @@ v2 requires agy 1.1.8 and drives it through `--output-format stream-json`. The u
 - A v1 fresh run may report no `conversation_id`. v1 recovered it by diffing agy's conversation cache, and v2 has no such path. Recover the thread with `list_sessions` if you need it.
 - Cancelled and interrupted v1 jobs behave as before; only the id is affected.
 
-**Behaviour changes to check your client against:** `agy_run` now blocks up to 2s waiting for agy to name the conversation, instead of returning instantly; fresh runs in the same directory no longer conflict, so anything that relied on that conflict error as a mutex now gets real concurrency (and agy runs with `--dangerously-skip-permissions`, so concurrent runs edit one working tree); and `list_models` is now refused on an agy older than 1.1.8, even though `agy models` itself would work there.
+**Behaviour changes to check your client against:** `agy_run` now blocks up to 2s waiting for agy to name the conversation, instead of returning instantly; fresh runs in the same directory no longer conflict, so anything that relied on that conflict error as a mutex now gets real concurrency (and agy runs with `--dangerously-skip-permissions`, so concurrent runs edit one working tree); and `list_models` is now refused on an agy older than 1.1.10, even though `agy models` itself would work there.
 
 ## Configuration
 

--- a/internal/agyver/agyver.go
+++ b/internal/agyver/agyver.go
@@ -10,11 +10,15 @@ import (
 	"strings"
 )
 
-// Required is the oldest agy that agy-mcp can drive. 1.1.8 added
-// --output-format (text, json, stream-json) to print mode; the whole job
-// pipeline reads the stream-json event stream, so an older agy cannot be used
-// at all rather than degraded.
-var Required = Version{Major: 1, Minor: 1, Patch: 8}
+// Required is the oldest agy that agy-mcp can drive. Two facts set the floor.
+// 1.1.8 added --output-format (text, json, stream-json) to print mode, and the
+// whole job pipeline reads the stream-json event stream, so an older agy cannot
+// be used at all rather than degraded. 1.1.10 is then the first release where
+// the run-shaping flags agy-mcp forwards in headless -p (--model, and --effort
+// once it is wired) actually take effect; on 1.1.8/1.1.9 they were silently
+// ignored, so a lower floor would let a passing gate hide a no-op flag. Both
+// facts are from agy's own changelog, verified against the installed 1.1.10.
+var Required = Version{Major: 1, Minor: 1, Patch: 10}
 
 // Version is a parsed agy version.
 type Version struct {

--- a/internal/agyver/agyver.go
+++ b/internal/agyver/agyver.go
@@ -17,7 +17,7 @@ import (
 // the run-shaping flags agy-mcp forwards in headless -p (--model, and --effort
 // once it is wired) actually take effect; on 1.1.8/1.1.9 they were silently
 // ignored, so a lower floor would let a passing gate hide a no-op flag. Both
-// facts are from agy's own changelog, verified against the installed 1.1.10.
+// facts are from agy's own changelog (run `agy changelog` to confirm).
 var Required = Version{Major: 1, Minor: 1, Patch: 10}
 
 // Version is a parsed agy version.

--- a/internal/agyver/agyver_test.go
+++ b/internal/agyver/agyver_test.go
@@ -316,10 +316,11 @@ func TestParseResolvesNoisyOutput(t *testing.T) {
 	}
 }
 
-// The number is only half of it: every case above that resolves to a pre-1.1.8
-// version is a gate bypass if the parser picks the wrong candidate, so assert
-// the consequence too. The inputs are DERIVED from parseCases rather than
-// copied, so a case added there is covered here automatically.
+// The number is only half of it: every case above that resolves to a sub-floor
+// version (below Required) is a gate bypass if the parser picks the wrong
+// candidate, so assert the consequence too. The inputs are DERIVED from
+// parseCases rather than copied, so a case added there is covered here
+// automatically.
 func TestParseNeverPromotesPastTheFloor(t *testing.T) {
 	t.Parallel()
 	checked := 0
@@ -423,17 +424,22 @@ func FuzzParseRoundTrip(f *testing.F) {
 
 func TestAtLeast(t *testing.T) {
 	t.Parallel()
+	// AtLeast is pure version ordering, so pin a fixed reference rather than the
+	// production floor (Required): this test must not move when the floor moves.
+	// The floor boundary itself stays covered by the manager version tests and by
+	// TestParseNeverPromotesPastTheFloor.
+	ref := Version{1, 1, 8}
 	cases := []struct {
 		v, min Version
 		want   bool
 	}{
-		{Version{1, 1, 8}, Required, true},  // exactly the minimum
-		{Version{1, 1, 9}, Required, true},  // patch ahead
-		{Version{1, 2, 0}, Required, true},  // minor ahead
-		{Version{2, 0, 0}, Required, true},  // major ahead
-		{Version{1, 1, 7}, Required, false}, // the release just before
-		{Version{1, 0, 99}, Required, false},
-		{Version{0, 9, 9}, Required, false},
+		{Version{1, 1, 8}, ref, true},  // exactly the reference
+		{Version{1, 1, 9}, ref, true},  // patch ahead
+		{Version{1, 2, 0}, ref, true},  // minor ahead
+		{Version{2, 0, 0}, ref, true},  // major ahead
+		{Version{1, 1, 7}, ref, false}, // the release just before
+		{Version{1, 0, 99}, ref, false},
+		{Version{0, 9, 9}, ref, false},
 	}
 	for _, tc := range cases {
 		if got := tc.v.AtLeast(tc.min); got != tc.want {
@@ -447,7 +453,7 @@ func TestString(t *testing.T) {
 	if got := (Version{1, 1, 8}).String(); got != "1.1.8" {
 		t.Fatalf("String() = %q, want 1.1.8", got)
 	}
-	if got := Required.String(); got != "1.1.8" {
+	if got := Required.String(); got != "1.1.10" {
 		t.Fatalf("Required = %q; update this test deliberately when the floor moves", got)
 	}
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -155,8 +155,8 @@ func (m *Manager) agyBinaryChecked(ctx context.Context) (string, error) {
 	}
 	if !v.AtLeast(agyver.Required) {
 		return "", fmt.Errorf(
-			"agy %s or newer is required (agy-mcp drives agy through --output-format stream-json, added in %s); found %s at %s",
-			agyver.Required, agyver.Required, v, agy)
+			"agy %s or newer is required (agy-mcp drives agy through --output-format stream-json); found %s at %s",
+			agyver.Required, v, agy)
 	}
 	m.verifiedAgy = agy
 	return agy, nil

--- a/internal/manager/version_posix_test.go
+++ b/internal/manager/version_posix_test.go
@@ -27,7 +27,7 @@ func TestReadAgyVersionToleratesWaitDelay(t *testing.T) {
 	// it afterwards rather than leaving a 30-second sleep behind on every run.
 	pidFile := filepath.Join(dir, "sleeper.pid")
 	// Print the version, leave a descendant holding stdout, exit cleanly.
-	body := "#!/bin/sh\necho 1.1.8\nsleep 30 &\necho $! > \"" + pidFile + "\"\nexit 0\n"
+	body := "#!/bin/sh\necho " + agyver.Required.String() + "\nsleep 30 &\necho $! > \"" + pidFile + "\"\nexit 0\n"
 	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -55,6 +55,6 @@ func TestReadAgyVersionToleratesWaitDelay(t *testing.T) {
 		t.Fatalf("parse %q: %v", raw, perr)
 	}
 	if !v.AtLeast(agyver.Required) {
-		t.Fatalf("version = %v, want the printed 1.1.8", v)
+		t.Fatalf("version = %v, want the printed %s", v, agyver.Required)
 	}
 }

--- a/internal/manager/version_test.go
+++ b/internal/manager/version_test.go
@@ -83,7 +83,7 @@ func TestAgyBinaryCheckedRetriesAfterRefusal(t *testing.T) {
 	if _, err := m.agyBinaryChecked(t.Context()); err == nil {
 		t.Fatal("precondition: the old version must be refused")
 	}
-	version.Store("1.1.8") // the user upgrades agy mid-session
+	version.Store(agyver.Required.String()) // the user upgrades agy mid-session
 	if _, err := m.agyBinaryChecked(t.Context()); err != nil {
 		t.Fatalf("an upgraded agy must be accepted without a restart: %v", err)
 	}


### PR DESCRIPTION
## Summary

Raises `agyver.Required` from 1.1.8 to 1.1.10 and removes the hardcoded floor literals from the tests so the next bump is a one-line change to the constant.

The old 1.1.8 floor permitted agy versions where `--model` and `--effort` are silently ignored in headless `-p` runs (per the agy 1.1.10 changelog: "Fixed `--model` and `--effort` being ignored ... in headless `-p` runs"). agy-mcp always drives agy headless and forwards `--model` on every run, so below 1.1.10 a core feature was a silent no-op. 1.1.10 is also the version agy-mcp is verified against.

## Changes

- `internal/agyver/agyver.go`: `Required` becomes `{1,1,10}`, with a broadened rationale citing the agy changelog.
- `internal/manager/manager.go`: drop the `", added in %s"` clause from the version-gate error so it is accurate at any floor. It previously read "stream-json, added in `<floor>`", which was only true while the floor equalled the stream-json version (both 1.1.8).
- Tests de-hardcoded: `TestAtLeast` uses a fixed local reference instead of `Required` (it tests pure ordering, independent of the floor); `version_posix_test.go` and `version_test.go` derive the passing version from `agyver.Required.String()`; the deliberate `TestString` canary moves to 1.1.10.
- `README.md`: floor mentions updated to 1.1.10; the continuation note was re-verified against a live agy 1.1.10.

## Related issues

Fixes #131. Unblocks #122 (needs floor >= 1.1.9) and the remaining `--effort` pass-through in #124 (needs 1.1.10).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test -race ./...` all green.
- [x] Ran the pre-push quality gate (reuse, correctness, quality, integration, regression, test-quality) plus an Antigravity cross-review; no behavioral defects, comment/claim-accuracy findings fixed in this branch.
- [x] Continuation behavior re-verified live against agy 1.1.10: a resumed run echoes the same conversation id with `num_turns` incremented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup and upgrade guidance to require agy 1.1.10 or newer.
  * Clarified compatibility for forwarded run-shaping flags and model listing.

* **Bug Fixes**
  * Improved minimum-version messaging when an incompatible agy version is detected.

* **Chores**
  * Updated version checks and validation to consistently enforce agy 1.1.10.
  * Updated version validation coverage to reflect the revised minimum requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->