### PR TITLE
test(manager): fix flaky StartJob TempDir teardown race (#149)

### DIFF
--- a/internal/manager/job_posix_test.go
+++ b/internal/manager/job_posix_test.go
@@ -29,6 +29,9 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
+	// The fake supervisor writes out/exit_code; wait for it before teardown so its
+	// writes finish before t.TempDir RemoveAll (see deferJobDone).
+	deferJobDone(t, m, job.ID)
 	if job.ID == "" {
 		t.Fatal("empty job id")
 	}
@@ -47,12 +50,6 @@ func TestStartJobPersistsMetaAndSpawns(t *testing.T) {
 	if !contains(meta.Args, "-p") || !contains(meta.Args, "--dangerously-skip-permissions") {
 		t.Errorf("args missing required flags: %v", meta.Args)
 	}
-
-	// The fake supervisor writes out/exit_code; wait briefly for it.
-	testutil.WaitFor(t, 15*time.Second, func() bool {
-		_, ok := m.store.ExitCode(job.ID)
-		return ok
-	}, "supervisor did not write exit_code")
 }
 
 // TestStartJobWiresConversationID covers the continue-a-conversation path that
@@ -72,6 +69,7 @@ func TestStartJobWiresConversationID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
+	deferJobDone(t, m, job.ID)
 	if job.ConversationID != convID {
 		t.Errorf("returned conversation id = %q, want %q", job.ConversationID, convID)
 	}
@@ -145,6 +143,7 @@ func TestStartJobNormalizesCwd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
+	deferJobDone(t, m, job.ID)
 	meta, err := m.store.Load(job.ID)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -219,6 +218,7 @@ func TestStartJobReducesModelRowToID(t *testing.T) {
 			if err != nil {
 				t.Fatalf("StartJob: %v", err)
 			}
+			deferJobDone(t, m, job.ID)
 			meta, err := m.store.Load(job.ID)
 			if err != nil {
 				t.Fatalf("Load: %v", err)
@@ -299,6 +299,34 @@ func TestStartJobSerializesSameConversation(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "already running on conversation") {
 		t.Fatalf("second run error = %v, want a refusal naming the shared conversation", err)
 	}
+}
+
+// deferJobDone registers a cleanup that blocks until the job's supervisor has
+// written its exit-code sentinel, which WriteFakeSupervisor emits as its LAST
+// write to the job dir (see fakesupervisor.go). A StartJob test that spawns a
+// supervisor and returns before it finishes races the detached supervisor's
+// writes against t.TempDir teardown, so RemoveAll intermittently fails with
+// "directory not empty" (issue #149).
+//
+// It is registered right after a successful StartJob rather than called at the
+// end of the test, so it still runs (t.Cleanup is LIFO, so before the newManager
+// StateDir's own teardown) when an assertion fails early via t.Fatalf and skips
+// the rest of the body; calling it inline at the end would be skipped on exactly
+// that path and mask the real failure with a spurious RemoveAll error.
+//
+// Only tests whose fake supervisor actually writes into the job dir and completes
+// on its own need it. Tests that expect StartJob to fail (no supervisor spawned),
+// that kill a sleeping supervisor (killJob), or that use a non-writing supervisor
+// such as `sleep` are not exposed; a supervisor that is SIGKILLed never writes an
+// exit code, so waiting for one there would time out.
+func deferJobDone(t *testing.T, m *Manager, id string) {
+	t.Helper()
+	t.Cleanup(func() {
+		testutil.WaitFor(t, 15*time.Second, func() bool {
+			_, ok := m.store.ExitCode(id)
+			return ok
+		}, "supervisor did not write its exit-code sentinel")
+	})
 }
 
 func contains(ss []string, want string) bool {


### PR DESCRIPTION
## Summary

Fixes #149. `StartJob` spawns a detached supervisor that writes into `<StateDir>/jobs/<id>/`. A few `StartJob` tests asserted on the persisted `meta` and returned immediately, so Go's `t.TempDir()` cleanup ran `os.RemoveAll` on the StateDir while the fake supervisor was still creating files, failing intermittently with "directory not empty". This flaked the v2.3.0 release CI (`go test ./... -race`, the `Test before release` step); it is not reproducible locally.

## Fix

Add a `deferJobDone` helper that registers a `t.Cleanup` blocking until the supervisor's `exit_code` sentinel is present. `WriteFakeSupervisor` emits `exit_code` as its last write to the job dir (the optional cache payload goes to a separate path), so waiting for it guarantees the supervisor has no pending job-dir writes. Registering a cleanup rather than calling it at the end of the body means it still runs, before the StateDir teardown (`t.Cleanup` is LIFO), when an assertion fails early via `t.Fatalf` and skips the rest of the body, so a real failure is not masked by a spurious `RemoveAll` error.

Applied to the three exposed tests (`TestStartJobWiresConversationID`, `TestStartJobNormalizesCwd`, `TestStartJobReducesModelRowToID`); `TestStartJobPersistsMetaAndSpawns`'s existing inline wait is folded onto the same helper.

## Scope

The exposed set is exactly a fake supervisor that writes into the job dir and completes on its own, with the test returning before it finishes. Not exposed and left unchanged: tests that expect `StartJob` to fail (no supervisor spawned), that kill a sleeping supervisor via `killJob`, that use a non-writing supervisor such as `sleep`, or that already await terminal state (`WaitTerminal`, `waitForEmptyStore`, an inline `exit_code` wait). A targeted per-test wait is used rather than a shared `newManager` cleanup, which would hang awaiting an `exit_code` the SIGKILLed supervisors in the `killJob` tests never write.

## Test plan

- [x] The four tests pass 30x under `-race`.
- [x] The full `manager` package passes under `-race`.
- [x] `go test ./...` is green.
- [x] `gofmt`, `go vet`, `golangci-lint`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved job-start test cleanup to reliably wait for simulated supervisors to finish.
  * Added safeguards to prevent temporary test data from being removed before job exit results are recorded.
  * Standardized completion handling across self-completing supervisor tests with a timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->