### PR TITLE
Hide agy console window on Windows

### DIFF
--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -24,6 +24,15 @@ func ensureSysProcAttr(cmd *exec.Cmd) {
 // it is isolated from the parent's console control events. The supervisor uses it
 // for agy; the process tree is actually terminated via the Job Object captured by
 // Track. It ORs the flags into any CreationFlags a caller set first.
+//
+// CREATE_NO_WINDOW additionally runs the child without a console. The supervisor
+// is itself started with DETACHED_PROCESS and so has no console to hand down, and
+// a console-mode child that cannot inherit one has a fresh console allocated for
+// it, which is a visible window. Suppressing it costs nothing: agy's stdio are
+// redirected to a devnull/pipe/file trio, and its tree is killed through the Job
+// Object rather than console control events. The flag stays effective alongside
+// CREATE_NEW_PROCESS_GROUP; it is ignored only for a non-console application or
+// with CREATE_NEW_CONSOLE or DETACHED_PROCESS, none of which apply here.
 func ConfigureGroup(cmd *exec.Cmd) {
 	ensureSysProcAttr(cmd)
 	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NO_WINDOW

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -23,10 +23,10 @@ func ensureSysProcAttr(cmd *exec.Cmd) {
 // ConfigureGroup marks the spawned process as the root of a new process group so
 // it is isolated from the parent's console control events. The supervisor uses it
 // for agy; the process tree is actually terminated via the Job Object captured by
-// Track. It ORs the flag into any CreationFlags a caller set first.
+// Track. It ORs the flags into any CreationFlags a caller set first.
 func ConfigureGroup(cmd *exec.Cmd) {
 	ensureSysProcAttr(cmd)
-	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NO_WINDOW
 }
 
 // StartDetached configures cmd so the spawned supervisor is detached from the

--- a/internal/proc/proc_windows_test.go
+++ b/internal/proc/proc_windows_test.go
@@ -42,9 +42,11 @@ func TestConfigureGroupSetsNewProcessGroup(t *testing.T) {
 
 func TestConfigureGroupPreservesExistingFlags(t *testing.T) {
 	cmd := exec.Command("cmd.exe", "/c", "exit")
-	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+	// The sentinel has to be a flag ConfigureGroup does not set itself, otherwise
+	// the check passes even when CreationFlags is overwritten rather than ORed.
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_DEFAULT_ERROR_MODE}
 	ConfigureGroup(cmd)
-	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_DEFAULT_ERROR_MODE == 0 {
 		t.Error("ConfigureGroup must preserve a pre-existing CreationFlag")
 	}
 	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {

--- a/internal/proc/proc_windows_test.go
+++ b/internal/proc/proc_windows_test.go
@@ -35,6 +35,9 @@ func TestConfigureGroupSetsNewProcessGroup(t *testing.T) {
 	if cmd.SysProcAttr == nil || cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
 		t.Fatal("ConfigureGroup must set CREATE_NEW_PROCESS_GROUP")
 	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Fatal("ConfigureGroup must set CREATE_NO_WINDOW")
+	}
 }
 
 func TestConfigureGroupPreservesExistingFlags(t *testing.T) {


### PR DESCRIPTION
On Windows, starting the supervisor can cause the `agy.exe` child process to show a visible console window.

`ConfigureGroup` already requests `CREATE_NEW_PROCESS_GROUP`; this change also requests `CREATE_NO_WINDOW` while preserving process-group behavior. Job Object supervision, stdio pipes, stream-json handling, and sync/write/async/cancel behavior are unchanged.

Adds a Windows-specific regression test for the creation flag. Relevant Windows proc/supervisor tests, targeted manager process tests, Windows build, and Linux/Darwin cross-builds pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows processes launched by the application no longer open an unnecessary console window.
  * Process group behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->