### PR TITLE
feat(agyver): raise the agy floor to 1.1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 An MCP (Model Context Protocol) server that wraps the [Antigravity CLI](https://antigravity.google) (`agy`), so any MCP client (Claude Code, Cursor, Cline, and others) can run `agy` prompts, peer reviews, and follow-up turns as native tools.
 
-> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, per-run controls and structured output, cross-platform builds) and verified against a live agy, with 1.1.12 the minimum supported version.
+> Status: feature complete (stdio and HTTP transports, async and sync job lifecycle, model and session discovery, per-run controls and structured output, cross-platform builds) and verified against a live agy, with 1.1.15 the minimum supported version.
 
 ## Why
 
@@ -53,9 +53,9 @@ Two transports run the same core:
 
 ## Requirements
 
-- **agy 1.1.12 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation. Three things set it: 1.1.8 added `--output-format` to print mode and agy-mcp drives every job through the `stream-json` format it introduced; 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in headless `-p` (`--model` and `--effort`) are honored rather than silently ignored; and 1.1.12 added machine-readable output to the `models` subcommand, the `command.data.models` envelope that `list_models` decodes into ids and labels instead of tab-splitting text (all three per agy's changelog). Older builds are refused rather than degraded.
+- **agy 1.1.15 or newer**, on `PATH` or configured explicitly via `AGY_MCP_AGY_PATH`. This is a hard floor, not a recommendation. The floor is 1.1.15 because that release fixed streamed text corrupting non-ASCII characters into replacement characters in the `--output-format stream-json` text deltas. Those deltas are the text agy-mcp falls back to for a run cut short before agy's result event, or one agy completes with an empty response: on an older agy that text is lossy for non-ASCII content (another language, emoji, box drawing, unicode in code), and agy-mcp cannot repair bytes it never received intact. Earlier, lower floors it subsumes: 1.1.8 added `--output-format` to print mode and agy-mcp drives every job through the `stream-json` format it introduced; 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in headless `-p` (`--model` and `--effort`) are honored rather than silently ignored; 1.1.12 added the machine-readable `models` envelope (`command.data.models`) that `list_models` decodes into ids and labels instead of tab-splitting text, and fixed `--mode` being ignored in headless `-p`; and 1.1.14 made a failed language server exit non-zero instead of reporting success, so agy-mcp records that failure as failed (all per agy's changelog). Older builds are refused rather than degraded.
 
-  The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.12 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
+  The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.15 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
 
   A missing `agy` does not stop the server from starting. `initialize`, `tools/list`, and `list_sessions` never exec it, so the lookup is deferred: the server starts, logs a warning to stderr, serves discovery normally, and the tools that do need the binary (`agy_run`, `agy_run_sync`, `list_models`) fail per call with `agy not found on PATH; set AGY_MCP_AGY_PATH`. An `agy` installed later is picked up without restarting the server. An explicit `AGY_MCP_AGY_PATH` is treated differently: it is a claim about one specific binary, so a typo or a non-executable target still fails fast at startup.
 - Go 1.26+ to build.
@@ -232,7 +232,7 @@ agy-mcp -http 127.0.0.1:8765 -http-token "$(openssl rand -hex 32)"
 
 ## Upgrading from v1
 
-v2 requires agy 1.1.12 and drives it through `--output-format stream-json`. The upgrade is safe to do in place, but two things are worth knowing.
+v2 requires agy 1.1.15 and drives it through `--output-format stream-json`. The upgrade is safe to do in place, but two things are worth knowing.
 
 **Stop the server before replacing the binary.** The supervisor is the same `agy-mcp` binary re-executed as `agy-mcp run-job <dir>`, so replacing it under a live v1 server pairs an old manager with a new supervisor. The supervisor detects that case and asks agy for the event stream anyway, so no result is lost, but a v1 manager and a v2 process sharing one `AGY_MCP_STATE_DIR` briefly disagree about cross-process locking, and a v1 run's conversation id can be misattributed in that window.
 
@@ -241,7 +241,7 @@ v2 requires agy 1.1.12 and drives it through `--output-format stream-json`. The 
 - A v1 fresh run may report no `conversation_id`. v1 recovered it by diffing agy's conversation cache, and v2 has no such path. Recover the thread with `list_sessions` if you need it.
 - Cancelled and interrupted v1 jobs behave as before; only the id is affected.
 
-**Behaviour changes to check your client against:** `agy_run` now blocks up to 2s waiting for agy to name the conversation, instead of returning instantly; fresh runs in the same directory no longer conflict, so anything that relied on that conflict error as a mutex now gets real concurrency (and agy runs with `--dangerously-skip-permissions`, so concurrent runs edit one working tree); and `list_models` is now refused on an agy older than 1.1.12, even though `agy models` itself would work there.
+**Behaviour changes to check your client against:** `agy_run` now blocks up to 2s waiting for agy to name the conversation, instead of returning instantly; fresh runs in the same directory no longer conflict, so anything that relied on that conflict error as a mutex now gets real concurrency (and agy runs with `--dangerously-skip-permissions`, so concurrent runs edit one working tree); and `list_models` is now refused on an agy older than 1.1.15, even though `agy models` itself would work there.
 
 ## Configuration
 

--- a/internal/agyver/agyver.go
+++ b/internal/agyver/agyver.go
@@ -10,24 +10,50 @@ import (
 	"strings"
 )
 
-// Required is the oldest agy that agy-mcp can drive. Three facts set the floor.
-// 1.1.8 added --output-format (text, json, stream-json) to print mode, and the
-// whole job pipeline reads the stream-json event stream, so an older agy cannot
-// be used at all rather than degraded. 1.1.10 is the first release where the
-// run-shaping flags agy-mcp forwards in headless -p (--model and --effort)
-// actually take effect; on 1.1.8/1.1.9 they were silently ignored, so a lower
-// floor would let a passing gate hide a no-op flag. 1.1.12 added machine-readable
-// output to the `models` subcommand: `agy --output-format json models` returns a
-// command envelope whose command.data.models is a list of {id,label} objects, and
-// list_models decodes that typed field instead of tab-splitting the text rows.
-// decodeModelsEnvelope refuses an envelope whose status is not SUCCESS, whose
-// command is not `models`, or that omits the models array, so a shape change in
-// any of those fails loudly rather than being read as an empty catalog; an agy
-// without the envelope at all is simply too old to read. All three facts are
-// from agy's own changelog (run
-// `agy changelog`): the 1.1.12 line reads "machine-readable output to the models
-// and agents subcommands".
-var Required = Version{Major: 1, Minor: 1, Patch: 12}
+// Required is the oldest agy that agy-mcp can drive. The floor is 1.1.15 because
+// that release fixed streamed text corrupting non-ASCII characters into U+FFFD
+// replacement characters in the --output-format stream-json text deltas. Those
+// deltas are the text agy-mcp reconstructs: the supervisor concatenates every
+// agent_response text_delta into the job's out file (internal/supervisor/stream.go),
+// and agy-mcp falls back to that streamed text as the job result whenever agy's
+// terminal result payload is absent or carried an empty response
+// (internal/manager/status.go): a run cut short before agy's result event, or one
+// it ends with no response. A still-running job is not
+// affected; it reports no result text until it is terminal. On an older agy that
+// reconstructed text is lossy for any non-ASCII content (another language, emoji,
+// box drawing, unicode in code), and agy-mcp cannot repair bytes it never received
+// intact, so the binary is refused rather than driven into silent corruption.
+// Whether agy's terminal result response field carried the same corruption is not
+// asserted here: the 1.1.15 line names the text deltas (and the interactive
+// display), not that response field.
+//
+// Earlier releases set earlier, lower floors that this one subsumes. They are kept
+// here so a maintainer who ever lowers the floor knows what each step below 1.1.15
+// gives up:
+//   - 1.1.8 added --output-format (text, json, stream-json) to print mode, and the
+//     whole job pipeline reads the stream-json event stream, so an older agy cannot
+//     be used at all rather than degraded.
+//   - 1.1.10 is the first release where the run-shaping flags agy-mcp forwards in
+//     headless -p (--model and --effort) actually take effect; on 1.1.8/1.1.9 they
+//     were silently ignored, so a lower floor would let a passing gate hide a
+//     no-op flag.
+//   - 1.1.12 added the machine-readable `models` envelope
+//     (`agy --output-format json models` -> command.data.models, a list of
+//     {id,label} objects) that list_models decodes instead of tab-splitting text.
+//     decodeModelsEnvelope refuses an envelope whose status is not SUCCESS, whose
+//     command is not `models`, or that omits the models array, so a shape change
+//     fails loudly rather than reading as an empty catalog; an agy without the
+//     envelope at all is simply too old to read. 1.1.12 also fixed --mode (which
+//     agy-mcp forwards) being silently ignored in headless -p.
+//   - 1.1.14 made a failed language server exit non-zero instead of exiting
+//     silently as success, so agy-mcp's exit-code-driven state reports that
+//     failure as failed rather than an empty done.
+//
+// All facts are from agy's own changelog (run `agy changelog`); the 1.1.15 line
+// reads "Fixed streamed text corrupting non-ASCII characters into replacement
+// characters, in both the interactive display and --output-format stream-json
+// text deltas."
+var Required = Version{Major: 1, Minor: 1, Patch: 15}
 
 // Version is a parsed agy version.
 type Version struct {

--- a/internal/agyver/agyver_test.go
+++ b/internal/agyver/agyver_test.go
@@ -453,7 +453,7 @@ func TestString(t *testing.T) {
 	if got := (Version{1, 1, 8}).String(); got != "1.1.8" {
 		t.Fatalf("String() = %q, want 1.1.8", got)
 	}
-	if got := Required.String(); got != "1.1.12" {
+	if got := Required.String(); got != "1.1.15" {
 		t.Fatalf("Required = %q; update this test deliberately when the floor moves", got)
 	}
 }

--- a/internal/manager/version_test.go
+++ b/internal/manager/version_test.go
@@ -68,14 +68,14 @@ func TestAgyBinaryCheckedRefusesOldVersion(t *testing.T) {
 }
 
 // TestAgyBinaryCheckedRefusesImmediateSubFloor pins the boundary the floor bump
-// moves: agy 1.1.11, the release directly below the 1.1.12 floor and one that
+// moves: agy 1.1.14, the release directly below the 1.1.15 floor and one that
 // used to pass, is now refused. That is what makes raising the floor a real gate
 // change rather than a constant edit; TestAgyBinaryCheckedRefusesOldVersion only
 // proves an ancient 1.1.7 is refused, which was true before the bump too.
 func TestAgyBinaryCheckedRefusesImmediateSubFloor(t *testing.T) {
-	m, _ := versionManager(t, "1.1.11", nil)
+	m, _ := versionManager(t, "1.1.14", nil)
 	if _, err := m.agyBinaryChecked(t.Context()); err == nil {
-		t.Fatal("agy 1.1.11 (one below the 1.1.12 floor) must be refused")
+		t.Fatal("agy 1.1.14 (one below the 1.1.15 floor) must be refused")
 	}
 }
 


### PR DESCRIPTION
## What

Raise the required minimum agy version (`agyver.Required`) from 1.1.12 to 1.1.15.

## Why

agy 1.1.15 fixed non-ASCII characters being corrupted into replacement characters in the `--output-format stream-json` text deltas. Those deltas are the text agy-mcp reconstructs and returns on its streamed fallback path: a run cut short before agy's result event, or one that ends with an empty response (the fallback helpers in `internal/manager/status.go`). On an older agy that reconstructed text is lossy for any non-ASCII content (another language, emoji, box drawing, unicode in code), and agy-mcp cannot repair bytes it never received intact, so the binary is refused rather than driven into silent corruption. The changelog scopes the fix to the interactive display and the stream-json text deltas, not the terminal `response` field, and the rationale comment says so explicitly rather than overclaiming.

Supporting reason: agy 1.1.14 made a failed language server exit non-zero instead of reporting success, so agy-mcp's exit-code-driven state now records that failure as failed rather than an empty done.

The common path (a successful run with a non-empty terminal `response`) returns that `response`, not the streamed text, so it is not exposed; the impact is limited to the fallback path. `--input-format stream-json`, also new in 1.1.15, was considered and not adopted: it does not fit the job-per-process, restart-resilient supervisor model, and `--conversation` already handles multi-turn continuation.

## Changes

- `internal/agyver/agyver.go`: `Required` to 1.1.15, with a rewritten rationale comment. The subsumed lower floors (1.1.8 output-format, 1.1.10 model/effort, 1.1.12 models envelope plus the `--mode` fix, 1.1.14) are kept so a future maintainer knows what each step below 1.1.15 gives up.
- `internal/manager/version_test.go`: retarget the immediate-sub-floor test to 1.1.14 (one below the new floor).
- `internal/agyver/agyver_test.go`: `TestString` canary to 1.1.15.
- `README.md`: requirements bullet, error-message example, status line, and "Upgrading from v1" notes to 1.1.15.

Measured-fact citations about specific agy releases (the 1.1.11 label/id behavior in `models.go`, the 1.1.12+ models envelope in `models.go` and `fakeagy.go`) are deliberately left unchanged: they describe when features appeared, not the floor.

## Verification

- `go build ./...`, `go vet`, `gofmt`, `golangci-lint`: clean.
- `go test ./...`: all packages pass (88.7% coverage on the changed packages).
- Sabotage-checked both boundary tests: dropping the floor to 1.1.14 turns `TestString` and the sub-floor test red, confirming they pin 1.1.15.
- Reviewed through the pre-push gate (six dimension agents plus a Gemini Pro peer review plus a report-only fix-wave pass). Every finding was a doc-accuracy precision issue in the rationale comment (an over-inclusive "in-flight" run-type, a "names only the text deltas" claim that dropped the interactive-display half, and an incomplete function citation), all now fixed. No behavioral defects.
