### PR TITLE
feat(agyver): raise the agy floor to 1.1.11 (#138 item 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An MCP (Model Context Protocol) server that wraps the [Antigravity CLI](https://antigravity.google) (`agy`), so any MCP client (Claude Code, Cursor, Cline, and others) can run `agy` prompts, peer reviews, and follow-up turns as native tools.
 
-> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, per-run controls and structured output, cross-platform builds) and verified against a live agy, with 1.1.10 the minimum supported version.
+> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, per-run controls and structured output, cross-platform builds) and verified against a live agy, with 1.1.11 the minimum supported version.
 
 ## Why
 
@@ -53,9 +53,9 @@ Two transports run the same core:
 
 ## Requirements
 
-- **agy 1.1.10 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation. Two things set it: 1.1.8 added `--output-format` to print mode and agy-mcp drives every job through the `stream-json` format it introduced, and 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in headless `-p` (`--model` and `--effort`) are honored rather than silently ignored (both per agy's changelog). Older builds are refused rather than degraded.
+- **agy 1.1.11 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation. Three things set it: 1.1.8 added `--output-format` to print mode and agy-mcp drives every job through the `stream-json` format it introduced; 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in headless `-p` (`--model` and `--effort`) are honored rather than silently ignored (both per agy's changelog); and 1.1.11 is the version the `agy models` row format (`<id>\t<label>` per line) was measured against, which `list_models` parses and the tool schema documents as ids. Older builds are refused rather than degraded.
 
-  The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.10 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
+  The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.11 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
 
   A missing `agy` does not stop the server from starting. `initialize`, `tools/list`, and `list_sessions` never exec it, so the lookup is deferred: the server starts, logs a warning to stderr, serves discovery normally, and the tools that do need the binary (`agy_run`, `agy_run_sync`, `list_models`) fail per call with `agy not found on PATH; set AGY_MCP_AGY_PATH`. An `agy` installed later is picked up without restarting the server. An explicit `AGY_MCP_AGY_PATH` is treated differently: it is a claim about one specific binary, so a typo or a non-executable target still fails fast at startup.
 - Go 1.26+ to build.
@@ -232,7 +232,7 @@ agy-mcp -http 127.0.0.1:8765 -http-token "$(openssl rand -hex 32)"
 
 ## Upgrading from v1
 
-v2 requires agy 1.1.10 and drives it through `--output-format stream-json`. The upgrade is safe to do in place, but two things are worth knowing.
+v2 requires agy 1.1.11 and drives it through `--output-format stream-json`. The upgrade is safe to do in place, but two things are worth knowing.
 
 **Stop the server before replacing the binary.** The supervisor is the same `agy-mcp` binary re-executed as `agy-mcp run-job <dir>`, so replacing it under a live v1 server pairs an old manager with a new supervisor. The supervisor detects that case and asks agy for the event stream anyway, so no result is lost, but a v1 manager and a v2 process sharing one `AGY_MCP_STATE_DIR` briefly disagree about cross-process locking, and a v1 run's conversation id can be misattributed in that window.
 
@@ -241,7 +241,7 @@ v2 requires agy 1.1.10 and drives it through `--output-format stream-json`. The 
 - A v1 fresh run may report no `conversation_id`. v1 recovered it by diffing agy's conversation cache, and v2 has no such path. Recover the thread with `list_sessions` if you need it.
 - Cancelled and interrupted v1 jobs behave as before; only the id is affected.
 
-**Behaviour changes to check your client against:** `agy_run` now blocks up to 2s waiting for agy to name the conversation, instead of returning instantly; fresh runs in the same directory no longer conflict, so anything that relied on that conflict error as a mutex now gets real concurrency (and agy runs with `--dangerously-skip-permissions`, so concurrent runs edit one working tree); and `list_models` is now refused on an agy older than 1.1.10, even though `agy models` itself would work there.
+**Behaviour changes to check your client against:** `agy_run` now blocks up to 2s waiting for agy to name the conversation, instead of returning instantly; fresh runs in the same directory no longer conflict, so anything that relied on that conflict error as a mutex now gets real concurrency (and agy runs with `--dangerously-skip-permissions`, so concurrent runs edit one working tree); and `list_models` is now refused on an agy older than 1.1.11, even though `agy models` itself would work there.
 
 ## Configuration
 

--- a/internal/agyver/agyver.go
+++ b/internal/agyver/agyver.go
@@ -10,15 +10,20 @@ import (
 	"strings"
 )
 
-// Required is the oldest agy that agy-mcp can drive. Two facts set the floor.
+// Required is the oldest agy that agy-mcp can drive. Three facts set the floor.
 // 1.1.8 added --output-format (text, json, stream-json) to print mode, and the
 // whole job pipeline reads the stream-json event stream, so an older agy cannot
-// be used at all rather than degraded. 1.1.10 is then the first release where
-// the run-shaping flags agy-mcp forwards in headless -p (--model and --effort)
-// actually take effect; on 1.1.8/1.1.9 they were silently
-// ignored, so a lower floor would let a passing gate hide a no-op flag. Both
-// facts are from agy's own changelog (run `agy changelog` to confirm).
-var Required = Version{Major: 1, Minor: 1, Patch: 10}
+// be used at all rather than degraded. 1.1.10 is the first release where the
+// run-shaping flags agy-mcp forwards in headless -p (--model and --effort)
+// actually take effect; on 1.1.8/1.1.9 they were silently ignored, so a lower
+// floor would let a passing gate hide a no-op flag. 1.1.11 is the version the
+// `agy models` output was measured against (one "<id>\t<label>" row per model);
+// list_models parses that shape and the tool schema documents the first column
+// as ids, so pinning the floor there keeps that promise from resting on an
+// older format nobody probed (issue #138). The 1.1.8 and 1.1.10 facts are from
+// agy's own changelog (run `agy changelog` to confirm); the 1.1.11 row format is
+// a probe recorded in internal/manager/models.go.
+var Required = Version{Major: 1, Minor: 1, Patch: 11}
 
 // Version is a parsed agy version.
 type Version struct {

--- a/internal/agyver/agyver.go
+++ b/internal/agyver/agyver.go
@@ -17,12 +17,15 @@ import (
 // run-shaping flags agy-mcp forwards in headless -p (--model and --effort)
 // actually take effect; on 1.1.8/1.1.9 they were silently ignored, so a lower
 // floor would let a passing gate hide a no-op flag. 1.1.11 is the version the
-// `agy models` output was measured against (one "<id>\t<label>" row per model);
-// list_models parses that shape and the tool schema documents the first column
-// as ids, so pinning the floor there keeps that promise from resting on an
-// older format nobody probed (issue #138). The 1.1.8 and 1.1.10 facts are from
-// agy's own changelog (run `agy changelog` to confirm); the 1.1.11 row format is
-// a probe recorded in internal/manager/models.go.
+// `agy models` output was probed against: id-first "<id>\t<label>" rows, which
+// is the shape list_models reports and the tool schema calls ids. parseModels
+// would still parse an older or differently-shaped output without erroring, so
+// this is not about crashing; it is that a build whose columns differed would
+// have the schema present labels as ids (the #135 class), so pinning the floor
+// at the probed version keeps the schema's id claim honest (issue #138). The
+// 1.1.8 and 1.1.10 facts are from agy's own changelog (run `agy changelog`); the
+// 1.1.11 row shape is pinned by the parse tests (TestParseModels) and the format
+// note in internal/testutil/fakeagy.go.
 var Required = Version{Major: 1, Minor: 1, Patch: 11}
 
 // Version is a parsed agy version.

--- a/internal/agyver/agyver_test.go
+++ b/internal/agyver/agyver_test.go
@@ -453,7 +453,7 @@ func TestString(t *testing.T) {
 	if got := (Version{1, 1, 8}).String(); got != "1.1.8" {
 		t.Fatalf("String() = %q, want 1.1.8", got)
 	}
-	if got := Required.String(); got != "1.1.10" {
+	if got := Required.String(); got != "1.1.11" {
 		t.Fatalf("Required = %q; update this test deliberately when the floor moves", got)
 	}
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -915,7 +915,8 @@ func buildAgyArgs(req StartRequest) []string {
 		// for that exact print-mode feature, unlike --effort which was accepted but a
 		// no-op in -p until 1.1.10. Passing it on every run makes prompt semantics mean
 		// what the caller wrote, independent of the installed agy version. Always
-		// available because the agy floor (agyver.Required) is 1.1.10 (>= 1.1.9).
+		// available because the agy floor (agyver.Required) is at or above the 1.1.9
+		// that introduced the flag.
 		disableSlashCommandsFlag,
 	}
 	if req.Model != "" {

--- a/internal/manager/version_test.go
+++ b/internal/manager/version_test.go
@@ -67,6 +67,18 @@ func TestAgyBinaryCheckedRefusesOldVersion(t *testing.T) {
 	}
 }
 
+// TestAgyBinaryCheckedRefusesImmediateSubFloor pins the boundary issue #138 item
+// 9 moved: agy 1.1.10, the release directly below the 1.1.11 floor and one that
+// used to pass, is now refused. That is what makes raising the floor a real gate
+// change rather than a constant edit; TestAgyBinaryCheckedRefusesOldVersion only
+// proves an ancient 1.1.7 is refused, which was true before the bump too.
+func TestAgyBinaryCheckedRefusesImmediateSubFloor(t *testing.T) {
+	m, _ := versionManager(t, "1.1.10", nil)
+	if _, err := m.agyBinaryChecked(t.Context()); err == nil {
+		t.Fatal("agy 1.1.10 (one below the 1.1.11 floor) must be refused")
+	}
+}
+
 // A refusal is deliberately not cached, so upgrading agy is picked up without
 // restarting the server, matching the deferred PATH lookup's promise.
 func TestAgyBinaryCheckedRetriesAfterRefusal(t *testing.T) {


### PR DESCRIPTION
## What

Addresses **item 9** of #138. The agy floor was 1.1.10, but the `agy models` row format (`<id>\t<label>` per line) that `list_models` parses and the tool schema documents as ids was only ever probed against agy 1.1.11. So the schema's "these are ids" promise rested on an older format nobody measured.

This pins the floor at 1.1.11 to match the version the row format was verified on:

- `agyver.Required` -> 1.1.11, with its rationale comment extended (the third fact alongside 1.1.8 stream-json and 1.1.10 flags-honored).
- `TestString` canary updated to 1.1.11 (the deliberate floor-value pin; the manager version tests derive the passing version from `agyver.Required`, so they adapt automatically).
- Reworded the `--disable-slash-commands` comment so it no longer hardcodes the floor number.
- README floor statements updated to 1.1.11. The "1.1.10 is the first release where `--model`/`--effort` are honored in `-p`" fact and the historical continuation-behaviour note stay, since both remain true.

**This raises the minimum supported agy, so it is a user-visible break** for anyone pinned to 1.1.10.

## Verification

- `go build`, `go test ./...`, and the gate mechanical floor (golangci-lint + go test with CI build tags) all green; coverage 88.6%.
- The floor value is pinned by `TestString`; sabotage-verified (reverting to 1.1.10 fails it). Too-old rejection stays covered by `version_test.go` (a 1.1.7 build is refused). An independent Gemini review confirmed the rationale and completeness of the multi-site update.

Refs #138 (item 9)
