### PR TITLE
feat(tools): echo the resolved model in status/wait output (#138 item 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Or add to your MCP client config:
 ## Tools
 
 - `agy_run(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?)` -> `{ job_id, conversation_id?, state }`
-- `agy_run_sync(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
-- `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage? }`
-- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, partial?, num_turns?, usage?, note? }`
+- `agy_run_sync(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, model?, partial?, num_turns?, usage?, step_type?, note? }`
+- `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, model?, partial?, num_turns?, usage?, step_type? }`
+- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, model?, partial?, num_turns?, usage?, step_type?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
 - `list_models()` -> `{ models, model_details }`
 - `list_sessions(dir?)` -> `{ sessions }`
@@ -108,6 +108,8 @@ Or add to your MCP client config:
 `models` holds ids alone, so its entries can be passed straight to `model`; `model_details` pairs each id with the display label `agy` prints for it, in the same order, for showing a readable name. Through v2.1.0 `models` carried each `agy models` row whole, which was a tab-joined `id<TAB>label` string that `agy` does not accept as a model at all, so a client had to split it and pick a column ([#135](https://github.com/tphakala/agy-mcp/issues/135)).
 
 `usage` is agy's own token accounting (`input_tokens`, `output_tokens`, `thinking_tokens`, `cache_read_tokens`, `total_tokens`), and together with `num_turns` it appears once a run reports a terminal result.
+
+`model` echoes the model id agy-mcp resolved for the run (the one you passed, or `AGY_MCP_DEFAULT_MODEL`, reduced to its id), so a caller can confirm which model actually ran. It is absent when no model was pinned and `agy` ran on its own default.
 
 A run that ends badly still hands back whatever it managed to say, so `result` is set on `failed` and `cancelled` jobs too and is worth reading rather than discarding. `partial` is what says whether to trust it as the final answer, and it follows from where the text came from rather than from the state.
 

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -60,6 +60,11 @@ type Status struct {
 	Result         string
 	Error          string // present when failed: agy's own message, or a stderr tail + exit code
 	ConversationID string
+	// Model is the model id agy-mcp resolved for this run and persisted to meta:
+	// the request's model, or AGY_MCP_DEFAULT_MODEL when none was given, reduced to
+	// the id column (see modelID). Empty when neither was set, meaning the server
+	// pinned no model and agy ran on its own default (which this build cannot name).
+	Model string
 	// Partial marks a Result this build cannot vouch for as the complete final
 	// answer. It follows from where the text came from, not from State:
 	//
@@ -99,6 +104,7 @@ func (m *Manager) Status(id string) (Status, error) {
 	st := Status{
 		Elapsed:        time.Since(meta.StartedAt),
 		ConversationID: meta.ConversationID,
+		Model:          meta.Model,
 	}
 	// The progress file is what makes a running job's conversation id readable:
 	// the supervisor records it as soon as agy's init event names the

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -826,3 +826,42 @@ func TestStatusRecoveredFromPayload(t *testing.T) {
 		})
 	}
 }
+
+// TestStatusEchoesResolvedModel: Status echoes the resolved model persisted to
+// meta (issue #138 item 2), so a caller can see which model actually ran. It is
+// set at construction, before the terminal-vs-running branch, so it rides every
+// state; an empty meta.Model stays empty (the server pinned no model).
+func TestStatusEchoesResolvedModel(t *testing.T) {
+	boot := readBootID()
+	for _, tc := range []struct {
+		name      string
+		metaModel string
+		pid       int
+		bootID    string
+		done      bool
+		want      string
+	}{
+		{"done state carries the model", "gemini-3.1-pro-high", 0, boot, true, "gemini-3.1-pro-high"},
+		{"interrupted state carries the model too", "gemini-3.1-pro-high", 999999, "old-boot", false, "gemini-3.1-pro-high"},
+		{"no pinned model stays empty", "", 0, boot, true, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newManager(t, managerOpts{})
+			dir, err := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), PID: tc.pid, BootID: tc.bootID, Model: tc.metaModel})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.done {
+				writeResultPayload(t, dir, streamjson.Result{Status: streamjson.StatusSuccess, Response: "x"})
+				_ = m.store.WriteExitCode("j", 0)
+			}
+			st, err := m.Status("j")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if st.Model != tc.want {
+				t.Errorf("st.Model = %q, want %q (state %q)", st.Model, tc.want, st.State)
+			}
+		})
+	}
+}

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -183,6 +183,9 @@ type statusOutput struct {
 	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set on any terminal state whose text could be recovered, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first. A running job carries none even once it has produced text, so collect the result once the state is terminal"`
 	Error          string `json:"error,omitempty" jsonschema:"why the job failed; present only when state is failed"`
 	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread. Empty until agy names a fresh run's conversation, which takes about a second, so agy_status, agy_wait and agy_run_sync all report none when asked inside that window; ask again once the run is under way"`
+	// Model echoes the resolved model so a caller can see which one actually ran;
+	// see manager.Status.Model.
+	Model string `json:"model,omitempty" jsonschema:"the model id agy-mcp resolved for this run and passed to agy: the model you set, or AGY_MCP_DEFAULT_MODEL, reduced to the id column. Absent when the server pinned no model and agy ran on its own default"`
 	// Partial marks a result that is not a verified final answer; see
 	// manager.Status.Partial.
 	Partial bool `json:"partial,omitempty" jsonschema:"true when result is not the verified final answer, so treat it as incomplete. It follows from where the text came from: true when the text was reconstructed from the streamed events, because agy never reported a terminal result or the one it reported carried no text, and true when agy reported a terminal result that was not a success, so its text is only what the run had produced when it stopped. A response agy itself marked successful is never partial, even on a job that was then cancelled or killed"`
@@ -216,6 +219,7 @@ func toStatusOutput(st manager.Status) statusOutput {
 		Result:         st.Result,
 		Error:          st.Error,
 		ConversationID: st.ConversationID,
+		Model:          st.Model,
 		Partial:        st.Partial,
 		NumTurns:       st.NumTurns,
 		StepType:       st.StepType,

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -1,10 +1,13 @@
 package mcptools
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tphakala/agy-mcp/v2/internal/manager"
 )
 
 // TestToStartRequestRejectsExcessiveTimeout: a client timeout is validated
@@ -260,5 +263,30 @@ func TestToStartRequestValidatesEffort(t *testing.T) {
 				t.Fatalf("Effort = %q, want %q", req.Effort, tc.effort)
 			}
 		})
+	}
+}
+
+// TestStatusOutputModelEchoAndOmitempty: toStatusOutput echoes the resolved model
+// onto the wire (issue #138 item 2), and omits the key entirely when the model is
+// empty, so the field never becomes a required member of the generated schema
+// (cf. #138 item 8).
+func TestStatusOutputModelEchoAndOmitempty(t *testing.T) {
+	got := toStatusOutput(manager.Status{State: manager.StateDone, Model: "gemini-3.1-pro-high"})
+	if got.Model != "gemini-3.1-pro-high" {
+		t.Errorf("Model = %q, want it echoed from the status", got.Model)
+	}
+	b, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"model":"gemini-3.1-pro-high"`) {
+		t.Errorf("marshaled output missing model: %s", b)
+	}
+	b2, err := json.Marshal(toStatusOutput(manager.Status{State: manager.StateDone}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b2), `"model"`) {
+		t.Errorf("an empty model must be omitted from the wire, got: %s", b2)
 	}
 }


### PR DESCRIPTION
## What

Addresses **item 2** of #138: `jobstore.Meta.Model` stored the resolved model id but nothing read it back, so a caller could not observe which model a run actually used.

This carries `meta.Model` through `manager.Status` and out onto the wire as a `model` field on `agy_status`, `agy_wait`, and `agy_run_sync` (they share `toStatusOutput`). The field is set once at the `Status()` construction point, before the terminal-vs-running branch, so it rides every state (done, failed, cancelled, timeout, spawn-fail, interrupted).

`model` uses `json:"model,omitempty"`:

- Present with the resolved id: the request model, or `AGY_MCP_DEFAULT_MODEL`, reduced to its id column (same `modelID` reduction the run itself uses).
- Absent when the server pinned no model and `agy` ran on its own default (which this build cannot name).
- `omitempty` also keeps it out of the generated schema's `required` set, so it does not reintroduce the concern tracked as item 8.

README output signatures and field docs are updated to match. While editing those three signatures I also added the pre-existing-missing `step_type?` to them, so they are now fully accurate.

## Verification

- `go build`, `go vet`, `go test ./...`, gate mechanical floor (golangci-lint + go test with CI build tags) all green.
- New tests in `status_test.go` (echo across done / interrupted / empty-model states) and `tools_test.go` (wire echo + `omitempty` omits an empty model). Both, and the `omitempty` tag, were sabotage-verified: each protected line was broken and the matching test watched to fail, then restored.
- Independent Gemini review confirmed: `Model` reaches the wire on every `Status` return path; no production caller synthesizes a `Status` that would drop it (both `agy_run_sync` and `agy_wait` route through `m.Status`); `omitempty` prevents `required`; and the doc claims hold against the code.

Refs #138 (item 2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run status now reports the resolved model ID when a model was explicitly selected.
  * The model field is omitted when no model is pinned.
* **Documentation**
  * Updated tool documentation to describe the new model information returned by synchronous runs, status checks, and wait operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->