### PR TITLE
chore(models): quality cleanup from the #138 batch (items 1, 5, 6, 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An MCP (Model Context Protocol) server that wraps the [Antigravity CLI](https://antigravity.google) (`agy`), so any MCP client (Claude Code, Cursor, Cline, and others) can run `agy` prompts, peer reviews, and follow-up turns as native tools.
 
-> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, per-run controls and structured output, cross-platform builds) and verified against a live agy (1.1.10), which is also the floor.
+> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, per-run controls and structured output, cross-platform builds) and verified against a live agy, with 1.1.10 the minimum supported version.
 
 ## Why
 

--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -229,7 +229,7 @@ func TestStartJobReducesModelRowToID(t *testing.T) {
 			if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
 				t.Errorf("args must carry the id alone, got: %v", meta.Args)
 			}
-			if tc.assertEffort && !hasArg(meta.Args, "--effort", "high") {
+			if tc.assertEffort && !hasArg(meta.Args, "--effort", tc.requestEffort) {
 				t.Errorf("args missing effort: %v", meta.Args)
 			}
 		})

--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -168,75 +168,71 @@ func TestStartJobNormalizesCwd(t *testing.T) {
 	}
 }
 
-// TestStartJobReducesModelRowToID: a caller that copies a whole `agy models` row
-// ("<id>\t<label>") passes a string agy does not accept as --model. Only the id
-// may reach the args and the persisted meta (issue #135).
+// TestStartJobReducesModelRowToID: a model value that arrives as a whole
+// `agy models` row ("<id>\t<label>") is a string agy does not accept as --model,
+// so StartJob must reduce it to the id column before it reaches the args and the
+// persisted meta (issue #135). The reduction runs after the default fallback is
+// applied, so it must hold whether the row comes from the caller's request or
+// from AGY_MCP_DEFAULT_MODEL; both are covered here.
 func TestStartJobReducesModelRowToID(t *testing.T) {
-	m := newManager(t, managerOpts{
-		agyPath:       "/usr/bin/agy",
-		supervisorExe: testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
-		// A configured default is set too, so this also pins that an explicit
-		// request model wins: the reduction runs after the fallback, and nothing
-		// else in the suite exercises both being present at once.
-		defaultModel:   "gemini-3.6-flash-low",
-		defaultTimeout: time.Minute,
-		maxConcurrency: 4,
-		withCacheFile:  true,
-	})
+	const row = "gemini-3.1-pro-high\tGemini 3.1 Pro (High)"
+	for _, tc := range []struct {
+		name          string
+		requestModel  string // the request's Model
+		requestEffort string // set only where effort coexistence is asserted
+		defaultModel  string // the configured AGY_MCP_DEFAULT_MODEL
+		assertEffort  bool
+	}{
+		{
+			// The request carries the row while a DIFFERENT default is configured, so
+			// this also pins that an explicit request model wins: the reduction runs
+			// after the fallback, and nothing else in the suite exercises both being
+			// present at once. Effort is set so the reduction is exercised on the
+			// request shape that motivated it; buildAgyArgs emits --effort independently
+			// of the model, so asserting both just pins that they coexist, not that agy
+			// would accept the pair.
+			name:          "explicit request row wins over a different default",
+			requestModel:  row,
+			requestEffort: "high",
+			defaultModel:  "gemini-3.6-flash-low",
+			assertEffort:  true,
+		},
+		{
+			// The row arrives via the fallback applied inside StartJob, which is
+			// invisible to the tool boundary that validates the request, so the
+			// reduction must cover it there too.
+			name:         "default fallback row",
+			defaultModel: row,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newManager(t, managerOpts{
+				agyPath:        "/usr/bin/agy",
+				supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
+				defaultModel:   tc.defaultModel,
+				defaultTimeout: time.Minute,
+				maxConcurrency: 4,
+				withCacheFile:  true,
+			})
 
-	job, err := m.StartJob(StartRequest{
-		Prompt: "x",
-		Model:  "gemini-3.1-pro-high\tGemini 3.1 Pro (High)",
-		Effort: "high",
-	})
-	if err != nil {
-		t.Fatalf("StartJob: %v", err)
-	}
-	meta, err := m.store.Load(job.ID)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if meta.Model != "gemini-3.1-pro-high" {
-		t.Errorf("meta.Model = %q, want the id column alone", meta.Model)
-	}
-	if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
-		t.Errorf("args must carry the id alone, got: %v", meta.Args)
-	}
-	// Effort is set here only so the reduction is exercised on the request shape
-	// that motivated it; buildAgyArgs emits --effort independently of the model,
-	// so this asserts the two coexist, not that agy would accept the pair.
-	if !hasArg(meta.Args, "--effort", "high") {
-		t.Errorf("args missing effort: %v", meta.Args)
-	}
-}
-
-// TestStartJobReducesDefaultModelRowToID: the same reduction must cover a model
-// that arrives from AGY_MCP_DEFAULT_MODEL rather than from the caller, because
-// the fallback is applied inside StartJob and so is invisible to the tool
-// boundary that validates the request (issue #135).
-func TestStartJobReducesDefaultModelRowToID(t *testing.T) {
-	m := newManager(t, managerOpts{
-		agyPath:        "/usr/bin/agy",
-		supervisorExe:  testutil.WriteFakeSupervisor(t, testutil.FakeSupervisor{Out: "done"}),
-		defaultTimeout: time.Minute,
-		defaultModel:   "gemini-3.1-pro-high\tGemini 3.1 Pro (High)",
-		maxConcurrency: 4,
-		withCacheFile:  true,
-	})
-
-	job, err := m.StartJob(StartRequest{Prompt: "x"})
-	if err != nil {
-		t.Fatalf("StartJob: %v", err)
-	}
-	meta, err := m.store.Load(job.ID)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if meta.Model != "gemini-3.1-pro-high" {
-		t.Errorf("meta.Model = %q, want the id column alone", meta.Model)
-	}
-	if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
-		t.Errorf("args must carry the id alone, got: %v", meta.Args)
+			job, err := m.StartJob(StartRequest{Prompt: "x", Model: tc.requestModel, Effort: tc.requestEffort})
+			if err != nil {
+				t.Fatalf("StartJob: %v", err)
+			}
+			meta, err := m.store.Load(job.ID)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if meta.Model != "gemini-3.1-pro-high" {
+				t.Errorf("meta.Model = %q, want the id column alone", meta.Model)
+			}
+			if !hasArg(meta.Args, "--model", "gemini-3.1-pro-high") {
+				t.Errorf("args must carry the id alone, got: %v", meta.Args)
+			}
+			if tc.assertEffort && !hasArg(meta.Args, "--effort", "high") {
+				t.Errorf("args missing effort: %v", meta.Args)
+			}
+		})
 	}
 }
 

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -41,8 +41,9 @@ type Model struct {
 // share, so the two cannot drift apart. `agy models` prints "<id>\t<label>" per
 // row; this trims the value, cuts on the FIRST tab (so a label that itself
 // contains a tab stays whole), and trims each half. A value with no tab yields
-// that value as the id and an empty label. It never invents or drops content;
-// the caller decides what an empty id means.
+// that value as the id and an empty label. Beyond trimming surrounding
+// whitespace it neither invents nor drops content; the caller decides what an
+// empty id means.
 func splitModelRow(row string) (id, label string) {
 	id, label, _ = strings.Cut(strings.TrimSpace(row), "\t")
 	return strings.TrimSpace(id), strings.TrimSpace(label)

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -37,29 +37,35 @@ type Model struct {
 	Label string
 }
 
+// splitModelRow applies the single row-split rule that modelID and parseModels
+// share, so the two cannot drift apart. `agy models` prints "<id>\t<label>" per
+// row; this trims the value, cuts on the FIRST tab (so a label that itself
+// contains a tab stays whole), and trims each half. A value with no tab yields
+// that value as the id and an empty label. It never invents or drops content;
+// the caller decides what an empty id means.
+func splitModelRow(row string) (id, label string) {
+	id, label, _ = strings.Cut(strings.TrimSpace(row), "\t")
+	return strings.TrimSpace(id), strings.TrimSpace(label)
+}
+
 // modelID reduces a model value to the id agy accepts.
 //
-// `agy models` prints "<id>\t<label>" per row, so a caller that copies a whole
-// row (or an operator who sets AGY_MCP_DEFAULT_MODEL to one) supplies a string
-// agy rejects outright ("is not recognized as a known model", measured against
-// agy 1.1.11). Keeping the part before the first tab turns it back into the id.
+// A caller that copies a whole `agy models` row ("<id>\t<label>"), or an operator
+// who sets AGY_MCP_DEFAULT_MODEL to one, supplies a string agy rejects outright
+// ("is not recognized as a known model", measured against agy 1.1.11); keeping
+// the id column alone turns it back into a value agy accepts.
 //
 // A value that is not a whole row is forwarded rather than guessed at: agy owns
 // the model namespace, and a bare display label in particular is one agy accepts
-// on its own.
-//
-// It never turns a non-empty value into an empty one, which is why the empty-id
-// case returns v rather than "". An empty model makes buildAgyArgs omit --model
-// altogether, so the run would silently use agy's own default; forwarding the
-// value instead lets agy refuse it, which is the loud failure a caller can act
-// on. The trimming matches parseModels, so a row and a hand-typed id reduce to
-// the same value (issue #135).
+// on its own. The empty-id case returns v (not "") for the same reason: an empty
+// model makes buildAgyArgs omit --model altogether and silently fall back to
+// agy's own default, so forwarding the value lets agy refuse it instead, which is
+// the loud failure a caller can act on (issue #135).
 func modelID(v string) string {
-	id, _, _ := strings.Cut(strings.TrimSpace(v), "\t")
-	if id = strings.TrimSpace(id); id == "" {
-		return v
+	if id, _ := splitModelRow(v); id != "" {
+		return id
 	}
-	return id
+	return v
 }
 
 // ListModels runs `agy models` and returns the available models.
@@ -94,22 +100,26 @@ func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
 	return parseModels(string(out)), nil
 }
 
-// parseModels turns `agy models` output into one Model per non-blank line,
-// splitting each row on its first tab.
-//
-// Splitting on the FIRST tab keeps a label that itself contains a tab attached
-// to the label rather than truncating the row. A line with no tab yields an id
-// with an empty label instead of being dropped, so output that carries no label
-// column still produces usable model values.
+// parseModels turns `agy models` output into one Model per non-blank line, using
+// splitModelRow to split each row into its id and label columns. A line with no
+// tab yields an id with an empty label instead of being dropped, so output that
+// carries no label column still produces usable model values.
 func parseModels(raw string) []Model {
-	var models []Model
+	// One model per line at most, so the newline count (plus one for a final line
+	// without a trailing newline) is a cheap, correct capacity hint; it over-counts
+	// only blank lines. This matches how the list_models handler preallocs and, like
+	// it, hands back a non-nil empty slice for empty input; no caller marshals this
+	// value, so nil vs empty is not observable downstream.
+	models := make([]Model, 0, strings.Count(raw, "\n")+1)
 	for line := range strings.Lines(raw) {
-		line = strings.TrimSpace(line)
-		if line == "" {
+		// splitModelRow trims before it cuts, so a blank or whitespace-only line is
+		// the only input that yields an empty id here; a real row never does. That
+		// makes the empty id the blank-line skip, with no second TrimSpace.
+		id, label := splitModelRow(line)
+		if id == "" {
 			continue
 		}
-		id, label, _ := strings.Cut(line, "\t")
-		models = append(models, Model{ID: strings.TrimSpace(id), Label: strings.TrimSpace(label)})
+		models = append(models, Model{ID: id, Label: label})
 	}
 	return models
 }

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -105,11 +105,11 @@ func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
 // tab yields an id with an empty label instead of being dropped, so output that
 // carries no label column still produces usable model values.
 func parseModels(raw string) []Model {
-	// One model per line at most, so the newline count (plus one for a final line
-	// without a trailing newline) is a cheap, correct capacity hint; it over-counts
-	// only blank lines. This matches how the list_models handler preallocs and, like
-	// it, hands back a non-nil empty slice for empty input; no caller marshals this
-	// value, so nil vs empty is not observable downstream.
+	// One model per line at most, so strings.Count(raw,"\n")+1 is an upper bound on
+	// the result: a cheap capacity hint that never under-allocates. It over-allocates
+	// by the blank lines skipped, plus one when raw ends in a trailing newline or is
+	// empty. Like the list_models handler, it returns a non-nil empty slice for empty
+	// input; no caller marshals this value, so nil vs empty is not observable downstream.
 	models := make([]Model, 0, strings.Count(raw, "\n")+1)
 	for line := range strings.Lines(raw) {
 		// splitModelRow trims before it cuts, so a blank or whitespace-only line is


### PR DESCRIPTION
## What

Quality cleanup drawn from the batched low-severity findings in #138. Four of the nine items, chosen because each is pure code quality with no behaviour change:

- **Item 1 + 6 (`internal/manager/models.go`)**: `modelID` and `parseModels` held two copies of the same row-split rule (trim, cut on the first tab, trim both halves). Extracted `splitModelRow` so the rule lives once and the two callers cannot drift, and preallocated `parseModels`'s result slice to match how the `list_models` handler already preallocs.
- **Item 5 (`internal/manager/job_posix_test.go`)**: folded the two near-identical model-row reduction tests into one table-driven test, keeping both scenarios (explicit request row wins over a different default; default-fallback row) and every assertion.
- **Item 7 (`README.md`)**: the status line said "verified against a live agy (1.1.10)", which read as if every measurement was taken at 1.1.10 and so contradicted the model-catalog note citing agy 1.1.11. Restated 1.1.10 as the minimum supported version.

## Not in this PR (the remaining #138 items)

Left open deliberately, each needs a decision or is unmeasured, so #138 stays open:

- **Item 2** (`jobstore.Meta.Model` is write-only): surfacing the resolved model in status/wait output is a small feature with an output-shape decision.
- **Item 3** (no `list_agents` tool): the `agy agents` output shape is NOT MEASURED; needs a live check before mirroring `list_models`.
- **Item 4** (`parseModels` treats any non-blank line as a model): adding enforcement is speculative robustness, not a defect.
- **Item 8** (`model_details` is `required` in the generated schema): a genuine trade (adding `omitempty` contradicts the always-an-array intent).
- **Item 9** (agy floor 1.1.10 vs row format verified on 1.1.11): raising the floor is a user-visible break needing a deliberate decision.

## Verification

- `go build ./...`, `go vet`, `go test ./...`, `go test -race ./internal/manager/` all green; golangci-lint clean; coverage 87.6%.
- No behaviour change: the existing `TestModelID`, `TestParseModels`, `TestParseModelsWithoutLabelColumn`, and the reduction tests pin the output; both `splitModelRow` trims and the folded blank-line skip were sabotage-verified (each protected line was broken and the matching test watched to fail, then restored).

## Review

Ran a full pre-push gate: six review agents (reuse, correctness, quality, integration, regression, test quality) plus a background Gemini cross-check. Result: zero defects in the diff. `modelID` proven byte-identical (a differential test over 4830 composed inputs plus an independent enumeration); `parseModels` byte-identical in contents, with the only difference being a non-nil-vs-nil empty slice on empty input that four reviewers independently traced to being unobservable at the `list_models` handler. Test discrimination was mutation-verified. One Low doc-precision fix was applied (the `parseModels` capacity-hint comment) and its every clause re-verified.

Refs #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to indicate agy 1.1.10 as the minimum supported version.

* **Bug Fixes**
  * Improved model selection handling to consistently preserve model identifiers and labels.
  * Blank model entries are now ignored while valid entries remain available for selection.

* **Tests**
  * Expanded coverage for explicit and default model configurations, including persisted model IDs and command-line arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->