### PR TITLE
feat(status): recovery hint for empty-result terminations (#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Or add to your MCP client config:
 ## Tools
 
 - `agy_run(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?)` -> `{ job_id, conversation_id?, state }`
-- `agy_run_sync(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, model?, partial?, num_turns?, usage?, step_type?, note? }`
-- `agy_status(job_id)` -> `{ state, elapsed, result?, error?, conversation_id?, model?, partial?, num_turns?, usage?, step_type? }`
-- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, conversation_id?, model?, partial?, num_turns?, usage?, step_type?, note? }`
+- `agy_run_sync(prompt, model?, effort?, mode?, agent?, sandbox?, dirs?, conversation_id?, continue_latest?, cwd?, timeout?, json_schema?, wait?)` -> `{ job_id, state, elapsed, result?, error?, recovery?, conversation_id?, model?, partial?, num_turns?, usage?, step_type?, note? }`
+- `agy_status(job_id)` -> `{ state, elapsed, result?, error?, recovery?, conversation_id?, model?, partial?, num_turns?, usage?, step_type? }`
+- `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, recovery?, conversation_id?, model?, partial?, num_turns?, usage?, step_type?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
 - `list_models()` -> `{ models, model_details }`
 - `list_sessions(dir?)` -> `{ sessions }`
@@ -121,7 +121,7 @@ Or add to your MCP client config:
 
 `model` echoes the model id agy-mcp resolved for the run (the one you passed, or `AGY_MCP_DEFAULT_MODEL`, reduced to its id), so a caller can confirm which model actually ran. It is absent when no model was pinned and `agy` ran on its own default.
 
-A run that ends badly still hands back whatever it managed to say, so `result` is set on `failed` and `cancelled` jobs too and is worth reading rather than discarding. `partial` is what says whether to trust it as the final answer, and it follows from where the text came from rather than from the state.
+A run that ends badly still hands back whatever it managed to say, so `result` is set on `failed` and `cancelled` jobs too and is worth reading rather than discarding. `partial` is what says whether to trust it as the final answer, and it follows from where the text came from rather than from the state. When such a run produced no text at all but still named a conversation, `recovery` carries a short note on continuing that conversation instead of restating the task.
 
 It is true when the text was reconstructed from the streamed events, which happens when agy never reported a terminal result (a clean exit whose final event never arrived, a cancel, a timeout, a supervisor that died mid-stream) and also when agy did report one whose response was empty, so the stream is the only text there is. It is likewise true when agy reported a terminal result that was not a success, in which case the text is only what the run had produced by the time it stopped. A response agy itself marked successful is never `partial`, even on a job that was then cancelled or killed: agy prints its result and can hang on the way out, so the answer was already complete when the job was terminated. Note the distinction that last sentence turns on, since a `done` job can still report `partial`: it is a claim about agy's own response, not about every result reported for a run agy marked successful.
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -29,7 +29,7 @@ type runInput struct {
 	ConversationID string   `json:"conversation_id,omitempty" jsonschema:"continue this specific conversation instead of starting fresh, so earlier context need not be restated; take it from a previous run's conversation_id or from list_sessions. Mutually exclusive with continue_latest"`
 	ContinueLatest bool     `json:"continue_latest,omitempty" jsonschema:"continue the most recent conversation for cwd instead of starting fresh. Mutually exclusive with conversation_id: setting this true together with a conversation_id is an error, though leaving it false alongside one is fine"`
 	Cwd            string   `json:"cwd,omitempty" jsonschema:"absolute path of the directory the agent runs in and may edit files under; also scopes continue_latest. Fresh runs sharing a cwd run concurrently. A relative path is resolved against the server's working directory, which is not necessarily yours, so pass an absolute one. Symlinks are resolved. Defaults to the server's own working directory"`
-	Timeout        string   `json:"timeout,omitempty" jsonschema:"max wall-clock duration for the whole run (Go duration, e.g. 20m); a value over 24h is rejected. On expiry the agy process tree is killed and the job ends in state failed. Omit to use the server's default"`
+	Timeout        string   `json:"timeout,omitempty" jsonschema:"max wall-clock duration for the whole run (Go duration, e.g. 20m); a value over 24h is rejected. On expiry the agy process tree is killed mid-run and the job ends in state failed. The kill is hard: any answer already streamed is offered back as a partial result, but work still in the model's reasoning or a tool call has produced no recoverable text yet, so a run killed before it streams its answer recovers nothing. To carry on, start a fresh agy_run with this run's conversation_id so the thread continues without restating the task; the killed turn's own reasoning is not recoverable. Omit to use the server's default"`
 	JSONSchema     string   `json:"json_schema,omitempty" jsonschema:"optional JSON Schema to enforce on the run's structured result: pass either an inline schema string or a path to a schema file, and agy constrains the final result to it (in stream-json mode the schema applies to the terminal result event). Omit for an unconstrained free-text result. Useful when the result is consumed programmatically, e.g. extraction, classification, or structured summaries"`
 }
 
@@ -178,10 +178,16 @@ type statusInput struct {
 }
 
 type statusOutput struct {
-	State          string `json:"state" jsonschema:"running, done, failed or cancelled"`
-	Elapsed        string `json:"elapsed" jsonschema:"wall-clock time the job has run, frozen at completion once terminal"`
-	Result         string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set on any terminal state whose text could be recovered, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first. A running job carries none even once it has produced text, so collect the result once the state is terminal"`
-	Error          string `json:"error,omitempty" jsonschema:"why the job failed; present only when state is failed"`
+	State   string `json:"state" jsonschema:"running, done, failed or cancelled"`
+	Elapsed string `json:"elapsed" jsonschema:"wall-clock time the job has run, frozen at completion once terminal"`
+	Result  string `json:"result,omitempty" jsonschema:"the delegated agent's output. Set on any terminal state whose text could be recovered, so a failed or cancelled job can carry one too; read it in those states rather than discarding it, but check partial first. A running job carries none even once it has produced text, so collect the result once the state is terminal"`
+	Error   string `json:"error,omitempty" jsonschema:"why the job failed; present only when state is failed"`
+	// Recovery is tool-facing advice, not a property of the job: it is present
+	// only when a run ended terminally with no text to offer but a conversation
+	// worth continuing (for example a timeout, a cancel, a crash, or an agy error
+	// before any answer was streamed), which otherwise reads as a bare empty
+	// failure (issue #151).
+	Recovery       string `json:"recovery,omitempty" jsonschema:"how to recover a run that ended with no result: present only on a terminal failed or cancelled job that produced no text but has a conversation_id. Start a fresh agy_run with that conversation_id to continue the thread without restating the task; the killed turn's own reasoning is not recoverable. Absent whenever any result, even a partial one, was recovered"`
 	ConversationID string `json:"conversation_id,omitempty" jsonschema:"conversation this run belongs to; pass it back as conversation_id to continue the thread. Empty until agy names a fresh run's conversation, which takes about a second, so agy_status, agy_wait and agy_run_sync all report none when asked inside that window; ask again once the run is under way"`
 	// Model echoes the resolved model so a caller can see which one actually ran;
 	// see manager.Status.Model.
@@ -232,6 +238,15 @@ func toStatusOutput(st manager.Status) statusOutput {
 			CacheReadTokens: u.CacheReadTokens,
 			TotalTokens:     u.TotalTokens,
 		}
+	}
+	// A run that ended terminally with no text but a known conversation is the
+	// issue #151 case: a bare empty failure the caller can still act on. Offer the
+	// continuation as recovery advice. A run that produced any text (even a
+	// partial one) needs none, since its output is already in Result.
+	if out.Result == "" && out.ConversationID != "" &&
+		(out.State == manager.StateFailed || out.State == manager.StateCancelled) {
+		out.Recovery = "no result text was recovered. " +
+			"Start a fresh agy_run with this conversation_id to continue the thread without restating the task."
 	}
 	return out
 }

--- a/internal/mcptools/tools_test.go
+++ b/internal/mcptools/tools_test.go
@@ -290,3 +290,43 @@ func TestStatusOutputModelEchoAndOmitempty(t *testing.T) {
 		t.Errorf("an empty model must be omitted from the wire, got: %s", b2)
 	}
 }
+
+// TestStatusOutputRecoveryHint: toStatusOutput sets the recovery hint only when a
+// run ended terminally with no text to offer but a conversation worth continuing,
+// the timeout/cancel-before-any-output case from issue #151. A run that produced
+// text (even a partial one), has no conversation_id, is still running, or finished
+// successfully gets no hint, and the omitempty key is absent from the wire then.
+func TestStatusOutputRecoveryHint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		st       manager.Status
+		wantHint bool
+	}{
+		{"timeout kill, no text, has conversation", manager.Status{State: manager.StateFailed, ConversationID: "c1"}, true},
+		{"cancel before any output", manager.Status{State: manager.StateCancelled, ConversationID: "c1"}, true},
+		{"failed but no conversation to continue", manager.Status{State: manager.StateFailed}, false},
+		{"failed with a partial result already offered", manager.Status{State: manager.StateFailed, ConversationID: "c1", Result: "as far as I got", Partial: true}, false},
+		{"done and successful needs no recovery", manager.Status{State: manager.StateDone, ConversationID: "c1"}, false},
+		{"running is not terminal", manager.Status{State: manager.StateRunning, ConversationID: "c1"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := toStatusOutput(tt.st)
+			if (got.Recovery != "") != tt.wantHint {
+				t.Errorf("Recovery = %q, want hint present = %v", got.Recovery, tt.wantHint)
+			}
+			if tt.wantHint && !strings.Contains(got.Recovery, "conversation_id") {
+				t.Errorf("a recovery hint must tell the caller to reuse conversation_id, got %q", got.Recovery)
+			}
+			b, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(b), `"recovery"`) != tt.wantHint {
+				t.Errorf("recovery key on wire = %v, want %v: %s", strings.Contains(string(b), `"recovery"`), tt.wantHint, b)
+			}
+		})
+	}
+}

--- a/internal/supervisor/stream.go
+++ b/internal/supervisor/stream.go
@@ -36,6 +36,11 @@ type streamOutcome struct {
 //     while the job is still running.
 //   - out, which accumulates the assistant's text. It is the fallback the
 //     manager reports as a partial result when no terminal event ever arrives.
+//     Only agent_response deltas contribute: agy's stream carries no thinking
+//     text (only a usage.thinking_tokens counter) and a tool step carries no
+//     response text, so a run killed while still reasoning or mid-tool, before
+//     it streams any answer, leaves out empty by design, not by defect
+//     (MEASURED against agy 1.1.15).
 //
 // The terminal result is returned rather than written here, so the caller can
 // order it against the exit-code sentinel.
@@ -70,12 +75,20 @@ func consumeStream(jobDir string, r io.Reader, out io.Writer) streamOutcome {
 					changed = true
 				}
 				// Append every delta rather than tracking which steps have already
-				// contributed. The field is a delta by name and agy emits it once per
-				// completed step, so appending reproduces the response; a run with
-				// several agent_response steps accumulates all of them, which is more
-				// context than the terminal result carries. The manager reads it when
-				// no terminal result reached disk, and also when one did but carried
+				// contributed. agy streams one agent_response step as many text_delta
+				// events (the ACTIVE states carry successive chunks, the DONE state the
+				// final tail), so appending every one in arrival order reproduces the
+				// response: for a single-response run, concatenating its agent_response
+				// deltas matched its terminal result byte-for-byte (MEASURED against agy
+				// 1.1.15). A run
+				// with several agent_response steps accumulates all of them, which is
+				// more context than the terminal result carries. The manager reads it
+				// when no terminal result reached disk, and also when one did but carried
 				// no response of its own, since then this is the only text there is.
+				//
+				// Do NOT dedup by step_index to "skip repeats": the deltas are not
+				// repeats and agy does not emit one per step, so a step-indexed filter
+				// would drop every ACTIVE chunk and keep only the final tail.
 				if su.StepType == streamjson.StepTypeAgentResponse && su.TextDelta != "" {
 					// A failed append costs partial-result fidelity, nothing more: the
 					// terminal result event is the authoritative response and is written


### PR DESCRIPTION
## Summary

Fixes #151. When a run was killed before it streamed any answer (a timeout, cancel, or crash while the model was still reasoning or mid-tool), agy-mcp reported `state: failed` with an empty `result` and no guidance, so the caller had nothing to act on.

Measuring agy 1.1.15's stream-json clarified what is and is not recoverable: agy streams an `agent_response` step as many `text_delta` events (ACTIVE chunks plus a DONE tail), and agy-mcp already appends every one, so partial *answer* text was already captured and recovered correctly. But the stream carries no thinking text (only a `usage.thinking_tokens` counter), so the reasoning of a killed turn is genuinely unrecoverable. A run killed before the response phase therefore recovers empty by design, not by defect.

Rather than try to recover text that does not exist, this adds an actionable `recovery` field to the status output. It is set only when a run ended terminally (failed or cancelled) with no recovered text but a known conversation, advising the caller to continue that conversation with a fresh `agy_run` instead of restating the task. It routes through the single `toStatusOutput` converter, so `agy_status`, `agy_run_sync` and `agy_wait` all carry it uniformly; it is additive (`json:",omitempty"`) and never set when any result, even a partial one, was recovered.

The change also corrects the `consumeStream` doc comments (the old "agy emits it once per completed step" was measured-false and invited a step-index dedup that would drop most of a response), sharpens the `timeout` tool-arg description to explain the hard mid-run kill and the `conversation_id` continuation, and documents the new field in the README tool signatures.

## Related issues

- Fixes #151
- Follow-up filed: #152 (a pre-existing test gap: the `fakeagy` double emits a single DONE delta, so no test exercises multi-chunk ACTIVE-delta accumulation)

## Test plan

- [x] `TestStatusOutputRecoveryHint` added, sabotage-verified (each of the three guards is pinned by a distinct table row; deleting any one turns the expected row red)
- [x] `go build ./...`, `go vet` on darwin, `GOOS=windows` and `GOOS=linux GOARCH=amd64`
- [x] `go test ./...` (full suite, no cache)
- [x] `gofmt` clean
- [x] Pre-push gate run (parallel review agents + Gemini cross-check); all findings were Low/doc-accuracy and are folded in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery guidance for failed or cancelled runs when no output is available but the conversation can be resumed.
  * Clarified timeout behavior, including process termination and recovery of partial results or conversations.

* **Documentation**
  * Updated tool documentation to describe the new recovery information and stream output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->