### PR TITLE
chore: bump to Go 1.27 + golangci-lint 2.13.1, add Go 1.27 ruleguard matchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   # Pinned to match the local toolchain so local runs and CI use the same
   # linter version (and the same ruleguard behavior).
-  GOLANGCI_LINT_VERSION: 'v2.12.2'
+  GOLANGCI_LINT_VERSION: 'v2.13.1'
 jobs:
   build:
     name: Build and test

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Two transports run the same core:
   The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.15 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
 
   A missing `agy` does not stop the server from starting. `initialize`, `tools/list`, and `list_sessions` never exec it, so the lookup is deferred: the server starts, logs a warning to stderr, serves discovery normally, and the tools that do need the binary (`agy_run`, `agy_run_sync`, `list_models`) fail per call with `agy not found on PATH; set AGY_MCP_AGY_PATH`. An `agy` installed later is picked up without restarting the server. An explicit `AGY_MCP_AGY_PATH` is treated differently: it is a claim about one specific binary, so a typo or a non-executable target still fails fast at startup.
-- Go 1.26+ to build.
+- Go 1.27+ to build.
 - The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) is implemented on **Linux** and **macOS** (process groups, SIGTERM cancel, an advisory flock) and on **Windows** (Job Objects, `OpenProcess` + process creation time, `LockFileEx`); stdio/HTTP serving, `list_models`, and `list_sessions` work identically everywhere.
 
   Windows behaves the same as Linux with two documented differences:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/tphakala/agy-mcp/v2
 
-go 1.26
-
-toolchain go1.26.5
+go 1.27.0
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0

--- a/rules/doc.go
+++ b/rules/doc.go
@@ -147,4 +147,48 @@
 // a raw net.Dial/net.Listen/http.Server.Addr address), verified empirically.
 // nosprintfhostport is enabled anyway as complementary coverage for the
 // URL-embedded case, which JoinHostPort deliberately does not flag.
+//
+// # Go 1.27 modernizers (harvested 2026-08-25, MEASURED against golangci-lint
+// 2.13.1 on go 1.27.0)
+//
+// Go 1.27 added stdlib APIs and new go fix modernizers. Each candidate matcher
+// was probed against this config's ENABLED stock analyzers (modernize,
+// staticcheck) before adding, per the overlap policy above: a probe file
+// planting every old pattern was run through golangci-lint, and a matcher was
+// added only where no stock analyzer fired.
+//
+// Added (the probe reported zero modernize/staticcheck findings on each pattern,
+// so this is unique coverage):
+//
+//   - random.go's RandMethodN: the generic Rand.N method (generic methods being
+//     the Go 1.27 language feature); no modernizer suggests it.
+//   - net.go's ResponseBodyDrain: Go 1.27's HTTP/1 auto-drain on Close makes an
+//     explicit io.Copy(io.Discard, Body) redundant; no analyzer flags it
+//     (errcheck fires only on an unchecked copy/close, a different concern).
+//   - net.go's URLValuesClone: url.Values.Clone deep-copies where maps.Clone
+//     shares the []string values; no analyzer flags the maps.Clone form.
+//   - strings.go's CutLast: strings.CutLast/bytes.CutLast replace LastIndex
+//     slicing; no analyzer suggests it.
+//   - testing.go's SynctestSleep: synctest.Sleep folds time.Sleep+synctest.Wait.
+//   - testing.go's HttptestNewTestServer: httptest.NewTestServer for a synctest
+//     bubble; no analyzer is synctest-context aware.
+//   - uuid.go's StdlibUUID: the new stdlib uuid package. Advisory and currently
+//     INERT here (agy-mcp does not import github.com/google/uuid); kept for the
+//     shared cross-project standard and to fire if that dependency is ever added.
+//
+// Declined (a stock analyzer this config already enables covers the pattern, so
+// a matcher would only lose the uniq-by-line lottery, the exact drop rule above).
+// Each was verified firing on the same probe:
+//
+//   - AtomicTypes (typed sync/atomic wrappers): modernize's atomictypes analyzer
+//     (new in Go 1.27's go fix) already fires, with autofix.
+//   - EmbeddedFieldLiteral (promoted-field struct-literal keys): modernize's
+//     embedlit analyzer (new in Go 1.27's go fix) already fires, with autofix.
+//   - tls.Config.Rand (deprecated in Go 1.27): staticcheck SA1019 already fires,
+//     and its own message names testing/cryptotest.SetGlobalRandom, so a
+//     richer-message matcher would add nothing.
+//   - runtime.SetFinalizer -> AddCleanup: this package's own PreferAddCleanup
+//     (runtime.go) already covers it; not a Go 1.27 change.
+//   - sort.Ints/Strings/Float64s -> slices.Sort: this package's own SortToSlices
+//     (slices.go) already covers it; not a Go 1.27 change.
 package gorules

--- a/rules/net.go
+++ b/rules/net.go
@@ -205,3 +205,65 @@ func ErrorBeforeUse(m dsl.Matcher) {
 	).
 		Report("potential nil pointer: $f may be nil if $err != nil; check error before using $f.$method()")
 }
+
+// ResponseBodyDrain detects an explicit drain of an HTTP response body before
+// Close, which Go 1.27 does automatically for HTTP/1 connections.
+//
+// Old pattern:
+//
+//	io.Copy(io.Discard, resp.Body)
+//	resp.Body.Close()
+//
+// Since Go 1.27, closing an HTTP/1 Response.Body drains any unread content up to
+// a conservative limit, so that the connection can be reused. The explicit copy
+// is redundant for small bodies. It still matters for bodies larger than that
+// limit, where the automatic drain gives up and the connection is dropped, so
+// this is advisory: keep the copy only when a large unread body is expected and
+// connection reuse is worth reading it. Only a copy immediately followed by
+// Close is matched, and not when the rest of the block reads resp.Trailer:
+// trailers are populated only once the body reaches EOF, which the bounded
+// automatic drain does not guarantee. A drain that reads to EOF for another
+// reason (surfacing a read error, a non-transport body) is also left alone.
+//
+// See: https://go.dev/doc/go1.27#nethttp
+func ResponseBodyDrain(m dsl.Matcher) {
+	m.Match(
+		`io.Copy(io.Discard, $resp.Body); $resp.Body.Close(); $*rest`,
+		`io.Copy(io.Discard, $resp.Body); _ = $resp.Body.Close(); $*rest`,
+		`_, _ = io.Copy(io.Discard, $resp.Body); $resp.Body.Close(); $*rest`,
+		`_, _ = io.Copy(io.Discard, $resp.Body); _ = $resp.Body.Close(); $*rest`,
+	).
+		Where(m["resp"].Type.Is("*http.Response") && !m["rest"].Contains(`$resp.Trailer`)).
+		Report("Go 1.27's HTTP/1 transport drains an unread response body on Close (up to a conservative limit); the io.Copy(io.Discard, $resp.Body) before Close is redundant unless a large unread body is expected or $resp.Trailer is read")
+}
+
+// URLValuesClone detects maps.Clone on url.Values and suggests the Values.Clone
+// method added in Go 1.27.
+//
+// Old pattern:
+//
+//	v2 := maps.Clone(v)    // shares each []string value
+//
+// New pattern (Go 1.27+):
+//
+//	v2 := v.Clone()
+//
+// maps.Clone copies the map but keeps the same backing array for every value
+// slice, so Values.Add on the copy appends into storage the original still
+// references (Values.Set replaces the entry and is unaffected). Values.Clone is
+// a deep copy. Reported without an auto-fix because a caller may rely on the
+// shallow copy.
+//
+// url.URL also gained a Clone method, but a plain *u copy is not flagged: the
+// only pointer field it shares is User, and url.Userinfo is documented as
+// immutable, so the struct copy is already safe.
+//
+// See: https://pkg.go.dev/net/url#Values.Clone
+// See: https://pkg.go.dev/net/url#URL.Clone
+func URLValuesClone(m dsl.Matcher) {
+	m.Match(
+		`maps.Clone($v)`,
+	).
+		Where(m["v"].Type.Is("url.Values")).
+		Report("use $v.Clone() instead of maps.Clone($v): maps.Clone shares the []string values, Values.Clone is a deep copy (Go 1.27+)")
+}

--- a/rules/net.go
+++ b/rules/net.go
@@ -234,7 +234,7 @@ func ResponseBodyDrain(m dsl.Matcher) {
 		`_, _ = io.Copy(io.Discard, $resp.Body); _ = $resp.Body.Close(); $*rest`,
 	).
 		Where(m["resp"].Type.Is("*http.Response") && !m["rest"].Contains(`$resp.Trailer`)).
-		Report("Go 1.27's HTTP/1 transport drains an unread response body on Close (up to a conservative limit); the io.Copy(io.Discard, $resp.Body) before Close is redundant unless a large unread body is expected or $resp.Trailer is read")
+		Report("Go 1.27's standard HTTP/1 Transport drains an unread response body on Close (up to a conservative limit); for a Transport-issued response the io.Copy(io.Discard, $resp.Body) before Close is redundant, unless a large unread body is expected or $resp.Trailer is read. A custom http.RoundTripper's body may not auto-drain, so keep the copy there")
 }
 
 // URLValuesClone detects maps.Clone on url.Values and suggests the Values.Clone

--- a/rules/random.go
+++ b/rules/random.go
@@ -72,3 +72,50 @@ func RandV2Migration(m dsl.Matcher) {
 	).
 		Report("rand.Seed is deprecated (Go 1.20+); global rand is auto-seeded; use rand.New(rand.NewSource($seed)) for reproducibility")
 }
+
+// RandMethodN detects a typed wrapper around a *rand.Rand bounded-integer method
+// and suggests the generic Rand.N method, which Go 1.27's generic methods made
+// possible.
+//
+// Old pattern (math/rand/v2, custom source):
+//
+//	r := rand.New(rand.NewPCG(1, 2))
+//	jitter := time.Duration(r.Int64N(int64(maxJitter)))
+//	idx := myIndex(r.IntN(int(n)))
+//
+// New pattern (Go 1.27+):
+//
+//	jitter := r.N(maxJitter)
+//	idx := r.N(n)
+//
+// Rand.N mirrors the top-level rand.N function: the type parameter is inferred
+// from the argument, so the two conversions disappear. The rule fires only when
+// the outer call is a conversion to the argument's own type, so r.N($n) yields
+// exactly the type the old expression produced. Ordinary function calls
+// wrapping IntN, and conversions to some other type, are left alone. There is
+// no auto-fix on purpose: int64(r.Int32N(int32(n))) with an int64 n matches,
+// and r.N(n) would use the untruncated bound. It does not fire on the global functions (rand.Int64N)
+// because rand.N has covered those since Go 1.22.
+//
+// m.Import is required: ruleguard resolves the package name in a type pattern
+// through its standard library table, where "rand" means math/rand, so without
+// it "*rand.Rand" never matches the v2 type. MEASURED against golangci-lint
+// 2.13.1 (ruleguard 0.4.5) on 2026-08-25: with the import the rule fires on
+// every planted site; a full import path in the type string, as in
+// "*math/rand/v2.Rand", is not a fix, it silently disables every rule in rules/.
+//
+// See: https://pkg.go.dev/math/rand/v2#Rand.N
+func RandMethodN(m dsl.Matcher) {
+	m.Import("math/rand/v2")
+
+	m.Match(
+		`$T($r.Int64N(int64($n)))`,
+		`$T($r.Int32N(int32($n)))`,
+		`$T($r.IntN(int($n)))`,
+		`$T($r.Uint64N(uint64($n)))`,
+		`$T($r.Uint32N(uint32($n)))`,
+		`$T($r.UintN(uint($n)))`,
+	).
+		Where(m["r"].Type.Is("*rand.Rand") && m["T"].Type.IdenticalTo(m["n"])).
+		Report("use $r.N($n) instead of converting through a fixed-width bounded method; Rand.N infers the integer type from $n (Go 1.27+); not a drop-in if the inner conversion truncated $n")
+}

--- a/rules/runtime.go
+++ b/rules/runtime.go
@@ -6,7 +6,8 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 
 // PreferAddCleanup detects runtime.SetFinalizer and suggests runtime.AddCleanup.
 //
-// runtime.SetFinalizer is NOT deprecated (no Deprecated: tag as of Go 1.26), so
+// runtime.SetFinalizer is NOT deprecated (no Deprecated: tag as of Go 1.27,
+// verified: staticcheck SA1019 does not flag it, unlike tls.Config.Rand), so
 // this is an advisory preference, not a deprecation warning. AddCleanup (Go 1.24)
 // is the recommended API for new code.
 //

--- a/rules/strings.go
+++ b/rules/strings.go
@@ -87,3 +87,93 @@ func FieldsFuncIteration(m dsl.Matcher) {
 	).
 		Report("use for $field := range bytes.FieldsFuncSeq($s, $f) to avoid intermediate slice allocation (Go 1.24+)")
 }
+
+// CutLast detects strings.LastIndex / bytes.LastIndex followed by manual
+// slicing or an index check, and suggests strings.CutLast / bytes.CutLast.
+//
+// Old patterns:
+//
+//	dir := path[:strings.LastIndex(path, "/")]
+//	base := path[strings.LastIndex(path, "/")+1:]
+//	if i := strings.LastIndex(s, sep); i >= 0 {
+//	    before, after := s[:i], s[i+len(sep):]
+//	}
+//
+// New pattern (Go 1.27+):
+//
+//	before, after, found := strings.CutLast(s, sep)
+//
+// CutLast returns (s, "", false) when sep is absent (bytes.CutLast returns
+// (s, nil, false)). The slicing idioms behave differently in that case, so each
+// Report says to check the found result: s[:LastIndex] panics on -1;
+// s[LastIndex+1:] yields the whole string; s[LastIndex+len(sep):] yields the
+// whole string only for a one-byte separator and drops part of it otherwise.
+//
+// The +1 slicing form fires only for a one-BYTE ASCII literal separator (a
+// single unescaped ASCII char, or a short escape such as "\n"), because +1 skips
+// exactly one byte and only then equals CutLast. The separator regex is
+// restricted to the ASCII range 0x00-0x7f on purpose: a multi-byte rune literal
+// like "ä" would skip into the middle of the rune, which CutLast never
+// does, so it is deliberately not matched. The index-check forms fire only when
+// the guarded code slices s at the index (s[:i], s[i:], s[i+n:]); an index used
+// for anything else is not a CutLast candidate.
+//
+// See: https://pkg.go.dev/strings#CutLast
+// See: https://pkg.go.dev/bytes#CutLast
+func CutLast(m dsl.Matcher) {
+	// Before-slice up to the separator: on a missing separator LastIndex is -1
+	// and s[:-1] panics, so this is not equivalent to CutLast; check found.
+	m.Match(
+		`$s[:strings.LastIndex($s, $sep)]`,
+	).
+		Report("use before, _, found := strings.CutLast($s, $sep) instead of slicing before strings.LastIndex (Go 1.27+); when $sep is absent this slice panics (index -1) whereas CutLast returns (s, \"\", false), so check found")
+
+	// After-slice from just past the separator.
+	m.Match(
+		`$s[strings.LastIndex($s, $sep)+len($sep):]`,
+	).
+		Report("use _, after, found := strings.CutLast($s, $sep) instead of slicing after strings.LastIndex (Go 1.27+); the not-found case differs (LastIndex is -1 when $sep is absent), so check found")
+
+	m.Match(
+		`$s[:bytes.LastIndex($s, $sep)]`,
+	).
+		Report("use before, _, found := bytes.CutLast($s, $sep) instead of slicing before bytes.LastIndex (Go 1.27+); when $sep is absent this slice panics (index -1) whereas bytes.CutLast returns (s, nil, false), so check found")
+
+	m.Match(
+		`$s[bytes.LastIndex($s, $sep)+len($sep):]`,
+	).
+		Report("use _, after, found := bytes.CutLast($s, $sep) instead of slicing after bytes.LastIndex (Go 1.27+); the not-found case differs (LastIndex is -1 when $sep is absent), so check found")
+
+	// The +1 form skips exactly one byte, so it is a CutLast candidate only when
+	// the separator is a one-character literal; with "::" it would keep a ":".
+	m.Match(
+		`$s[strings.LastIndex($s, $sep)+1:]`,
+	).
+		Where(m["sep"].Text.Matches(`^"(\\.|[\x00-\x21\x23-\x5b\x5d-\x7f])"$`)).
+		Report("use before, after, found := strings.CutLast($s, $sep) instead of slicing around strings.LastIndex (Go 1.27+); when $sep is absent the slicing idiom yields all of $s but CutLast yields after == \"\", so check found")
+
+	m.Match(
+		`$s[bytes.LastIndex($s, $sep)+1:]`,
+	).
+		Where(m["sep"].Text.Matches(`^\[\]byte\("(\\.|[\x00-\x21\x23-\x5b\x5d-\x7f])"\)$`) || m["sep"].Text.Matches(`^\[\]byte\{'(\\.|[\x00-\x26\x28-\x5b\x5d-\x7f])'\}$`)).
+		Report("use before, after, found := bytes.CutLast($s, $sep) instead of slicing around bytes.LastIndex (Go 1.27+); when $sep is absent the slicing idiom yields all of $s but CutLast yields after == nil, so check found")
+
+	// Index check followed by manual slicing in the body.
+	m.Match(
+		`if $i := strings.LastIndex($s, $sep); $i >= 0 { $*body }`,
+		`if $i := strings.LastIndex($s, $sep); $i != -1 { $*body }`,
+		`$i := strings.LastIndex($s, $sep); if $i < 0 { $*_ }; $*body`,
+		`$i := strings.LastIndex($s, $sep); if $i == -1 { $*_ }; $*body`,
+	).
+		Where(m["body"].Contains(`$s[:$i]`) || m["body"].Contains(`$s[$i:]`) || m["body"].Contains(`$s[$i+$_:]`)).
+		Report("use before, after, found := strings.CutLast($s, $sep) instead of checking strings.LastIndex and slicing by hand (Go 1.27+)")
+
+	m.Match(
+		`if $i := bytes.LastIndex($s, $sep); $i >= 0 { $*body }`,
+		`if $i := bytes.LastIndex($s, $sep); $i != -1 { $*body }`,
+		`$i := bytes.LastIndex($s, $sep); if $i < 0 { $*_ }; $*body`,
+		`$i := bytes.LastIndex($s, $sep); if $i == -1 { $*_ }; $*body`,
+	).
+		Where(m["body"].Contains(`$s[:$i]`) || m["body"].Contains(`$s[$i:]`) || m["body"].Contains(`$s[$i+$_:]`)).
+		Report("use before, after, found := bytes.CutLast($s, $sep) instead of checking bytes.LastIndex and slicing by hand (Go 1.27+)")
+}

--- a/rules/testing.go
+++ b/rules/testing.go
@@ -156,5 +156,5 @@ func HttptestNewTestServer(m dsl.Matcher) {
 		`synctest.Test($_, func($*_) { $*body })`,
 	).
 		Where(m["body"].Contains(`httptest.NewServer($_)`)).
-		Report("this synctest bubble starts an httptest.NewServer on a real listener; use httptest.NewTestServer(t, handler), which serves over an in-memory network that stays inside the bubble, reachable only through srv.Client() (Go 1.27+)")
+		Report("this synctest bubble starts an httptest.NewServer on a real listener; pass the enclosing test's *testing.T to httptest.NewTestServer (with the handler) instead, which serves over an in-memory network that stays inside the bubble, reachable only through srv.Client() (Go 1.27+)")
 }

--- a/rules/testing.go
+++ b/rules/testing.go
@@ -94,3 +94,67 @@ func TestingArtifactDir(m dsl.Matcher) {
 		Where(m.File().Name.Matches(`_test\.go$`)).
 		Report("in tests, consider t.ArtifactDir() for test output files instead of os.MkdirTemp (Go 1.26+); use t.TempDir() for scratch space that should be cleaned up")
 }
+
+// SynctestSleep detects time.Sleep immediately followed by synctest.Wait and
+// suggests the synctest.Sleep helper added in Go 1.27.
+//
+// Old pattern:
+//
+//	time.Sleep(d)
+//	synctest.Wait()
+//
+// New pattern (Go 1.27+):
+//
+//	synctest.Sleep(d)
+//
+// synctest.Sleep is documented as exactly equivalent to the two-call sequence:
+// it advances the bubble's fake clock by d and then waits for every other
+// goroutine in the bubble to be durably blocked, so the system under test has
+// settled before the test continues.
+//
+// Report-only, no autofix. Rewriting to synctest.Sleep($d) drops the only
+// time.Sleep call, so when $d does not itself reference time and the file has no
+// other time.* use, --fix would orphan the "time" import and fail to compile
+// (ruleguard does not prune imports). This matcher advises the swap rather than
+// performing it.
+//
+// See: https://pkg.go.dev/testing/synctest#Sleep
+func SynctestSleep(m dsl.Matcher) {
+	m.Match(
+		`time.Sleep($d); synctest.Wait()`,
+	).
+		Report("use synctest.Sleep($d) instead of time.Sleep($d) followed by synctest.Wait() (Go 1.27+)")
+}
+
+// HttptestNewTestServer detects httptest.NewServer started inside a synctest
+// bubble and suggests httptest.NewTestServer, added in Go 1.27.
+//
+// Old pattern:
+//
+//	srv := httptest.NewServer(handler)
+//	defer srv.Close()
+//
+// New pattern (Go 1.27+):
+//
+//	srv := httptest.NewTestServer(t, handler)
+//
+// NewTestServer takes a testing.TB and serves over an in-memory network by
+// default, which is what a synctest bubble needs: a real loopback listener has
+// goroutines outside the bubble, so the bubble never reaches a durably blocked
+// state. The httptest.Server docs now say most tests should use NewTestServer,
+// but the in-memory network only serves requests sent through srv.Client(), so
+// this rule fires only on a synctest.Test call whose closure body starts an
+// httptest.NewServer, where the real network is an actual problem rather than
+// a style choice; a NewServer elsewhere in the same file is left alone, and a
+// NewServer started by a helper the closure calls is not seen. NewTLSServer is
+// not matched: NewTestServer's URL is plain http://example.com, so a TLS test
+// needs its own HTTPS URL and is not a mechanical swap.
+//
+// See: https://pkg.go.dev/net/http/httptest#NewTestServer
+func HttptestNewTestServer(m dsl.Matcher) {
+	m.Match(
+		`synctest.Test($_, func($*_) { $*body })`,
+	).
+		Where(m["body"].Contains(`httptest.NewServer($_)`)).
+		Report("this synctest bubble starts an httptest.NewServer on a real listener; use httptest.NewTestServer(t, handler), which serves over an in-memory network that stays inside the bubble, reachable only through srv.Client() (Go 1.27+)")
+}

--- a/rules/uuid.go
+++ b/rules/uuid.go
@@ -1,0 +1,44 @@
+//go:build ruleguard
+
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// StdlibUUID detects the github.com/google/uuid API and suggests the standard
+// library uuid package added in Go 1.27.
+//
+// Old pattern:
+//
+//	import "github.com/google/uuid"
+//	id := uuid.New()
+//	s := uuid.NewString()
+//	parsed, err := uuid.Parse(s)
+//
+// New pattern (Go 1.27+):
+//
+//	import "uuid"
+//	id := uuid.New()
+//	s := uuid.New().String()
+//	parsed, err := uuid.Parse(s)
+//
+// The standard package implements RFC 9562, draws random bytes from crypto/rand,
+// and covers the common surface: New (v4), NewV4, NewV7, Parse, MustParse, Nil,
+// Max, plus String and the encoding.TextMarshaler pair on UUID. Dropping the
+// dependency is only worth it when nothing else in the module needs the extra
+// google/uuid API (v1, v5, SQL scanning, ClockSequence), so this is advisory.
+//
+// See: https://pkg.go.dev/uuid
+func StdlibUUID(m dsl.Matcher) {
+	m.Match(
+		`uuid.New()`,
+		`uuid.NewString()`,
+		`uuid.NewRandom()`,
+		`uuid.NewV7()`,
+		`uuid.Parse($s)`,
+		`uuid.MustParse($s)`,
+		`uuid.Nil`,
+		`uuid.Max`,
+	).
+		Where(m.File().Imports("github.com/google/uuid")).
+		Report("the standard library uuid package (Go 1.27+) covers New/NewV4/NewV7/Parse/MustParse/Nil/Max; consider dropping github.com/google/uuid (its NewRandom/NewV7 lose the error return, and Nil/Max become functions)")
+}


### PR DESCRIPTION
## Summary

Bumps the toolchain to Go 1.27 (`go.mod` `go 1.27.0`, dropping the redundant `toolchain go1.26.5` line) and golangci-lint to v2.13.1, then adds seven Go 1.27 modernization matchers to the `rules/*.go` go-ruleguard set that gocritic loads.

Each of the seven was verified unique against this project's *enabled* stock analyzers before being added: a probe file planting every pattern was run through golangci-lint 2.13.1 on go 1.27, and a matcher was kept only where no `modernize`/`staticcheck` analyzer already fired. Five further Go 1.27 candidates were deliberately declined because a stock analyzer or an existing matcher already covers them (`atomictypes`/`embedlit` via modernize, `tls.Config.Rand` via SA1019, `SetFinalizer` via the existing `PreferAddCleanup`, `sort.Ints` via the existing `SortToSlices`); the reasoning is recorded in `rules/doc.go`.

Added matchers: `RandMethodN` (generic `rand.Rand.N`), `ResponseBodyDrain` (redundant drain before an HTTP/1 `Response.Body.Close`), `URLValuesClone` (`maps.Clone` on `url.Values` to `Values.Clone`), `CutLast` (`strings`/`bytes.LastIndex` slicing to `CutLast`), `SynctestSleep` (`time.Sleep`+`synctest.Wait` to `synctest.Sleep`), `HttptestNewTestServer` (`httptest.NewServer` inside a synctest bubble), and `StdlibUUID` (`github.com/google/uuid` to the stdlib `uuid` package). The README build requirement is updated to Go 1.27+.

No production Go code changed; the `rules/*.go` files carry `//go:build ruleguard` and are consumed only by the linter.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, and the ruleguard canary `go build -tags ruleguard ./rules/` all clean on go 1.27.0
- [x] `golangci-lint run ./...` reports 0 issues (the seven new matchers do not fire on existing code; modernize does not panic on go 1.27)
- [x] `go test ./... -race` passes across all packages
- [x] Each new matcher probed to fire on its target pattern; `CutLast`'s `+1` form verified to match an ASCII separator but not a multi-byte rune
- [ ] CI green on the matrix (Linux/macOS/Windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added modernization checks for Go 1.27 APIs across networking, random numbers, strings, testing, and UUID handling.
  * Added guidance for replacing manual patterns with newer standard-library APIs.
  * Added recommendations for improved HTTP response cleanup and test synchronization.

* **Documentation**
  * Updated build requirements and documented Go 1.27 modernization coverage.

* **Chores**
  * Updated the Go toolchain and linting workflow versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->