### PR TITLE
fix(models): return model ids from list_models, not whole agy rows (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Every job runs `agy --output-format stream-json`, and the supervisor decodes tha
 - `agy_run` / `agy_status` / `agy_cancel`: start an `agy` prompt, poll for completion, cancel if needed.
 - `agy_run_sync`: start a prompt and wait for it inline (bounded, with MCP progress notifications); returns the `job_id` to wait on or poll if it outlives the wait cap.
 - `agy_wait`: block until an already-started job finishes (bounded, with MCP progress notifications); one call replaces an `agy_status` poll loop.
-- `list_models`: enumerate available `agy` models.
+- `list_models`: enumerate available `agy` models, as the ids the `model` parameter accepts plus their display labels.
 - `list_sessions`: list known conversations so review threads can be continued.
 
 `agy_run` and `agy_run_sync` also take optional per-run controls, each forwarded to `agy` only when set: pick the `model`, reasoning `effort` (`low`/`medium`/`high`), execution `mode` (including a `plan`-only pass), a named `agent`, `sandbox` terminal restrictions, and a `json_schema` to constrain the result to structured output.
+
+Pass `model` as an **id** (`gemini-3.1-pro-high`), the form `list_models` returns in its `models` field, not as the display label `agy` prints beside it (`Gemini 3.1 Pro (High)`). `agy` takes either form on its own, but every display label in the `agy` 1.1.11 catalog was refused once `effort` was set too, at every effort. The same applies to `AGY_MCP_DEFAULT_MODEL`. Not every id accepts every effort either, and some accept none, so omit `effort` unless you need a specific one.
 
 Session continuation rides `agy`'s own durable conversation store (`--conversation <id>`), so threads survive across calls without keeping a process warm.
 
@@ -100,8 +102,10 @@ Or add to your MCP client config:
 - `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage? }`
 - `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
-- `list_models()` -> `{ models }`
+- `list_models()` -> `{ models, model_details }`
 - `list_sessions(dir?)` -> `{ sessions }`
+
+`models` holds ids alone, so its entries can be passed straight to `model`; `model_details` pairs each id with the display label `agy` prints for it, in the same order, for showing a readable name. Through v2.1.0 `models` carried each `agy models` row whole, which was a tab-joined `id<TAB>label` string that `agy` does not accept as a model at all, so a client had to split it and pick a column ([#135](https://github.com/tphakala/agy-mcp/issues/135)).
 
 `usage` is agy's own token accounting (`input_tokens`, `output_tokens`, `thinking_tokens`, `cache_read_tokens`, `total_tokens`), and together with `num_turns` it appears once a run reports a terminal result.
 
@@ -220,6 +224,10 @@ Two extra hardening layers are always available:
 agy-mcp -http 127.0.0.1:8765 -http-token "$(openssl rand -hex 32)"
 ```
 
+## Upgrading from v2.1
+
+**Behaviour change to check your client against:** `list_models` used to return each `agy models` row whole in `models`, as a tab-joined `id<TAB>label` string. It now returns the id alone, and pairs each id with its display label in the new `model_details` field. No type on the wire changed, only the values, so a client that renders `models` to a human now shows a slug and should read `model_details[].label` instead, and one that split each entry on the tab will find nothing to split. A stored old value passed back as `model` still works: the server reduces a whole row to its id before running it.
+
 ## Upgrading from v1
 
 v2 requires agy 1.1.10 and drives it through `--output-format stream-json`. The upgrade is safe to do in place, but two things are worth knowing.
@@ -239,7 +247,7 @@ v2 requires agy 1.1.10 and drives it through `--output-format stream-json`. The 
 |-----|---------|---------|
 | `AGY_MCP_AGY_PATH` | `agy` on PATH | path to the agy binary |
 | `AGY_MCP_STATE_DIR` | `$XDG_STATE_HOME/agy-mcp` | job state directory |
-| `AGY_MCP_DEFAULT_MODEL` | agy default | default model |
+| `AGY_MCP_DEFAULT_MODEL` | agy default | default model, as an id (`gemini-3.1-pro-high`), not a display label |
 | `AGY_MCP_HTTP_TOKEN` | (none) | optional bearer token for HTTP mode; empty = unauthenticated |
 | `AGY_MCP_WAIT_READY_FILE` | (none) | absolute path `wait-job` / `hook-wait` create once their SIGINT/SIGTERM handler is installed, so a parent can signal without racing it; must be fresh per invocation, an existing file is refused rather than overwritten; empty = nothing is written |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	AgyPath        string        // path to the agy binary
 	SupervisorExe  string        // path to the agy-mcp binary used as the run-job supervisor
 	StateDir       string        // root of the on-disk job store
-	DefaultModel   string        // empty means let agy use its configured default
+	DefaultModel   string        // a model id (see list_models); empty means let agy use its configured default
 	DefaultTimeout time.Duration // hard per-job timeout
 	MaxConcurrency int           // global cap on concurrent jobs
 	JobTTL         time.Duration // age after which finished jobs are GC'd

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,7 +46,10 @@ func TestResolveStateDirOverride(t *testing.T) {
 // TestResolveDefaultModelAndJobTTL: AGY_MCP_DEFAULT_MODEL flows into the config,
 // and JobTTL defaults to 24h (a regression to 0 would silently disable GC).
 func TestResolveDefaultModelAndJobTTL(t *testing.T) {
-	t.Setenv("AGY_MCP_DEFAULT_MODEL", "Gemini 3.1 Pro (High)")
+	// A model id, the form AGY_MCP_DEFAULT_MODEL should be set to: a display label
+	// works only until a run also sets effort, which agy then refuses (issue #135).
+	// Resolve itself is pass-through, so this pins the value, not a normalization.
+	t.Setenv("AGY_MCP_DEFAULT_MODEL", "gemini-3.1-pro-high")
 	t.Setenv("AGY_MCP_STATE_DIR", t.TempDir())
 	fakeAgyOnPath(t)
 
@@ -54,7 +57,7 @@ func TestResolveDefaultModelAndJobTTL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.DefaultModel != "Gemini 3.1 Pro (High)" {
+	if c.DefaultModel != "gemini-3.1-pro-high" {
 		t.Errorf("DefaultModel = %q, want the AGY_MCP_DEFAULT_MODEL value", c.DefaultModel)
 	}
 	if c.JobTTL != 24*time.Hour {

--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -25,7 +25,7 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 		withCacheFile:  true,
 	})
 
-	job, err := m.StartJob(StartRequest{Prompt: "review main.go", Model: "Gemini 3.1 Pro (High)"})
+	job, err := m.StartJob(StartRequest{Prompt: "review main.go", Model: "gemini-3.1-pro-high"})
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 	if meta.Prompt != "review main.go" {
 		t.Errorf("prompt = %q", meta.Prompt)
 	}
-	if !hasArg(meta.Args, "--model", "Gemini 3.1 Pro (High)") {
+	if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
 		t.Errorf("args missing model: %v", meta.Args)
 	}
 	if !contains(meta.Args, "-p") || !contains(meta.Args, "--dangerously-skip-permissions") {
@@ -136,7 +136,7 @@ func TestStartJobNormalizesCwd(t *testing.T) {
 		agyPath:        "/usr/bin/agy",
 		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
 		defaultTimeout: time.Minute,
-		defaultModel:   "Gemini 3.1 Pro (High)",
+		defaultModel:   "gemini-3.1-pro-high",
 		maxConcurrency: 4,
 		withCacheFile:  true,
 	})
@@ -154,17 +154,89 @@ func TestStartJobNormalizesCwd(t *testing.T) {
 	}
 	// The model and timeout defaults must be resolved into meta (and the args),
 	// not left stale: issue #24 asks to normalize all-or-none.
-	if meta.Model != "Gemini 3.1 Pro (High)" {
+	if meta.Model != "gemini-3.1-pro-high" {
 		t.Errorf("meta.Model = %q, want the resolved default", meta.Model)
 	}
 	if meta.Timeout != time.Minute {
 		t.Errorf("meta.Timeout = %v, want the resolved default", meta.Timeout)
 	}
-	if !hasArg(meta.Args, "--model", "Gemini 3.1 Pro (High)") {
+	if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
 		t.Errorf("args missing resolved default model: %v", meta.Args)
 	}
 	if !hasArg(meta.Args, "--print-timeout", time.Minute.String()) {
 		t.Errorf("args missing resolved default timeout: %v", meta.Args)
+	}
+}
+
+// TestStartJobReducesModelRowToID: a caller that copies a whole `agy models` row
+// ("<id>\t<label>") passes a string agy does not accept as --model. Only the id
+// may reach the args and the persisted meta (issue #135).
+func TestStartJobReducesModelRowToID(t *testing.T) {
+	m := newManager(t, managerOpts{
+		agyPath:       "/usr/bin/agy",
+		supervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		// A configured default is set too, so this also pins that an explicit
+		// request model wins: the reduction runs after the fallback, and nothing
+		// else in the suite exercises both being present at once.
+		defaultModel:   "gemini-3.6-flash-low",
+		defaultTimeout: time.Minute,
+		maxConcurrency: 4,
+		withCacheFile:  true,
+	})
+
+	job, err := m.StartJob(StartRequest{
+		Prompt: "x",
+		Model:  "gemini-3.1-pro-high\tGemini 3.1 Pro (High)",
+		Effort: "high",
+	})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	meta, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if meta.Model != "gemini-3.1-pro-high" {
+		t.Errorf("meta.Model = %q, want the id column alone", meta.Model)
+	}
+	if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
+		t.Errorf("args must carry the id alone, got: %v", meta.Args)
+	}
+	// Effort is set here only so the reduction is exercised on the request shape
+	// that motivated it; buildAgyArgs emits --effort independently of the model,
+	// so this asserts the two coexist, not that agy would accept the pair.
+	if !hasArg(meta.Args, "--effort", "high") {
+		t.Errorf("args missing effort: %v", meta.Args)
+	}
+}
+
+// TestStartJobReducesDefaultModelRowToID: the same reduction must cover a model
+// that arrives from AGY_MCP_DEFAULT_MODEL rather than from the caller, because
+// the fallback is applied inside StartJob and so is invisible to the tool
+// boundary that validates the request (issue #135).
+func TestStartJobReducesDefaultModelRowToID(t *testing.T) {
+	m := newManager(t, managerOpts{
+		agyPath:        "/usr/bin/agy",
+		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+		defaultTimeout: time.Minute,
+		defaultModel:   "gemini-3.1-pro-high\tGemini 3.1 Pro (High)",
+		maxConcurrency: 4,
+		withCacheFile:  true,
+	})
+
+	job, err := m.StartJob(StartRequest{Prompt: "x"})
+	if err != nil {
+		t.Fatalf("StartJob: %v", err)
+	}
+	meta, err := m.store.Load(job.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if meta.Model != "gemini-3.1-pro-high" {
+		t.Errorf("meta.Model = %q, want the id column alone", meta.Model)
+	}
+	if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
+		t.Errorf("args must carry the id alone, got: %v", meta.Args)
 	}
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -93,7 +93,7 @@ func New(c config.Config) *Manager {
 // StartRequest describes a run to start.
 type StartRequest struct {
 	Prompt         string
-	Model          string   // optional; falls back to cfg.DefaultModel
+	Model          string   // optional; falls back to cfg.DefaultModel, then reduced by modelID
 	Effort         string   // optional; --effort <low|medium|high>, reasoning effort for the session
 	Mode           string   // optional; --mode <accept-edits|plan>, agy's agent execution mode
 	Agent          string   // optional; --agent <name>, selects a specific agy agent
@@ -400,6 +400,10 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	if req.Model == "" {
 		req.Model = m.cfg.DefaultModel
 	}
+	// Reduce a whole `agy models` row to its id (see modelID). Applied after the
+	// fallback above so it covers a configured AGY_MCP_DEFAULT_MODEL too, and
+	// before the args and meta below, which are the two readers of req.Model.
+	req.Model = modelID(req.Model)
 	if req.Timeout <= 0 {
 		req.Timeout = m.cfg.DefaultTimeout
 	}

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -18,8 +18,52 @@ const (
 	listModelsKillGrace = time.Second
 )
 
-// ListModels runs `agy models` and returns the available model names.
-func (m *Manager) ListModels(ctx context.Context) ([]string, error) {
+// Model is one entry from `agy models`: the id agy accepts as --model, and the
+// display label it prints beside it.
+//
+// The two are not interchangeable, which is why this is a pair rather than one
+// string. Measured against agy 1.1.11: agy takes either an id or a display
+// label as --model on its own, but rejects a whole row ("<id>\t<label>") as an
+// unrecognized model. Once --effort is set too, every display label in the 1.1.11
+// catalog was refused at every effort, while some ids are accepted alongside
+// one. That is why list_models hands callers the id (issue #135).
+//
+// Which efforts a given id accepts is agy's own business and deliberately not
+// restated here: it varies per model and some ids accept none at all. Two
+// earlier versions of this comment generalized a rule from a handful of probes
+// and were wrong both times, so state only what a probe covered.
+type Model struct {
+	ID    string
+	Label string
+}
+
+// modelID reduces a model value to the id agy accepts.
+//
+// `agy models` prints "<id>\t<label>" per row, so a caller that copies a whole
+// row (or an operator who sets AGY_MCP_DEFAULT_MODEL to one) supplies a string
+// agy rejects outright ("is not recognized as a known model", measured against
+// agy 1.1.11). Keeping the part before the first tab turns it back into the id.
+//
+// A value that is not a whole row is forwarded rather than guessed at: agy owns
+// the model namespace, and a bare display label in particular is one agy accepts
+// on its own.
+//
+// It never turns a non-empty value into an empty one, which is why the empty-id
+// case returns v rather than "". An empty model makes buildAgyArgs omit --model
+// altogether, so the run would silently use agy's own default; forwarding the
+// value instead lets agy refuse it, which is the loud failure a caller can act
+// on. The trimming matches parseModels, so a row and a hand-typed id reduce to
+// the same value (issue #135).
+func modelID(v string) string {
+	id, _, _ := strings.Cut(strings.TrimSpace(v), "\t")
+	if id = strings.TrimSpace(id); id == "" {
+		return v
+	}
+	return id
+}
+
+// ListModels runs `agy models` and returns the available models.
+func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
 	// Version-gated like the job path even though `agy models` itself does not
 	// need stream-json: an agy too old to drive is a configuration problem, and
 	// one clear message about it beats a model list from a binary that cannot
@@ -50,14 +94,22 @@ func (m *Manager) ListModels(ctx context.Context) ([]string, error) {
 	return parseModels(string(out)), nil
 }
 
-func parseModels(raw string) []string {
-	var models []string
+// parseModels turns `agy models` output into one Model per non-blank line,
+// splitting each row on its first tab.
+//
+// Splitting on the FIRST tab keeps a label that itself contains a tab attached
+// to the label rather than truncating the row. A line with no tab yields an id
+// with an empty label instead of being dropped, so output that carries no label
+// column still produces usable model values.
+func parseModels(raw string) []Model {
+	var models []Model
 	for line := range strings.Lines(raw) {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		models = append(models, line)
+		id, label, _ := strings.Cut(line, "\t")
+		models = append(models, Model{ID: strings.TrimSpace(id), Label: strings.TrimSpace(label)})
 	}
 	return models
 }

--- a/internal/manager/models_test.go
+++ b/internal/manager/models_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -21,16 +22,62 @@ func TestListModelsIncludesStderrOnError(t *testing.T) {
 	}
 }
 
+// TestParseModels pins the split of each `agy models` row into its id and label
+// columns. The raw text is the shape agy 1.1.11 prints: "<id>\t<label>" per row.
+// Keeping the whole row as one "model name" is what issue #135 was, since the
+// row is not a value agy accepts as --model at all.
 func TestParseModels(t *testing.T) {
-	raw := "Gemini 3.5 Flash (Medium)\nGemini 3.1 Pro (High)\n\nClaude Opus 4.6 (Thinking)\n"
-	got := parseModels(raw)
-	want := []string{"Gemini 3.5 Flash (Medium)", "Gemini 3.1 Pro (High)", "Claude Opus 4.6 (Thinking)"}
-	if len(got) != len(want) {
-		t.Fatalf("got %v", got)
+	raw := "gemini-3.5-flash-medium\tGemini 3.5 Flash (Medium)\n" +
+		"gemini-3.1-pro-high\tGemini 3.1 Pro (High)\n" +
+		"\n" +
+		"   \n" + // whitespace-only rows are skipped like blank ones
+		"  claude-opus-4-6-thinking \t  Claude Opus 4.6 (Thinking)  \n" + // padding is trimmed off both columns
+		"gpt-oss-120b-medium\tGPT-OSS 120B\t(Medium)\n" // only the FIRST tab cuts
+	want := []Model{
+		{ID: "gemini-3.5-flash-medium", Label: "Gemini 3.5 Flash (Medium)"},
+		{ID: "gemini-3.1-pro-high", Label: "Gemini 3.1 Pro (High)"},
+		{ID: "claude-opus-4-6-thinking", Label: "Claude Opus 4.6 (Thinking)"},
+		{ID: "gpt-oss-120b-medium", Label: "GPT-OSS 120B\t(Medium)"},
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("got[%d]=%q want %q", i, got[i], want[i])
-		}
+	if got := parseModels(raw); !slices.Equal(got, want) {
+		t.Fatalf("parseModels() = %#v, want %#v", got, want)
+	}
+}
+
+// TestParseModelsWithoutLabelColumn: a row with no tab is an id with an empty
+// label, not a dropped row, so output carrying no label column still yields
+// usable model values.
+func TestParseModelsWithoutLabelColumn(t *testing.T) {
+	want := []Model{{ID: "gemini-3.1-pro-high"}, {ID: "claude-sonnet-4-6"}}
+	if got := parseModels("gemini-3.1-pro-high\nclaude-sonnet-4-6\n"); !slices.Equal(got, want) {
+		t.Fatalf("parseModels() = %#v, want %#v", got, want)
+	}
+}
+
+// TestModelID pins which part of a model value reaches agy: the id column only,
+// with anything that is not a whole `agy models` row forwarded untouched because
+// agy owns the model namespace (issue #135).
+func TestModelID(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"whole row keeps only the id", "gemini-3.1-pro-high\tGemini 3.1 Pro (High)", "gemini-3.1-pro-high"},
+		{"bare id is unchanged", "gemini-3.1-pro-high", "gemini-3.1-pro-high"},
+		{"bare label is forwarded untouched", "Gemini 3.1 Pro (High)", "Gemini 3.1 Pro (High)"},
+		{"empty stays empty so the flag is omitted", "", ""},
+		{"only the first tab cuts", "gemini-3.1-pro-high\tGemini 3.1 Pro\t(High)", "gemini-3.1-pro-high"},
+		// Trimming must match parseModels, or the id list_models reports for a row
+		// and the id that reaches --model for that same row would differ.
+		{"padding is trimmed", "  gemini-3.1-pro-high  ", "gemini-3.1-pro-high"},
+		{"padded row reduces to the trimmed id", "  gemini-3.1-pro-high \tGemini 3.1 Pro (High)", "gemini-3.1-pro-high"},
+		// An empty id column must never collapse to "": buildAgyArgs omits --model
+		// for an empty value, so the run would silently use agy's own default
+		// instead of failing on a value the caller actually supplied.
+		{"leading tab does not empty a non-empty value", "\tGemini 3.1 Pro (High)", "Gemini 3.1 Pro (High)"},
+		{"an all-whitespace value is forwarded, not emptied", "\t", "\t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := modelID(tc.in); got != tc.want {
+				t.Errorf("modelID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/manager/start_test.go
+++ b/internal/manager/start_test.go
@@ -17,7 +17,7 @@ import (
 func TestBuildAgyArgs(t *testing.T) {
 	got := buildAgyArgs(StartRequest{
 		Prompt:         "review this",
-		Model:          "Gemini 3.1 Pro (High)",
+		Model:          "gemini-3.1-pro-high",
 		Effort:         "high",
 		Mode:           "plan",
 		Agent:          "reviewer",
@@ -32,7 +32,7 @@ func TestBuildAgyArgs(t *testing.T) {
 		"--print-timeout", "20m0s",
 		"--output-format", "stream-json",
 		"--disable-slash-commands",
-		"--model", "Gemini 3.1 Pro (High)",
+		"--model", "gemini-3.1-pro-high",
 		"--effort", "high",
 		"--mode", "plan",
 		"--agent", "reviewer",
@@ -59,6 +59,18 @@ func TestBuildAgyArgs(t *testing.T) {
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("buildAgyArgs minimal =\n  %q\nwant\n  %q", got, want)
+	}
+
+	// A model value carrying spaces must survive as ONE argument, immediately after
+	// --model. A bare display label is still a supported input (StartJob's modelID
+	// forwards one unchanged, and agy accepts it when no --effort accompanies it),
+	// and every other model fixture in this test is a space-free slug: a builder
+	// that truncated the value at whitespace satisfies every other assertion here
+	// and fails only this one.
+	const spaced = "Gemini 3.1 Pro (High)"
+	got = buildAgyArgs(StartRequest{Prompt: "hi", Model: spaced, Timeout: time.Minute})
+	if i := slices.Index(got, "--model"); i < 0 || i+1 >= len(got) || got[i+1] != spaced {
+		t.Fatalf("buildAgyArgs must pass a spaced model as one argument after --model, got %q", got)
 	}
 }
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -20,7 +20,7 @@ import (
 // here rather than in the tool description avoids restating the schema in prose.
 type runInput struct {
 	Prompt         string   `json:"prompt" jsonschema:"the complete task for the delegated agent: what to do, the context needed to do it, and the output wanted back; the agent cannot see this conversation, so the prompt must stand alone. It is sent to agy literally, so a leading slash-command or skill name (a prompt starting with /) is treated as text, not expanded"`
-	Model          string   `json:"model,omitempty" jsonschema:"agy model name; omit to use the server's default model, or agy's own default when the server sets none. Call list_models for the accepted values"`
+	Model          string   `json:"model,omitempty" jsonschema:"agy model id, e.g. gemini-3.1-pro-high; omit to use the server's default model, or agy's own default when the server sets none. Call list_models for the accepted values and pass one from its models field, not a display label from model_details, because agy rejects a display label whenever effort is also set. Not every id accepts every effort either, and some accept none, so omit effort unless you need a specific one"`
 	Effort         string   `json:"effort,omitempty" jsonschema:"reasoning effort for this run (agy --effort): low, medium or high. Omit to use agy's default"`
 	Mode           string   `json:"mode,omitempty" jsonschema:"agy agent execution mode for this run (agy --mode): accept-edits or plan. Omit to use agy's default mode"`
 	Agent          string   `json:"agent,omitempty" jsonschema:"name of a specific agy agent to run for this session (agy --agent); omit to use agy's default agent"`
@@ -241,8 +241,18 @@ type cancelOutput struct {
 
 type emptyInput struct{}
 
+// modelDetail pairs a model's id with the label agy prints for it, so a client
+// can show the readable name while still passing the id.
+type modelDetail struct {
+	ID string `json:"id" jsonschema:"the value to pass as the model parameter of agy_run and agy_run_sync"`
+	// No omitempty: the key stays present with an empty string when agy printed
+	// no label, so a client reads one shape rather than testing for absence.
+	Label string `json:"label" jsonschema:"human-readable name agy prints for this model, e.g. Gemini 3.1 Pro (High). For display only: agy rejects a label as the model parameter whenever effort is also set, so pass the id instead. Empty string when agy printed no label for the model"`
+}
+
 type modelsOutput struct {
-	Models []string `json:"models" jsonschema:"model names accepted by the model parameter of agy_run and agy_run_sync"`
+	Models       []string      `json:"models" jsonschema:"model ids accepted by the model parameter of agy_run and agy_run_sync, e.g. gemini-3.1-pro-high. These are the values to pass"`
+	ModelDetails []modelDetail `json:"model_details" jsonschema:"the same models paired with their display labels, in the same order as models. Use it to show a readable name; keep passing the id"`
 }
 
 type sessionsInput struct {
@@ -357,16 +367,23 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 		Name:        toolListModels,
 		Title:       "List agy models",
 		Annotations: annReadExternal,
-		Description: "List the agy model names accepted by the model parameter of agy_run and agy_run_sync. Call it only when you intend to override the default; omitting model picks a default already, so most runs need no call here. Shells out to the agy CLI, so it fails if agy is missing from PATH or not authenticated.",
+		Description: "List the agy model ids accepted by the model parameter of agy_run and agy_run_sync. Pass a value from models; model_details carries the same entries with their display labels, which are for showing a readable name only. Call it only when you intend to override the default; omitting model picks a default already, so most runs need no call here. Shells out to the agy CLI, so it fails if agy is missing from PATH or not authenticated.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ emptyInput) (*mcp.CallToolResult, modelsOutput, error) {
 		models, err := mgr.ListModels(ctx)
 		if err != nil {
 			return nil, modelsOutput{}, err
 		}
-		if models == nil {
-			models = []string{}
+		// Both fields are always arrays, never null: a client that indexes the
+		// result should see an empty list rather than have to special-case null.
+		out := modelsOutput{
+			Models:       make([]string, 0, len(models)),
+			ModelDetails: make([]modelDetail, 0, len(models)),
 		}
-		return nil, modelsOutput{Models: models}, nil
+		for _, mo := range models {
+			out.Models = append(out.Models, mo.ID)
+			out.ModelDetails = append(out.ModelDetails, modelDetail{ID: mo.ID, Label: mo.Label})
+		}
+		return nil, out, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{

--- a/internal/mcptools/tools_posix_test.go
+++ b/internal/mcptools/tools_posix_test.go
@@ -17,19 +17,79 @@ import (
 // serve_http_test.go so `go test ./...` stays green on Windows too.
 
 // TestListModelsOverMCP exercises the list_models tool end to end: the handler
-// runs `agy models` (the fake agy prints two lines) and returns them on the
-// wire. This handler had no MCP-layer test.
+// runs `agy models` (the fake agy prints two "<id>\t<label>" rows, the shape agy
+// 1.1.11 prints) and returns them on the wire. This handler had no MCP-layer
+// test.
+//
+// The split matters, it is not cosmetic: `models` is what a caller passes as the
+// model parameter, so it must carry ids alone. Returning the whole row, or the
+// label, is issue #135, because a label makes agy refuse any run that also sets
+// effort.
 func TestListModelsOverMCP(t *testing.T) {
-	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: "Model A\nModel B"})
+	// The third row carries no label column, so this also pins what a label-less
+	// model looks like on the wire: an empty string, not a missing key.
+	mgr, _ := newTestManager(t, testutil.FakeAgy{
+		Stdout: "gemini-3.1-pro-high\tGemini 3.1 Pro (High)\n" +
+			"claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)\n" +
+			"some-unlabelled-model",
+	})
 	cs := connect(t, mgr, nil)
 
 	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: "list_models"})
 	if err != nil || res.IsError {
 		t.Fatalf("list_models: err=%v res=%+v", err, res)
 	}
-	models, _ := structMap(t, res.StructuredContent)["models"].([]any)
-	if len(models) != 2 || models[0] != "Model A" || models[1] != "Model B" {
-		t.Fatalf("models = %v, want [Model A, Model B]", models)
+	out := structMap(t, res.StructuredContent)
+	wantIDs := []string{"gemini-3.1-pro-high", "claude-sonnet-4-6", "some-unlabelled-model"}
+	wantLabels := []string{"Gemini 3.1 Pro (High)", "Claude Sonnet 4.6 (Thinking)", ""}
+
+	models, _ := out["models"].([]any)
+	if len(models) != len(wantIDs) {
+		t.Fatalf("models = %v, want %d ids", models, len(wantIDs))
+	}
+	details, _ := out["model_details"].([]any)
+	if len(details) != len(wantIDs) {
+		t.Fatalf("model_details = %v, want one entry per model", details)
+	}
+	// Assert every entry, not just the first: the schema promises model_details is
+	// "in the same order as models", and a mispairing that starts at entry 2 is
+	// exactly what a spot-check of entry 0 cannot see.
+	for i := range wantIDs {
+		if models[i] != wantIDs[i] {
+			t.Errorf("models[%d] = %v, want the id column alone (%q)", i, models[i], wantIDs[i])
+		}
+		d, _ := details[i].(map[string]any)
+		if d["id"] != wantIDs[i] || d["label"] != wantLabels[i] {
+			t.Errorf("model_details[%d] = %v, want id %q paired with label %q", i, d, wantIDs[i], wantLabels[i])
+		}
+	}
+}
+
+// TestListModelsEmptyCatalogReturnsArrays: with nothing to list, both fields must
+// be empty JSON arrays rather than null, so a client can index the result without
+// a null check. The handler builds both with make(), and nothing else pins that;
+// dropping either initialiser marshals the field as null and breaks such a client
+// silently.
+func TestListModelsEmptyCatalogReturnsArrays(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Stdout: ""})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: "list_models"})
+	if err != nil || res.IsError {
+		t.Fatalf("list_models: err=%v res=%+v", err, res)
+	}
+	out := structMap(t, res.StructuredContent)
+	for _, field := range []string{"models", "model_details"} {
+		// A null decodes to nil any, which fails this assertion; an empty array
+		// decodes to an empty []any, which passes.
+		got, ok := out[field].([]any)
+		if !ok {
+			t.Errorf("%s = %v, want an empty array, not null", field, out[field])
+			continue
+		}
+		if len(got) != 0 {
+			t.Errorf("%s = %v, want empty for an empty catalog", field, got)
+		}
 	}
 }
 

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -160,6 +160,26 @@ func TestToStartRequestPassesRunOptions(t *testing.T) {
 	}
 }
 
+// TestToStartRequestPassesModel: model is threaded into the start request
+// verbatim, where the manager reduces it (a whole `agy models` row becomes its id)
+// and buildAgyArgs forwards it as --model. This layer deliberately does not
+// validate or rewrite it, since agy owns the model namespace and the reduction
+// has to sit below the AGY_MCP_DEFAULT_MODEL fallback to cover that too.
+//
+// It completes the pass-through family above: model was the one run option with no
+// test here, so dropping `Model: in.Model` from toStartRequest left every test in
+// the repo green while silently ignoring a caller's model choice.
+func TestToStartRequestPassesModel(t *testing.T) {
+	t.Parallel()
+	req, err := runInput{Prompt: "x", Model: "gemini-3.1-pro-high"}.toStartRequest()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Model != "gemini-3.1-pro-high" {
+		t.Errorf("Model = %q, want it threaded through unchanged", req.Model)
+	}
+}
+
 // TestToStartRequestValidatesMode: mode is an agy enum (accept-edits, plan), so a
 // bad value must fail fast at the tool boundary with a message that quotes the bad
 // value and names the accepted values, rather than reaching agy. An empty mode is

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -80,10 +80,12 @@ func (cfg FakeAgy) version() string {
 //   - `agy --version`, which the manager probes once before it will run
 //     anything. Without this every manager-level test would fail in the version
 //     gate rather than exercising its actual subject.
-//   - `agy models`, which prints one plain model name per line, not JSON.
-//     plainPath holds that listing (Stdout, reused as the model list), and the
-//     configured Stderr and Exit apply so a failing listing can be exercised
-//     too.
+//   - `agy models`, which prints one tab-separated "<id>\t<display label>" row
+//     per line, not JSON (agy 1.1.11); a row carrying no tab is read as an id
+//     with no label. plainPath holds that listing (Stdout, reused as the model
+//     list), and the configured Stderr and Exit apply so a failing listing can
+//     be exercised too. Note the real binary prints its progress banner on
+//     stderr, which is why ListModels reads stdout alone.
 func (cfg FakeAgy) subcommandPreamble(plainPath, errPath string) string {
 	return fmt.Sprintf("if [ \"$1\" = \"--version\" ]; then printf '%%s\\n' %q; exit 0; fi\n", cfg.version()) +
 		fmt.Sprintf("if [ \"$1\" = \"models\" ]; then cat %q; cat %q 1>&2; exit %d; fi\n", plainPath, errPath, cfg.Exit)


### PR DESCRIPTION
Fixes #135.

## The problem

`agy models` prints one tab-separated `<id>\t<display label>` row per model. agy-mcp handed each row back **whole** through `list_models` as a "model name", and a whole row is not a value agy accepts as `--model` at all, so a caller had to split it by eye and guess a column. Picking the display label then made agy refuse any run that also set `effort`, which is the reported failure.

## The fix

`parseModels` splits each row on its first tab into `Model{ID, Label}`. `list_models` returns `models` (ids alone, the values to pass) plus a new `model_details` pairing each id with its label for display. A row carrying no tab is kept as an id with an empty label, so output without a label column still yields usable values.

`StartJob` reduces a pasted whole row to its id before building args, **after** the `AGY_MCP_DEFAULT_MODEL` fallback. That placement is load-bearing and is what the issue's own analysis missed: the fallback is applied inside the manager, well below `toStartRequest`, so a fix at the tool boundary would have left a default configured as a row broken. A dedicated test fails if the two lines are swapped.

The reduction trims (so a row and a hand-typed id reduce to the same value) and never turns a non-empty value into an empty one. That second property matters: an empty model makes `buildAgyArgs` omit `--model` entirely, so the run would silently use agy's own default instead of failing on a value the caller actually supplied.

## Wire change to check your client against

`models` carried whole rows through v2.1.0 and now carries ids. No type changed, only the values. A client rendering `models` to a human now shows a slug and should read `model_details[].label`; one that split entries on the tab will find nothing to split. A stored old value passed back as `model` still works, via the reduction above. Documented under "Upgrading from v2.1".

## Measured against agy 1.1.11

Every claim in the docs and comments was probed against the live binary rather than reasoned about:

- a whole `<id>\t<label>` row is refused as an unrecognized model
- an id **or** a display label is accepted on its own (22/22 catalog entries)
- every display label in the catalog is refused once `effort` is set, at every effort (33/33)
- some ids are accepted alongside an effort (9/33); some accept none

The docs deliberately **do not** restate which efforts a given id takes. That varies per model, and two earlier drafts of this branch shipped confident rules about it that later probing refuted, including one in an LLM-facing tool schema.

## Decisions left open

Three things I deliberately did not do, flagged for your call rather than settled here:

1. **The literal #135 repro still fails.** A bare display label plus `effort` is still forwarded and still dies at launch with agy's confusing message. This implements the issue's option 2 (steer callers to the id), not option 1 (catalog label to id mapping) or option 3 (fail fast). Option 1 needs the `agy models` catalog on the job-start path, i.e. a network/auth subprocess with a 30s timeout, and the mapping is not a slug transform (`Claude Sonnet 4.6 (Thinking)` to `claude-sonnet-4-6`). Option 3 needs a heuristic on a namespace agy owns, which risks wrongly rejecting a run agy would accept. Both peer reviews advised against both. Filed as a follow-up.
2. **`model_details` is `required` in the generated output schema** (the SDK marks non-`omitempty` fields required, and sets `additionalProperties: false`). Clients that refetch `tools/list` are fine; one validating against a pinned copy of the old schema is not. Adding `omitempty` would contradict the always-an-array intent.
3. **The agy floor stays 1.1.10** while the row format is verified only on 1.1.11. The code degrades safely either way (a label-only build yields exactly what v2.1.0 produced, pinned by a test), but the schema prose would be describing ids on such a build.

## Verification

`go build`, `go vet`, `go test ./...`, `golangci-lint run ./...` (0 issues), `GOOS=windows go build`/`go vet`, and `go test -race` on the changed packages: all green.

Every new test was sabotage-checked: the production line it depends on was removed and the test confirmed to go red. 11 mutations, all RED, including the fallback-ordering swap, a last-tab split, dropped trims, the empty-id collapse, dropped `make()` initialisers, a details mispairing starting at index 1, and dropping `Model: in.Model` from `toStartRequest` (which previously left the entire repo green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model listings now provide separate model IDs and display labels.
  * Model IDs are used when starting jobs, while labels remain available for presentation.
  * Empty model catalogs return empty lists instead of null values.
  * Added support for model entries without display labels.

* **Documentation**
  * Clarified model ID configuration, selection behavior, and upgrade guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->