### PR TITLE
feat(tools): always disable agy's slash-command/skill expansion in print mode (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ outright, and on expiry the
 value rejected before the run starts; `wait` defaults
 to 2m and is silently clamped to 10m, and it bounds only the inline wait, never the job itself.
 `agy_cancel` is asynchronous, so it usually returns `running` and the job settles to `cancelled`
-a moment later.
+a moment later. A `prompt` is sent to agy literally: a leading slash-command or skill name
+(a prompt beginning with `/`) is treated as text rather than expanded, so caller input means
+exactly what it says regardless of the installed agy version.
 
 A fresh `agy_run` (no `conversation_id`, no `continue_latest`) reports the conversation agy
 created for it. agy names the conversation in the `init` event of its stream, which arrives

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -889,6 +889,7 @@ const (
 	conversationFlag               = "--conversation"
 	jsonSchemaFlag                 = "--json-schema"
 	outputFormatFlag               = "--output-format"
+	disableSlashCommandsFlag       = "--disable-slash-commands"
 	// streamJSONFormat is the only format agy-mcp drives. It is what makes the
 	// conversation id observable mid-run (the init event carries it) and what
 	// leaves an interrupted run with recoverable text; the single-object `json`
@@ -901,6 +902,17 @@ func buildAgyArgs(req StartRequest) []string {
 		dangerouslySkipPermissionsFlag,
 		printTimeoutFlag, req.Timeout.String(),
 		outputFormatFlag, streamJSONFormat,
+		// Keep caller prompts literal. Per agy's changelog, 1.1.9 added slash-command
+		// and skill expansion to print mode together with --disable-slash-commands as
+		// its opt-out, so without this a prompt whose leading token starts with "/"
+		// (a path, a leading-slash sentence, or any caller text that happens to begin
+		// with "/") is reinterpreted as a skill or command. The flag is functional in
+		// headless -p, not merely accepted: the changelog introduces it as the opt-out
+		// for that exact print-mode feature, unlike --effort which was accepted but a
+		// no-op in -p until 1.1.10. Passing it on every run makes prompt semantics mean
+		// what the caller wrote, independent of the installed agy version. Always
+		// available because the agy floor (agyver.Required) is 1.1.10 (>= 1.1.9).
+		disableSlashCommandsFlag,
 	}
 	if req.Model != "" {
 		args = append(args, modelFlag, req.Model)

--- a/internal/manager/start_test.go
+++ b/internal/manager/start_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/tphakala/agy-mcp/v2/internal/config"
 )
 
-// TestBuildAgyArgs pins the agy command line: the fixed flags, then --model,
-// --effort, --mode, --agent, --sandbox, repeated --add-dir, --conversation,
-// --json-schema, and finally -p with the prompt, with the optional flags omitted
-// when their fields are empty (and --sandbox omitted when false).
+// TestBuildAgyArgs pins the agy command line: the fixed flags (ending in
+// --disable-slash-commands so prompts stay literal), then --model, --effort,
+// --mode, --agent, --sandbox, repeated --add-dir, --conversation, --json-schema,
+// and finally -p with the prompt, with the optional flags omitted when their
+// fields are empty (and --sandbox omitted when false).
 func TestBuildAgyArgs(t *testing.T) {
 	got := buildAgyArgs(StartRequest{
 		Prompt:         "review this",
@@ -30,6 +31,7 @@ func TestBuildAgyArgs(t *testing.T) {
 		"--dangerously-skip-permissions",
 		"--print-timeout", "20m0s",
 		"--output-format", "stream-json",
+		"--disable-slash-commands",
 		"--model", "Gemini 3.1 Pro (High)",
 		"--effort", "high",
 		"--mode", "plan",
@@ -52,6 +54,7 @@ func TestBuildAgyArgs(t *testing.T) {
 		"--dangerously-skip-permissions",
 		"--print-timeout", "1m0s",
 		"--output-format", "stream-json",
+		"--disable-slash-commands",
 		"-p", "hi",
 	}
 	if !slices.Equal(got, want) {

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -19,7 +19,7 @@ import (
 // exclusive, what a field defaults to, and what happens on expiry. Keeping that
 // here rather than in the tool description avoids restating the schema in prose.
 type runInput struct {
-	Prompt         string   `json:"prompt" jsonschema:"the complete task for the delegated agent: what to do, the context needed to do it, and the output wanted back; the agent cannot see this conversation, so the prompt must stand alone"`
+	Prompt         string   `json:"prompt" jsonschema:"the complete task for the delegated agent: what to do, the context needed to do it, and the output wanted back; the agent cannot see this conversation, so the prompt must stand alone. It is sent to agy literally, so a leading slash-command or skill name (a prompt starting with /) is treated as text, not expanded"`
 	Model          string   `json:"model,omitempty" jsonschema:"agy model name; omit to use the server's default model, or agy's own default when the server sets none. Call list_models for the accepted values"`
 	Effort         string   `json:"effort,omitempty" jsonschema:"reasoning effort for this run (agy --effort): low, medium or high. Omit to use agy's default"`
 	Mode           string   `json:"mode,omitempty" jsonschema:"agy agent execution mode for this run (agy --mode): accept-edits or plan. Omit to use agy's default mode"`


### PR DESCRIPTION
## Summary

Makes agy-mcp always pass `--disable-slash-commands`, so a delegated `-p` prompt is sent to agy literally: a leading slash-command or skill name (a prompt starting with `/`) is treated as text rather than expanded.

agy 1.1.9 added slash-command/skill expansion to print mode, so without this flag a caller prompt beginning with `/` (a path, a leading-slash sentence, or any text that happens to start with `/`) would be silently reinterpreted as a skill or command, and the behavior would differ between agy 1.1.8 and 1.1.9+. For a delegation server that forwards caller prompts verbatim, predictable version-independent literal semantics are the safer default.

This is issue #122's recommended Option 1 (disable by default). A caller-controllable toggle (Option 3) can be layered on later if a use case for delegated skill invocation appears.

## Changes

- `internal/manager/manager.go`: a `disableSlashCommandsFlag` constant, appended to the fixed args in `buildAgyArgs` (always present, like `--dangerously-skip-permissions`), with a rationale comment.
- `internal/manager/start_test.go`: `TestBuildAgyArgs` pins the flag in both the full and minimal arg lists (the minimal case proves it is always passed, not optional).
- `internal/mcptools/tools.go`: the `prompt` input's schema notes the literal semantics.
- `README.md`: documents that delegated prompts are sent literally.

The flag persists in the job's stored args (`meta.Args`) and the supervisor replays them verbatim, so no supervisor change is needed. It rides both `agy_run` and `agy_run_sync` via the shared `buildAgyArgs`.

## Related issues

Closes #122.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), and `go test -race ./...` all green.
- [x] Sabotage-verified: removing the fixed flag reddens `TestBuildAgyArgs` (both the full and minimal cases).
- [x] Ran the pre-push quality gate (6 review agents); no behavioral defects.
- [x] `--disable-slash-commands` is a bare flag present since agy 1.1.9, confirmed against the installed agy 1.1.10 `--help`; safe unconditionally at the 1.1.10 floor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompts beginning with `/` are now passed literally to agy instead of being interpreted as slash commands or skill names.

* **Documentation**
  * Updated the README and prompt guidance to clarify literal prompt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->