### PR TITLE
feat(tools): expose --effort run option as a pass-through (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Two transports run the same core:
 
 ## Requirements
 
-- **agy 1.1.10 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation. Two things set it: 1.1.8 added `--output-format` to print mode and agy-mcp drives every job through the `stream-json` format it introduced, and 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in headless `-p` (`--model`, and `--effort` once wired) are honored rather than silently ignored (both per agy's changelog). Older builds are refused rather than degraded.
+- **agy 1.1.10 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation. Two things set it: 1.1.8 added `--output-format` to print mode and agy-mcp drives every job through the `stream-json` format it introduced, and 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in headless `-p` (`--model` and `--effort`) are honored rather than silently ignored (both per agy's changelog). Older builds are refused rather than degraded.
 
   The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.10 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
 
@@ -93,8 +93,8 @@ Or add to your MCP client config:
 
 ## Tools
 
-- `agy_run(prompt, model?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?)` -> `{ job_id, conversation_id?, state }`
-- `agy_run_sync(prompt, model?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
+- `agy_run(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?)` -> `{ job_id, conversation_id?, state }`
+- `agy_run_sync(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
 - `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage? }`
 - `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
@@ -112,8 +112,9 @@ them without consulting this file. The constraints worth knowing up front: `conv
 and `continue_latest` are mutually exclusive (setting `continue_latest` true alongside a
 `conversation_id` is an error); `timeout` is a Go duration and a value above 24h is rejected
 outright, and on expiry the
-`agy` process tree is killed and the job ends in state `failed`; `mode`, when set, must be
-`accept-edits` or `plan`, and any other value is rejected before the run starts; `wait` defaults
+`agy` process tree is killed and the job ends in state `failed`; `effort`, when set, must be
+`low`, `medium` or `high`, and `mode`, when set, must be `accept-edits` or `plan`, with any other
+value rejected before the run starts; `wait` defaults
 to 2m and is silently clamped to 10m, and it bounds only the inline wait, never the job itself.
 `agy_cancel` is asynchronous, so it usually returns `running` and the job settles to `cancelled`
 a moment later.

--- a/internal/agyver/agyver.go
+++ b/internal/agyver/agyver.go
@@ -14,8 +14,8 @@ import (
 // 1.1.8 added --output-format (text, json, stream-json) to print mode, and the
 // whole job pipeline reads the stream-json event stream, so an older agy cannot
 // be used at all rather than degraded. 1.1.10 is then the first release where
-// the run-shaping flags agy-mcp forwards in headless -p (--model, and --effort
-// once it is wired) actually take effect; on 1.1.8/1.1.9 they were silently
+// the run-shaping flags agy-mcp forwards in headless -p (--model and --effort)
+// actually take effect; on 1.1.8/1.1.9 they were silently
 // ignored, so a lower floor would let a passing gate hide a no-op flag. Both
 // facts are from agy's own changelog (run `agy changelog` to confirm).
 var Required = Version{Major: 1, Minor: 1, Patch: 10}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -94,6 +94,7 @@ func New(c config.Config) *Manager {
 type StartRequest struct {
 	Prompt         string
 	Model          string   // optional; falls back to cfg.DefaultModel
+	Effort         string   // optional; --effort <low|medium|high>, reasoning effort for the session
 	Mode           string   // optional; --mode <accept-edits|plan>, agy's agent execution mode
 	Agent          string   // optional; --agent <name>, selects a specific agy agent
 	Sandbox        bool     // optional; --sandbox, runs agy with terminal restrictions
@@ -880,6 +881,7 @@ const (
 	dangerouslySkipPermissionsFlag = "--dangerously-skip-permissions"
 	printTimeoutFlag               = "--print-timeout"
 	modelFlag                      = "--model"
+	effortFlag                     = "--effort"
 	modeFlag                       = "--mode"
 	agentFlag                      = "--agent"
 	sandboxFlag                    = "--sandbox"
@@ -902,6 +904,9 @@ func buildAgyArgs(req StartRequest) []string {
 	}
 	if req.Model != "" {
 		args = append(args, modelFlag, req.Model)
+	}
+	if req.Effort != "" {
+		args = append(args, effortFlag, req.Effort)
 	}
 	if req.Mode != "" {
 		args = append(args, modeFlag, req.Mode)

--- a/internal/manager/start_test.go
+++ b/internal/manager/start_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 // TestBuildAgyArgs pins the agy command line: the fixed flags, then --model,
-// --mode, --agent, --sandbox, repeated --add-dir, --conversation, --json-schema,
-// and finally -p with the prompt, with the optional flags omitted when their
-// fields are empty (and --sandbox omitted when false).
+// --effort, --mode, --agent, --sandbox, repeated --add-dir, --conversation,
+// --json-schema, and finally -p with the prompt, with the optional flags omitted
+// when their fields are empty (and --sandbox omitted when false).
 func TestBuildAgyArgs(t *testing.T) {
 	got := buildAgyArgs(StartRequest{
 		Prompt:         "review this",
 		Model:          "Gemini 3.1 Pro (High)",
+		Effort:         "high",
 		Mode:           "plan",
 		Agent:          "reviewer",
 		Sandbox:        true,
@@ -30,6 +31,7 @@ func TestBuildAgyArgs(t *testing.T) {
 		"--print-timeout", "20m0s",
 		"--output-format", "stream-json",
 		"--model", "Gemini 3.1 Pro (High)",
+		"--effort", "high",
 		"--mode", "plan",
 		"--agent", "reviewer",
 		"--sandbox",

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -21,6 +21,7 @@ import (
 type runInput struct {
 	Prompt         string   `json:"prompt" jsonschema:"the complete task for the delegated agent: what to do, the context needed to do it, and the output wanted back; the agent cannot see this conversation, so the prompt must stand alone"`
 	Model          string   `json:"model,omitempty" jsonschema:"agy model name; omit to use the server's default model, or agy's own default when the server sets none. Call list_models for the accepted values"`
+	Effort         string   `json:"effort,omitempty" jsonschema:"reasoning effort for this run (agy --effort): low, medium or high. Omit to use agy's default"`
 	Mode           string   `json:"mode,omitempty" jsonschema:"agy agent execution mode for this run (agy --mode): accept-edits or plan. Omit to use agy's default mode"`
 	Agent          string   `json:"agent,omitempty" jsonschema:"name of a specific agy agent to run for this session (agy --agent); omit to use agy's default agent"`
 	Sandbox        bool     `json:"sandbox,omitempty" jsonschema:"run the agent with agy's sandbox (terminal restrictions) enabled (agy --sandbox); off by default"`
@@ -43,6 +44,15 @@ const maxJobTimeout = 24 * time.Hour
 const (
 	agyModeAcceptEdits = "accept-edits"
 	agyModePlan        = "plan"
+)
+
+// agy --effort accepts exactly these reasoning-effort levels. toStartRequest
+// validates against them so a bad value fails at the tool boundary with a clear
+// message rather than reaching agy.
+const (
+	agyEffortLow    = "low"
+	agyEffortMedium = "medium"
+	agyEffortHigh   = "high"
 )
 
 // ToolAgyRunSync is the agy_run_sync tool name, exported so out-of-package
@@ -121,15 +131,19 @@ var (
 )
 
 // toStartRequest converts the wire input into a manager start request,
-// validating the mode and timeout.
+// validating the effort, mode and timeout.
 func (in runInput) toStartRequest() (manager.StartRequest, error) {
 	req := manager.StartRequest{
 		Prompt: in.Prompt, Model: in.Model, Dirs: in.Dirs,
 		ConversationID: in.ConversationID, ContinueLatest: in.ContinueLatest, Cwd: in.Cwd,
 		JSONSchema: in.JSONSchema,
+		Effort:     in.Effort,
 		Mode:       in.Mode,
 		Agent:      in.Agent,
 		Sandbox:    in.Sandbox,
+	}
+	if in.Effort != "" && in.Effort != agyEffortLow && in.Effort != agyEffortMedium && in.Effort != agyEffortHigh {
+		return manager.StartRequest{}, fmt.Errorf("invalid effort %q: want %s, %s or %s", in.Effort, agyEffortLow, agyEffortMedium, agyEffortHigh)
 	}
 	if in.Mode != "" && in.Mode != agyModeAcceptEdits && in.Mode != agyModePlan {
 		return manager.StartRequest{}, fmt.Errorf("invalid mode %q: want %s or %s", in.Mode, agyModeAcceptEdits, agyModePlan)

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -137,14 +137,17 @@ func TestToStartRequestPassesJSONSchema(t *testing.T) {
 	}
 }
 
-// TestToStartRequestPassesRunOptions: the mode/agent/sandbox inputs are threaded
-// into the start request so buildAgyArgs can forward them to agy. A dropped field
-// here would silently ignore a caller's run-shaping request.
+// TestToStartRequestPassesRunOptions: the effort/mode/agent/sandbox inputs are
+// threaded into the start request so buildAgyArgs can forward them to agy. A
+// dropped field here would silently ignore a caller's run-shaping request.
 func TestToStartRequestPassesRunOptions(t *testing.T) {
 	t.Parallel()
-	req, err := runInput{Prompt: "x", Mode: "plan", Agent: "reviewer", Sandbox: true}.toStartRequest()
+	req, err := runInput{Prompt: "x", Effort: "high", Mode: "plan", Agent: "reviewer", Sandbox: true}.toStartRequest()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Effort != "high" {
+		t.Errorf("Effort = %q, want high", req.Effort)
 	}
 	if req.Mode != "plan" {
 		t.Errorf("Mode = %q, want plan", req.Mode)
@@ -192,6 +195,49 @@ func TestToStartRequestValidatesMode(t *testing.T) {
 			}
 			if req.Mode != tc.mode {
 				t.Fatalf("Mode = %q, want %q", req.Mode, tc.mode)
+			}
+		})
+	}
+}
+
+// TestToStartRequestValidatesEffort: effort is an agy enum (low, medium, high),
+// so a bad value must fail fast at the tool boundary with a message that quotes
+// the bad value and names the accepted values, rather than reaching agy. An empty
+// effort is valid and means "omit the flag". Validation is exact, so a wrong case
+// is rejected.
+func TestToStartRequestValidatesEffort(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, effort string
+		wantErr      bool
+	}{
+		{name: "empty is ok", effort: "", wantErr: false},
+		{name: "low ok", effort: "low", wantErr: false},
+		{name: "medium ok", effort: "medium", wantErr: false},
+		{name: "high ok", effort: "high", wantErr: false},
+		{name: "unknown rejected", effort: "maximum", wantErr: true},
+		{name: "wrong case rejected", effort: "High", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := runInput{Prompt: "x", Effort: tc.effort}.toStartRequest()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("effort %q was accepted, want a rejection", tc.effort)
+				}
+				if !strings.Contains(err.Error(), tc.effort) ||
+					!strings.Contains(err.Error(), "low") ||
+					!strings.Contains(err.Error(), "medium") ||
+					!strings.Contains(err.Error(), "high") {
+					t.Fatalf("err = %v, want it to quote %q and name the accepted values", err, tc.effort)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("effort %q was rejected, want accepted: %v", tc.effort, err)
+			}
+			if req.Effort != tc.effort {
+				t.Fatalf("Effort = %q, want %q", req.Effort, tc.effort)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Exposes agy's `--effort <low|medium|high>` as an optional input on `agy_run` and `agy_run_sync`, completing issue #124. It mirrors exactly how #130 wired `--mode`/`--agent`/`--sandbox`: the value is appended to `buildAgyArgs` only when set, and enum-validated at the tool boundary in `toStartRequest` so a bad value fails fast with a clear message rather than reaching agy.

`--effort` was the one flag #130 deferred, because on agy 1.1.8/1.1.9 it is silently ignored in headless `-p` runs (fixed in the agy 1.1.10 changelog). The floor is now 1.1.10 (#131), so it takes effect and can ship.

## Changes

- `internal/manager/manager.go`: `StartRequest.Effort`, an `effortFlag = "--effort"` constant, and a `buildAgyArgs` append when set.
- `internal/mcptools/tools.go`: `runInput.Effort` (with a jsonschema description), `agyEffort{Low,Medium,High}` constants, threaded into `toStartRequest` and enum-validated. `runSyncInput` embeds `runInput`, so `agy_run_sync` gets it too.
- Tests: `TestBuildAgyArgs` pins the `--effort` arg and its position; a new `TestToStartRequestValidatesEffort` mirrors the mode validation test (empty/low/medium/high accepted, unknown and wrong-case rejected with a message naming the accepted values).
- `README.md`: documents the `effort` input and its constraint, and both tool signatures now list `effort?`.
- `internal/agyver/agyver.go`: drops the now-stale "`--effort` once it is wired" hedge from the floor rationale, since this change wires it.

## Related issues

Closes #124.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), and `go test -race ./...` all green.
- [x] Sabotage-verified: disabling the enum validation reddens `TestToStartRequestValidatesEffort`; disabling the `buildAgyArgs` append reddens `TestBuildAgyArgs`.
- [x] Ran the pre-push quality gate (6 review agents). Zero behavioral defects; the doc-drift findings (README signature list, two stale comments) are fixed in this branch.
- [x] Confirmed agy's real accepted set is `low|medium|high` against the installed agy 1.1.10 (`agy --help`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional reasoning-effort setting to run commands.
  - Supported effort levels: `low`, `medium`, and `high`.
  - The selected effort level is applied when starting runs.

- **Bug Fixes**
  - Added validation to reject unsupported or incorrectly formatted effort values.

- **Documentation**
  - Updated tool usage documentation and noted availability beginning with agy 1.1.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->