### PR TITLE
fix(proc,status): suppress the remaining Windows console windows and close two coverage gaps

### DIFF
--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -174,6 +174,10 @@ func readAgyVersion(ctx context.Context, agy string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, versionCheckTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, agy, "--version")
+	// Suppress the console window this probe would otherwise flash on Windows when
+	// the manager itself has no console to inherit (an MCP client launching it from
+	// a GUI app). No-op elsewhere.
+	proc.ConfigureNoWindow(cmd)
 	// Without this, killing the process on deadline does not unblock the output
 	// copy: CombinedOutput reads through a pipe whose write end agy's descendants
 	// inherit, so a grandchild that outlives the kill holds the read open and the

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -163,6 +163,15 @@ func (m *Manager) agyBinaryChecked(ctx context.Context) (string, error) {
 	return agy, nil
 }
 
+// probeCmd builds the command for one of the manager's short-lived agy probes.
+// It exists so the console-window suppression both probes need is applied in one
+// place a test can inspect, rather than being remembered separately at each site.
+func probeCmd(ctx context.Context, agy string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, agy, args...)
+	proc.ConfigureNoWindow(cmd)
+	return cmd
+}
+
 // readAgyVersion runs `agy --version` and returns its raw output.
 //
 // A non-zero exit is deliberately not treated as failure: --version is not
@@ -173,11 +182,7 @@ func (m *Manager) agyBinaryChecked(ctx context.Context) (string, error) {
 func readAgyVersion(ctx context.Context, agy string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, versionCheckTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, agy, "--version")
-	// Suppress the console window this probe would otherwise flash on Windows when
-	// the manager itself has no console to inherit (an MCP client launching it from
-	// a GUI app). No-op elsewhere.
-	proc.ConfigureNoWindow(cmd)
+	cmd := probeCmd(ctx, agy, "--version")
 	// Without this, killing the process on deadline does not unblock the output
 	// copy: CombinedOutput reads through a pipe whose write end agy's descendants
 	// inherit, so a grandchild that outlives the kill holds the read open and the

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/tphakala/agy-mcp/v2/internal/proc"
 )
 
 // listModelsTimeout bounds `agy models`, and listModelsKillGrace bounds how long
@@ -96,6 +98,8 @@ func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
 	// (the subcommand flagset does not define it). The listing banner stays on
 	// stderr, so stdout is the envelope alone.
 	cmd := exec.CommandContext(ctx, agy, outputFormatFlag, jsonOutputFormat, "models")
+	// Same console-window suppression as the version probe; no-op off Windows.
+	proc.ConfigureNoWindow(cmd)
 	cmd.WaitDelay = listModelsKillGrace
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -8,8 +8,6 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-
-	"github.com/tphakala/agy-mcp/v2/internal/proc"
 )
 
 // listModelsTimeout bounds `agy models`, and listModelsKillGrace bounds how long
@@ -97,17 +95,17 @@ func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
 	// `models` subcommand; agy rejects `models --output-format json` outright
 	// (the subcommand flagset does not define it). The listing banner stays on
 	// stderr, so stdout is the envelope alone.
-	cmd := exec.CommandContext(ctx, agy, outputFormatFlag, jsonOutputFormat, "models")
-	// Same console-window suppression as the version probe; no-op off Windows.
-	proc.ConfigureNoWindow(cmd)
+	cmd := probeCmd(ctx, agy, outputFormatFlag, jsonOutputFormat, "models")
 	cmd.WaitDelay = listModelsKillGrace
 	out, err := cmd.Output()
 	if err != nil {
 		// Output() captures stderr into (*exec.ExitError).Stderr; include it so a
 		// real cause (an auth prompt, a usage error) is visible instead of a bare
 		// "exit status 1".
-		if ee, ok := errors.AsType[*exec.ExitError](err); ok && len(ee.Stderr) > 0 {
-			return nil, fmt.Errorf("agy models: %w: %s", err, strings.TrimSpace(string(ee.Stderr)))
+		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
+			if stderr := strings.TrimSpace(string(ee.Stderr)); stderr != "" {
+				return nil, fmt.Errorf("agy models: %w: %s", err, stderr)
+			}
 		}
 		return nil, fmt.Errorf("agy models: %w", err)
 	}

--- a/internal/manager/models_test.go
+++ b/internal/manager/models_test.go
@@ -22,6 +22,30 @@ func TestListModelsIncludesStderrOnError(t *testing.T) {
 	}
 }
 
+// A whitespace-only stderr is not a message: appending it would produce
+// "agy models: exit status 1: " with nothing after the separator, the same
+// dangling-separator shape errorSummary and spawnFailMessage were fixed for.
+// TestListModelsIncludesStderrOnError only covers a stderr with content, so
+// without this the trim is unpinned.
+func TestListModelsOmitsWhitespaceOnlyStderr(t *testing.T) {
+	skipIfWindows(t, "Unix-specific: WriteFakeAgy emits a bash script that is not executable on Windows")
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stderr: " \n\t ", Exit: 1})
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	_, err := m.ListModels(t.Context())
+	if err == nil {
+		t.Fatal("ListModels must fail when agy exits non-zero")
+	}
+	if strings.HasSuffix(err.Error(), ": ") || strings.HasSuffix(err.Error(), ":") {
+		t.Fatalf("err = %q, ends in a dangling separator with no message after it", err)
+	}
+	// Positive control: the failure itself must still be reported, so the trim
+	// cannot pass by swallowing the error entirely.
+	if !strings.Contains(err.Error(), "agy models:") {
+		t.Fatalf("err = %q, want it to name the failing command", err)
+	}
+}
+
 // TestDecodeModelsEnvelope pins how agy's JSON models envelope becomes Models:
 // the id/label pairs come from command.data.models, a label-less entry keeps an
 // empty label rather than being dropped, an empty models array is a valid empty

--- a/internal/manager/probe_windows_test.go
+++ b/internal/manager/probe_windows_test.go
@@ -1,0 +1,40 @@
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestProbeCmdSuppressesConsoleWindow pins the binding #158 relies on: every
+// command the manager builds through probeCmd carries CREATE_NO_WINDOW, so the
+// short-lived probes do not flash a console window. Deleting the ConfigureNoWindow
+// call inside probeCmd must turn this red by assertion, not by a nil panic (see
+// the nil guard below), which is why the helper exists in one inspectable place.
+func TestProbeCmdSuppressesConsoleWindow(t *testing.T) {
+	cmd := probeCmd(context.Background(), "cmd.exe", "/c", "exit")
+	if cmd.SysProcAttr == nil {
+		t.Fatal("probeCmd must set SysProcAttr so window suppression is applied")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("probeCmd must set CREATE_NO_WINDOW")
+	}
+}
+
+// TestProbeCmdDoesNotGroupOrDetach: the probes want window suppression alone,
+// not the process-group or detachment flags the supervisor path uses. Asserting
+// their absence keeps probeCmd from quietly becoming an alias for ConfigureGroup
+// or StartDetached.
+func TestProbeCmdDoesNotGroupOrDetach(t *testing.T) {
+	cmd := probeCmd(context.Background(), "cmd.exe", "/c", "exit")
+	if cmd.SysProcAttr == nil {
+		t.Fatal("probeCmd must set SysProcAttr")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP != 0 {
+		t.Error("probeCmd must not set CREATE_NEW_PROCESS_GROUP")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.DETACHED_PROCESS != 0 {
+		t.Error("probeCmd must not detach the child")
+	}
+}

--- a/internal/manager/probebinding_test.go
+++ b/internal/manager/probebinding_test.go
@@ -1,0 +1,119 @@
+package manager
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The console-window suppression #158 added is only real if every agy spawn in
+// this package goes through probeCmd, which is where proc.ConfigureNoWindow is
+// applied. probeCmd's own Windows test pins that the helper sets the flag; this
+// pins that the probes actually use the helper.
+//
+// Without it the binding is invisible to the suite: replacing probeCmd with a
+// bare exec.CommandContext at both production call sites leaves every test, go
+// vet, and the Windows vet green, so the fix can be reverted silently. That is a
+// property of the call sites rather than of any single function's behaviour,
+// which is why it is checked structurally instead of by an assertion on output.
+//
+// It runs on every platform, unlike probe_windows_test.go, so a POSIX-only CI
+// leg still catches a regression here.
+func TestNoDirectExecOutsideProbeCmd(t *testing.T) {
+	const helper = "probeCmd"
+
+	// The supervisor spawn is the one legitimate direct exec in this package: it
+	// starts agy-mcp's own supervisor, not agy, and it goes through
+	// proc.StartDetached, whose DETACHED_PROCESS leaves the child with no console
+	// at all (CREATE_NO_WINDOW is ignored alongside it, as ConfigureGroup's doc
+	// records). The exemption is keyed on the enclosing function so that renaming
+	// or moving that spawn fails this test rather than silently widening the
+	// exemption; the positive control below proves the entry still matches
+	// something.
+	exempt := map[string]string{"StartJob": "spawns the supervisor via proc.StartDetached, which drops the console"}
+	seenExempt := map[string]bool{}
+
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var checked int
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		checked++
+
+		// Walk each top-level function separately so the enclosing function's name
+		// is known at the call site, which is what lets probeCmd itself be exempt.
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if fn.Name.Name == helper {
+				continue
+			}
+			if _, ok := exempt[fn.Name.Name]; ok {
+				seenExempt[fn.Name.Name] = true
+				continue
+			}
+			ast.Inspect(fn, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "exec" {
+					return true
+				}
+				if sel.Sel.Name != "Command" && sel.Sel.Name != "CommandContext" {
+					return true
+				}
+				t.Errorf("%s: %s calls exec.%s directly; agy spawns in this package must go through %s so proc.ConfigureNoWindow is applied (see #158)",
+					fset.Position(call.Pos()), fn.Name.Name, sel.Sel.Name, helper)
+				return true
+			})
+		}
+	}
+
+	// Positive control: a glob that matched nothing, or a package that stopped
+	// containing the helper, would make the loop above vacuous.
+	if checked == 0 {
+		t.Fatal("parsed no non-test Go files; the check above proved nothing")
+	}
+	if !strings.Contains(readSource(t, "manager.go"), "func "+helper+"(") {
+		t.Fatalf("%s is not defined in manager.go; this test is pinned to the wrong helper", helper)
+	}
+	// An exemption that no longer matches any function is a stale carve-out, and a
+	// stale carve-out silently permits whatever later takes that name.
+	for name, why := range exempt {
+		if !seenExempt[name] {
+			t.Errorf("exemption for %s (%s) matched no function; remove it or update the name", name, why)
+		}
+	}
+}
+
+func readSource(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -654,14 +654,16 @@ func tailFile(path string, n int64) (string, error) {
 }
 
 // cleanTail returns the trailing stderr of a terminal job (the last errTailBytes,
-// trailing newline trimmed and starting on a valid UTF-8 boundary), or "" when
-// there is none.
+// trailing whitespace trimmed and starting on a valid UTF-8 boundary), or "" when
+// there is none. Trimming all trailing whitespace here, not just newlines, means a
+// caller's tail != "" check distinguishes a real message from a whitespace-only
+// tail that would otherwise render as a message after a separator.
 func cleanTail(dir string) (string, error) {
 	tail, err := tailFile(jobstore.ErrPath(dir), errTailBytes)
 	if err != nil {
 		return "", err
 	}
-	tail = strings.TrimRight(tail, "\n")
+	tail = strings.TrimRightFunc(tail, unicode.IsSpace)
 	// tailFile may have started mid-rune; advance to a valid UTF-8 boundary so a
 	// multi-byte rune is not split.
 	for tail != "" && !utf8.RuneStart(tail[0]) {
@@ -725,10 +727,11 @@ func isQuotaError(msg string) bool {
 		strings.Contains(l, "too many requests")
 }
 
-// errorSummary describes a non-zero exit that agy left no result payload for.
-// The three outcomes are kept distinct because a caller reading only this string
-// cannot otherwise tell them apart: stderr had something, stderr was empty, or
-// stderr could not be read at all.
+// errorSummary summarizes a non-zero exit for which no error message came from a
+// result payload: either agy left no payload, or the payload's Error was empty.
+// It distinguishes three stderr outcomes, kept distinct because a caller reading
+// only this string cannot otherwise tell them apart: stderr had content, stderr
+// was empty or absent, or stderr could not be read at all.
 func errorSummary(dir string, code int) string {
 	tail, err := cleanTail(dir)
 	if err != nil {
@@ -736,11 +739,6 @@ func errorSummary(dir string, code int) string {
 		// the run produced no error output.
 		return fmt.Sprintf("exit %d: <stderr unavailable: %v>", code, err)
 	}
-	// cleanTail strips trailing newlines but not other trailing whitespace. The
-	// previous TrimSpace over the whole assembled string did strip it (the "exit"
-	// prefix meant only the tail end was ever affected), so keep that here rather
-	// than letting a tail of spaces through as if it were a message.
-	tail = strings.TrimRightFunc(tail, unicode.IsSpace)
 	if tail == "" {
 		// A readable but empty stderr. Naming it beats the dangling "exit N:" that
 		// trimming a colon with nothing after it used to leave behind, which read
@@ -755,7 +753,13 @@ func errorSummary(dir string, code int) string {
 // names both causes and appends any stderr instead of masking it.
 func spawnFailMessage(dir string) string {
 	msg := "agy exited 127: the supervisor could not exec the agy binary (check the configured agy path), or agy itself exited 127"
-	if tail, err := cleanTail(dir); err == nil && tail != "" {
+	tail, err := cleanTail(dir)
+	switch {
+	case err != nil:
+		// The stderr file exists but cannot be read; name it, as errorSummary does,
+		// rather than silently dropping it.
+		msg += fmt.Sprintf("; stderr unavailable: %v", err)
+	case tail != "":
 		msg += "; stderr: " + tail
 	}
 	return msg

--- a/internal/manager/status.go
+++ b/internal/manager/status.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
@@ -724,14 +725,29 @@ func isQuotaError(msg string) bool {
 		strings.Contains(l, "too many requests")
 }
 
+// errorSummary describes a non-zero exit that agy left no result payload for.
+// The three outcomes are kept distinct because a caller reading only this string
+// cannot otherwise tell them apart: stderr had something, stderr was empty, or
+// stderr could not be read at all.
 func errorSummary(dir string, code int) string {
 	tail, err := cleanTail(dir)
 	if err != nil {
-		// The stderr file exists but cannot be read; say so rather than emitting a
-		// bare "exit N:" that looks like there was no error output.
+		// The stderr file exists but cannot be read; say so rather than implying
+		// the run produced no error output.
 		return fmt.Sprintf("exit %d: <stderr unavailable: %v>", code, err)
 	}
-	return strings.TrimSpace("exit " + strconv.Itoa(code) + ": " + tail)
+	// cleanTail strips trailing newlines but not other trailing whitespace. The
+	// previous TrimSpace over the whole assembled string did strip it (the "exit"
+	// prefix meant only the tail end was ever affected), so keep that here rather
+	// than letting a tail of spaces through as if it were a message.
+	tail = strings.TrimRightFunc(tail, unicode.IsSpace)
+	if tail == "" {
+		// A readable but empty stderr. Naming it beats the dangling "exit N:" that
+		// trimming a colon with nothing after it used to leave behind, which read
+		// as a truncated message rather than as an absence of one.
+		return fmt.Sprintf("exit %d (no stderr output)", code)
+	}
+	return "exit " + strconv.Itoa(code) + ": " + tail
 }
 
 // spawnFailMessage explains a 127 exit. The supervisor writes 127 both when it

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -729,6 +729,44 @@ func TestStatusSpawnFail(t *testing.T) {
 // TestStatusExit127SurfacesStderr: 127 is also a valid agy exit code, so when
 // agy itself exits 127 (with stderr) the message must surface that stderr rather
 // than masking it behind the spawn-failure text.
+// spawnFailMessage names an unreadable stderr rather than dropping the error,
+// the same way errorSummary does. Without this the branch has no coverage at
+// all, and removing it leaves the whole package green.
+//
+// POSIX only, for the reason TestErrorSummaryDistinguishesEmptyStderr's
+// unreadable row is: on Windows a directory's Size() is 0, so tailFile sizes a
+// zero-length buffer and ReadAt returns (0, nil) without reading, so the read
+// never fails and there is no error to name.
+func TestStatusSpawnFailNamesUnreadableStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("a directory does not make tailFile's read fail on Windows")
+	}
+	m := newManager(t, managerOpts{})
+	dir, err := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.Mkdir(jobstore.ErrPath(dir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("j", jobstore.ExitSpawnFail); err != nil {
+		t.Fatalf("WriteExitCode: %v", err)
+	}
+
+	st, err := m.Status("j")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !strings.Contains(st.Error, "stderr unavailable:") {
+		t.Fatalf("error = %q, want the unreadable stderr named", st.Error)
+	}
+	// The 127 explanation must survive alongside it, so the added clause
+	// supplements the message rather than replacing it.
+	if !strings.Contains(st.Error, "could not exec the agy binary") {
+		t.Fatalf("error = %q, want the spawn-failure explanation kept", st.Error)
+	}
+}
+
 func TestStatusExit127SurfacesStderr(t *testing.T) {
 	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -113,6 +113,64 @@ func TestErrorSummaryTruncatesOnUTF8Boundary(t *testing.T) {
 	}
 }
 
+// errorSummary must tell three cases apart, because this string is all a caller
+// sees for a non-zero exit that left no result payload. The empty-stderr case is
+// the one that used to render as a dangling "exit N:", which reads as a message
+// that got cut off rather than as the absence of one. MEASURED against agy
+// 1.1.22: a run terminating non-zero with nothing on stderr does occur, and its
+// status Error was exactly "exit 1:".
+func TestErrorSummaryDistinguishesEmptyStderr(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		stderr  string
+		writeIt bool
+		code    int
+		want    string
+	}{
+		{name: "stderr with content", stderr: "boom", writeIt: true, code: 1, want: "exit 1: boom"},
+		{name: "trailing newline trimmed", stderr: "boom\n\n", writeIt: true, code: 2, want: "exit 2: boom"},
+		{name: "empty stderr file", stderr: "", writeIt: true, code: 1, want: "exit 1 (no stderr output)"},
+		{name: "whitespace-only stderr", stderr: "  \t\n ", writeIt: true, code: 3, want: "exit 3 (no stderr output)"},
+		{name: "no stderr file at all", writeIt: false, code: 4, want: "exit 4 (no stderr output)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newManager(t, managerOpts{})
+			dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+			if tc.writeIt {
+				if err := os.WriteFile(jobstore.ErrPath(dir), []byte(tc.stderr), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := errorSummary(dir, tc.code); got != tc.want {
+				t.Errorf("errorSummary = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The same absence, seen through Status, which is where a caller actually meets
+// it. Pinned separately so the message cannot regress only on the path that
+// matters while the unit test above still passes.
+func TestStatusFailedWithEmptyStderrNamesTheAbsence(t *testing.T) {
+	m := newManager(t, managerOpts{})
+	_, _ = m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	_ = m.store.WriteExitCode("j", 1)
+
+	st, err := m.Status("j")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.State != StateFailed {
+		t.Fatalf("state = %q, want failed", st.State)
+	}
+	if st.Error != "exit 1 (no stderr output)" {
+		t.Fatalf("error = %q, want the absence named rather than a dangling colon", st.Error)
+	}
+	if strings.HasSuffix(st.Error, ":") {
+		t.Errorf("error %q ends in a dangling colon", st.Error)
+	}
+}
+
 func TestStatusDone(t *testing.T) {
 	m := newManager(t, managerOpts{})
 	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -114,34 +115,70 @@ func TestErrorSummaryTruncatesOnUTF8Boundary(t *testing.T) {
 }
 
 // errorSummary must tell three cases apart, because this string is all a caller
-// sees for a non-zero exit that left no result payload. The empty-stderr case is
+// sees for a non-zero exit with no error message from a result payload (no
+// payload, or a payload whose Error was empty). The empty-stderr case is
 // the one that used to render as a dangling "exit N:", which reads as a message
 // that got cut off rather than as the absence of one. MEASURED against agy
 // 1.1.22: a run terminating non-zero with nothing on stderr does occur, and its
 // status Error was exactly "exit 1:".
 func TestErrorSummaryDistinguishesEmptyStderr(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		stderr  string
-		writeIt bool
-		code    int
-		want    string
+		name       string
+		stderr     string
+		writeIt    bool
+		errIsDir   bool
+		code       int
+		want       string
+		wantPrefix bool
 	}{
 		{name: "stderr with content", stderr: "boom", writeIt: true, code: 1, want: "exit 1: boom"},
-		{name: "trailing newline trimmed", stderr: "boom\n\n", writeIt: true, code: 2, want: "exit 2: boom"},
+		{name: "trailing whitespace trimmed", stderr: "boom\n\n", writeIt: true, code: 2, want: "exit 2: boom"},
+		// Leading whitespace is part of the message and must survive: cleanTail
+		// trims only the trailing end. This pins the parity a TrimRightFunc ->
+		// TrimSpace change would break.
+		{name: "leading whitespace preserved", stderr: "  boom  \n", writeIt: true, code: 1, want: "exit 1:   boom"},
 		{name: "empty stderr file", stderr: "", writeIt: true, code: 1, want: "exit 1 (no stderr output)"},
 		{name: "whitespace-only stderr", stderr: "  \t\n ", writeIt: true, code: 3, want: "exit 3 (no stderr output)"},
 		{name: "no stderr file at all", writeIt: false, code: 4, want: "exit 4 (no stderr output)"},
+		// A directory at the stderr path makes tailFile's read fail, which is the
+		// only way to reach errorSummary's <stderr unavailable> branch. POSIX only:
+		// see the skip below.
+		{name: "unreadable stderr", errIsDir: true, code: 5, want: "exit 5: <stderr unavailable:", wantPrefix: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newManager(t, managerOpts{})
-			dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
-			if tc.writeIt {
+			dir, err := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			switch {
+			case tc.errIsDir:
+				// A directory reads as an error on POSIX, but not on Windows: there a
+				// directory's Size() is 0, so tailFile sizes a zero-length buffer and
+				// (*os.File).ReadAt returns (0, nil) without ever reading, leaving
+				// tail empty and no error. Skipping keeps this row honest rather than
+				// asserting a branch the platform cannot reach. NOT MEASURED on
+				// Windows; derived from tailFile's buffer sizing and ReadAt's
+				// len(b) > 0 loop.
+				if runtime.GOOS == "windows" {
+					t.Skip("a directory does not make tailFile's read fail on Windows")
+				}
+				if err := os.Mkdir(jobstore.ErrPath(dir), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			case tc.writeIt:
 				if err := os.WriteFile(jobstore.ErrPath(dir), []byte(tc.stderr), 0o644); err != nil {
 					t.Fatal(err)
 				}
 			}
-			if got := errorSummary(dir, tc.code); got != tc.want {
+			got := errorSummary(dir, tc.code)
+			if tc.wantPrefix {
+				if !strings.HasPrefix(got, tc.want) {
+					t.Errorf("errorSummary = %q, want prefix %q", got, tc.want)
+				}
+				return
+			}
+			if got != tc.want {
 				t.Errorf("errorSummary = %q, want %q", got, tc.want)
 			}
 		})
@@ -151,7 +188,7 @@ func TestErrorSummaryDistinguishesEmptyStderr(t *testing.T) {
 // The same absence, seen through Status, which is where a caller actually meets
 // it. Pinned separately so the message cannot regress only on the path that
 // matters while the unit test above still passes.
-func TestStatusFailedWithEmptyStderrNamesTheAbsence(t *testing.T) {
+func TestStatusFailedWithMissingStderrNamesTheAbsence(t *testing.T) {
 	m := newManager(t, managerOpts{})
 	_, _ = m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
 	_ = m.store.WriteExitCode("j", 1)
@@ -165,9 +202,6 @@ func TestStatusFailedWithEmptyStderrNamesTheAbsence(t *testing.T) {
 	}
 	if st.Error != "exit 1 (no stderr output)" {
 		t.Fatalf("error = %q, want the absence named rather than a dangling colon", st.Error)
-	}
-	if strings.HasSuffix(st.Error, ":") {
-		t.Errorf("error %q ends in a dangling colon", st.Error)
 	}
 }
 

--- a/internal/manager/testhelpers_test.go
+++ b/internal/manager/testhelpers_test.go
@@ -20,7 +20,7 @@ type managerOpts struct {
 	defaultTimeout time.Duration
 	defaultModel   string
 	jobTTL         time.Duration
-	withCacheFile  bool   // true -> m.cacheFile = a fresh t.TempDir()/last_conversations.json
+	withCacheFile  bool // true -> m.cacheFile = a fresh t.TempDir()/last_conversations.json
 }
 
 // newManager builds a *Manager for tests, consolidating the suite's several

--- a/internal/proc/proc_other.go
+++ b/internal/proc/proc_other.go
@@ -8,9 +8,11 @@ import (
 )
 
 // Non-Linux, non-Windows, non-macOS stubs so the manager and supervisor packages
-// build on platforms (e.g. FreeBSD) without a supervision implementation. Both
-// callers check Supported and refuse before spawning, so these are never
-// reached at runtime.
+// build on platforms (e.g. FreeBSD) without a supervision implementation. The
+// spawning entry points (ConfigureGroup, StartDetached, Track) are gated behind
+// Supported by their callers, which refuse before spawning, so those never run
+// here. ConfigureNoWindow is the exception: the manager's probes call it
+// unconditionally, so it does run, and does nothing.
 
 // Supported is false here: supervision relies on process groups / job objects.
 const Supported = false

--- a/internal/proc/proc_other.go
+++ b/internal/proc/proc_other.go
@@ -17,6 +17,8 @@ const Supported = false
 
 func ConfigureGroup(_ *exec.Cmd) {}
 
+func ConfigureNoWindow(_ *exec.Cmd) {}
+
 func StartDetached(_ *exec.Cmd) error { return ErrUnsupported }
 
 // Group has no state on unsupported platforms; Track never returns one.

--- a/internal/proc/proc_posix.go
+++ b/internal/proc/proc_posix.go
@@ -23,6 +23,11 @@ func ConfigureGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
+// ConfigureNoWindow is a no-op here. It exists so the manager's probe spawns can
+// call it unconditionally; only Windows allocates a console window for a child
+// that cannot inherit one.
+func ConfigureNoWindow(_ *exec.Cmd) {}
+
 // StartDetached configures cmd so the child leads its own process group and
 // starts it, so the child (the detached supervisor) can be tracked as a group
 // and survives the parent's death via init adoption. On Linux and macOS this is

--- a/internal/proc/proc_posix_test.go
+++ b/internal/proc/proc_posix_test.go
@@ -31,6 +31,24 @@ func TestConfigureGroupPreservesExistingAttrs(t *testing.T) {
 	}
 }
 
+// ConfigureNoWindow is a no-op off Windows, but the manager's probes call it
+// unconditionally, so it must tolerate a command with no SysProcAttr and must
+// not invent one or disturb an existing one.
+func TestConfigureNoWindowIsInertHere(t *testing.T) {
+	cmd := exec.Command("true")
+	ConfigureNoWindow(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Errorf("ConfigureNoWindow must not allocate SysProcAttr here, got %+v", cmd.SysProcAttr)
+	}
+
+	withAttrs := exec.Command("true")
+	withAttrs.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	ConfigureNoWindow(withAttrs)
+	if !withAttrs.SysProcAttr.Setsid {
+		t.Error("ConfigureNoWindow must leave an existing SysProcAttr untouched")
+	}
+}
+
 // TestErrUnsupportedIsNonNil: ErrUnsupported must be a non-nil sentinel even on
 // Linux, so a caller comparing a (nil) success error against it never gets a
 // false match (errors.Is(nil, nil) is true).

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -39,13 +39,13 @@ func ConfigureGroup(cmd *exec.Cmd) {
 }
 
 // ConfigureNoWindow suppresses the console window of a short-lived child without
-// otherwise changing how it is spawned. It is for the probes the manager runs
-// directly (`agy --version`, the models listing), which want neither a new
-// process group nor Job Object supervision, only the window suppression.
+// otherwise changing how it is spawned. It is for the short-lived probes the
+// manager runs directly, which want neither a new process group nor Job Object
+// supervision, only the window suppression.
 //
 // A console-mode child that cannot inherit a console gets a fresh one allocated,
-// and that console has a visible window, so a manager launched from a GUI app
-// rather than a terminal would otherwise flash one window per probe.
+// and that console has a visible window, so a manager with no console of its own
+// would otherwise flash one window per probe.
 func ConfigureNoWindow(cmd *exec.Cmd) {
 	ensureSysProcAttr(cmd)
 	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -38,6 +38,19 @@ func ConfigureGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NO_WINDOW
 }
 
+// ConfigureNoWindow suppresses the console window of a short-lived child without
+// otherwise changing how it is spawned. It is for the probes the manager runs
+// directly (`agy --version`, the models listing), which want neither a new
+// process group nor Job Object supervision, only the window suppression.
+//
+// A console-mode child that cannot inherit a console gets a fresh one allocated,
+// and that console has a visible window, so a manager launched from a GUI app
+// rather than a terminal would otherwise flash one window per probe.
+func ConfigureNoWindow(cmd *exec.Cmd) {
+	ensureSysProcAttr(cmd)
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+}
+
 // StartDetached configures cmd so the spawned supervisor is detached from the
 // manager and starts it. DETACHED_PROCESS drops the console (the manager's stdio
 // is the JSON-RPC stream), and, when the manager sits in a job that permits it,

--- a/internal/proc/proc_windows_test.go
+++ b/internal/proc/proc_windows_test.go
@@ -54,6 +54,47 @@ func TestConfigureGroupPreservesExistingFlags(t *testing.T) {
 	}
 }
 
+// ConfigureNoWindow is what keeps the manager's short-lived probes (the
+// `agy --version` check and the models listing) from flashing a console window
+// when the manager itself has no console to inherit.
+func TestConfigureNoWindowSetsCreateNoWindow(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit")
+	ConfigureNoWindow(cmd)
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Fatal("ConfigureNoWindow must set CREATE_NO_WINDOW")
+	}
+}
+
+// The probes want window suppression alone: a new process group would change how
+// console control events reach them, and neither probe is supervised as a tree.
+// Asserting the absence keeps ConfigureNoWindow from quietly becoming an alias
+// for ConfigureGroup.
+func TestConfigureNoWindowDoesNotStartNewProcessGroup(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit")
+	ConfigureNoWindow(cmd)
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP != 0 {
+		t.Error("ConfigureNoWindow must not set CREATE_NEW_PROCESS_GROUP")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.DETACHED_PROCESS != 0 {
+		t.Error("ConfigureNoWindow must not detach the child")
+	}
+}
+
+// Same hazard TestConfigureGroupPreservesExistingFlags guards: the sentinel is a
+// flag ConfigureNoWindow does not set itself, so the check fails if CreationFlags
+// is assigned rather than ORed.
+func TestConfigureNoWindowPreservesExistingFlags(t *testing.T) {
+	cmd := exec.Command("cmd.exe", "/c", "exit")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_DEFAULT_ERROR_MODE}
+	ConfigureNoWindow(cmd)
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_DEFAULT_ERROR_MODE == 0 {
+		t.Error("ConfigureNoWindow must preserve a pre-existing CreationFlag")
+	}
+	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("ConfigureNoWindow must add CREATE_NO_WINDOW")
+	}
+}
+
 // TestStartDetachedRunsAndSetsFlags: StartDetached must actually start the process
 // and mark it detached (no inherited console).
 func TestStartDetachedRunsAndSetsFlags(t *testing.T) {

--- a/internal/proc/proc_windows_test.go
+++ b/internal/proc/proc_windows_test.go
@@ -54,9 +54,8 @@ func TestConfigureGroupPreservesExistingFlags(t *testing.T) {
 	}
 }
 
-// ConfigureNoWindow is what keeps the manager's short-lived probes (the
-// `agy --version` check and the models listing) from flashing a console window
-// when the manager itself has no console to inherit.
+// ConfigureNoWindow is what keeps the manager's short-lived probes from flashing
+// a console window when the manager itself has no console to inherit.
 func TestConfigureNoWindowSetsCreateNoWindow(t *testing.T) {
 	cmd := exec.Command("cmd.exe", "/c", "exit")
 	ConfigureNoWindow(cmd)
@@ -65,13 +64,15 @@ func TestConfigureNoWindowSetsCreateNoWindow(t *testing.T) {
 	}
 }
 
-// The probes want window suppression alone: a new process group would change how
-// console control events reach them, and neither probe is supervised as a tree.
-// Asserting the absence keeps ConfigureNoWindow from quietly becoming an alias
-// for ConfigureGroup.
+// The probes want window suppression alone, and neither probe is supervised as a
+// tree. Asserting the absence keeps ConfigureNoWindow from quietly becoming an
+// alias for ConfigureGroup.
 func TestConfigureNoWindowDoesNotStartNewProcessGroup(t *testing.T) {
 	cmd := exec.Command("cmd.exe", "/c", "exit")
 	ConfigureNoWindow(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("ConfigureNoWindow must set SysProcAttr")
+	}
 	if cmd.SysProcAttr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP != 0 {
 		t.Error("ConfigureNoWindow must not set CREATE_NEW_PROCESS_GROUP")
 	}

--- a/internal/supervisor/stream.go
+++ b/internal/supervisor/stream.go
@@ -95,8 +95,8 @@ func consumeStream(jobDir string, r io.Reader, out io.Writer) streamOutcome {
 				//
 				// Do NOT dedup by step_index to "skip repeats": the deltas are not
 				// repeats and agy does not emit one per step, so a step-indexed filter
-				// would drop every ACTIVE chunk and keep only the final tail.
-				// TestConsumeStreamAccumulatesChunksWithinOneStep pins exactly that.
+				// would keep one delta of the step and drop the rest, whichever way it
+				// dedups. TestConsumeStreamAccumulatesChunksWithinOneStep pins exactly that.
 				if su.StepType == streamjson.StepTypeAgentResponse && su.TextDelta != "" {
 					// A failed append costs partial-result fidelity, nothing more: the
 					// terminal result event is the authoritative response and is written

--- a/internal/supervisor/stream.go
+++ b/internal/supervisor/stream.go
@@ -78,17 +78,25 @@ func consumeStream(jobDir string, r io.Reader, out io.Writer) streamOutcome {
 				// contributed. agy streams one agent_response step as many text_delta
 				// events (the ACTIVE states carry successive chunks, the DONE state the
 				// final tail), so appending every one in arrival order reproduces the
-				// response: for a single-response run, concatenating its agent_response
-				// deltas matched its terminal result byte-for-byte (MEASURED against agy
-				// 1.1.15). A run
-				// with several agent_response steps accumulates all of them, which is
-				// more context than the terminal result carries. The manager reads it
+				// response.
+				//
+				// MEASURED against agy 1.1.15, and re-measured against 1.1.22: a
+				// 9448-byte response arrived as 38 ACTIVE deltas of 125 to 226 bytes
+				// each plus a 2248-byte DONE tail, all on one step_index, and
+				// concatenating all 39 equalled the terminal result byte for byte
+				// (non-ASCII text included). A response short enough to fit one chunk
+				// arrives as a single DONE delta instead, with no ACTIVE events at all
+				// (also MEASURED against 1.1.22), so both shapes have to work.
+				//
+				// A run with several agent_response steps accumulates all of them, which
+				// is more context than the terminal result carries. The manager reads it
 				// when no terminal result reached disk, and also when one did but carried
 				// no response of its own, since then this is the only text there is.
 				//
 				// Do NOT dedup by step_index to "skip repeats": the deltas are not
 				// repeats and agy does not emit one per step, so a step-indexed filter
 				// would drop every ACTIVE chunk and keep only the final tail.
+				// TestConsumeStreamAccumulatesChunksWithinOneStep pins exactly that.
 				if su.StepType == streamjson.StepTypeAgentResponse && su.TextDelta != "" {
 					// A failed append costs partial-result fidelity, nothing more: the
 					// terminal result event is the authoritative response and is written

--- a/internal/supervisor/stream_test.go
+++ b/internal/supervisor/stream_test.go
@@ -108,6 +108,53 @@ func TestConsumeStreamAccumulatesDeltas(t *testing.T) {
 	}
 }
 
+// agy streams one agent_response step as MANY text_delta events: successive
+// ACTIVE chunks followed by a DONE tail, all sharing one step_index (MEASURED
+// against agy 1.1.22: a 9448-byte response arrived as 38 ACTIVE deltas plus a
+// 2248-byte DONE tail, and concatenating all 39 equalled the terminal result
+// byte for byte).
+//
+// This is the shape TestConsumeStreamAccumulatesDeltas does NOT cover: that one
+// gives every delta a distinct step_index, so a dedup keyed on step_index keeps
+// all three and passes. Here the indexes are identical, so such a dedup keeps
+// one delta and drops the rest.
+//
+// The stream deliberately carries no result event, so out is the only place the
+// text can be observed and the assertion cannot pass off the terminal payload.
+func TestConsumeStreamAccumulatesChunksWithinOneStep(t *testing.T) {
+	stream := `{"event":"init","conversation_id":"c-1"}
+{"event":"step_update","step_update":{"step_index":1,"state":"ACTIVE","step_type":"agent_response","text_delta":"chunk one "}}
+{"event":"step_update","step_update":{"step_index":1,"state":"ACTIVE","step_type":"agent_response","text_delta":"chunk two "}}
+{"event":"step_update","step_update":{"step_index":1,"state":"ACTIVE","step_type":"agent_response","text_delta":"chunk three "}}
+{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"agent_response","text_delta":"the tail"}}
+`
+	_, out, oc := consume(t, stream)
+	const want = "chunk one chunk two chunk three the tail"
+	if got := out.String(); got != want {
+		t.Fatalf("out = %q, want %q; every delta of a step must be appended, ACTIVE ones included", got, want)
+	}
+	// Positive control: all four lines decoded, so the equality above cannot be
+	// satisfied by lines that were skipped rather than accumulated.
+	if oc.malformed != 0 {
+		t.Fatalf("malformed = %d, want 0", oc.malformed)
+	}
+}
+
+// The DONE tail alone is not the answer. Pinned separately because it is the
+// exact regression a `state == "DONE"` filter would introduce, and because that
+// filter still leaves the test above failing in a way that could be mistaken for
+// an ordering bug rather than a dropped-chunk bug.
+func TestConsumeStreamDoesNotKeepOnlyTheDoneTail(t *testing.T) {
+	stream := `{"event":"init","conversation_id":"c-1"}
+{"event":"step_update","step_update":{"step_index":1,"state":"ACTIVE","step_type":"agent_response","text_delta":"dropped-if-done-only "}}
+{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"agent_response","text_delta":"tail"}}
+`
+	_, out, _ := consume(t, stream)
+	if got := out.String(); got == "tail" {
+		t.Fatal("out kept only the DONE tail; the ACTIVE chunk before it was dropped")
+	}
+}
+
 // A run cut off before its result event still leaves its conversation behind,
 // which is what lets the manager report a continuable partial result. This
 // fixture's cut lands mid-line, so the truncated step contributes no text: the

--- a/internal/supervisor/stream_test.go
+++ b/internal/supervisor/stream_test.go
@@ -109,10 +109,9 @@ func TestConsumeStreamAccumulatesDeltas(t *testing.T) {
 }
 
 // agy streams one agent_response step as MANY text_delta events: successive
-// ACTIVE chunks followed by a DONE tail, all sharing one step_index (MEASURED
-// against agy 1.1.22: a 9448-byte response arrived as 38 ACTIVE deltas plus a
-// 2248-byte DONE tail, and concatenating all 39 equalled the terminal result
-// byte for byte).
+// ACTIVE chunks followed by a DONE tail, all sharing one step_index (the shape,
+// and the measurement behind it, are recorded at consumeStream's append site in
+// stream.go).
 //
 // This is the shape TestConsumeStreamAccumulatesDeltas does NOT cover: that one
 // gives every delta a distinct step_index, so a dedup keyed on step_index keeps
@@ -137,21 +136,6 @@ func TestConsumeStreamAccumulatesChunksWithinOneStep(t *testing.T) {
 	// satisfied by lines that were skipped rather than accumulated.
 	if oc.malformed != 0 {
 		t.Fatalf("malformed = %d, want 0", oc.malformed)
-	}
-}
-
-// The DONE tail alone is not the answer. Pinned separately because it is the
-// exact regression a `state == "DONE"` filter would introduce, and because that
-// filter still leaves the test above failing in a way that could be mistaken for
-// an ordering bug rather than a dropped-chunk bug.
-func TestConsumeStreamDoesNotKeepOnlyTheDoneTail(t *testing.T) {
-	stream := `{"event":"init","conversation_id":"c-1"}
-{"event":"step_update","step_update":{"step_index":1,"state":"ACTIVE","step_type":"agent_response","text_delta":"dropped-if-done-only "}}
-{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"agent_response","text_delta":"tail"}}
-`
-	_, out, _ := consume(t, stream)
-	if got := out.String(); got == "tail" {
-		t.Fatal("out kept only the DONE tail; the ACTIVE chunk before it was dropped")
 	}
 }
 

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
+	"github.com/tphakala/agy-mcp/v2/internal/streamjson"
 	"github.com/tphakala/agy-mcp/v2/internal/testutil"
 )
 
@@ -85,6 +86,45 @@ func TestSupervisorCapturesOutputAndSentinel(t *testing.T) {
 	code, err := os.ReadFile(filepath.Join(dir, "exit_code"))
 	if err != nil || strings.TrimSpace(string(code)) != "0" {
 		t.Fatalf("exit_code = %q, err=%v", code, err)
+	}
+}
+
+// End-to-end counterpart to TestConsumeStreamAccumulatesChunksWithinOneStep:
+// the fake emits the response as several ACTIVE deltas plus a DONE tail on one
+// step, the way agy streams a long response, and the supervisor must land the
+// whole thing in the out file. The direct consumeStream test pins the decoder;
+// this pins the path a real run takes, including the fake that stands in for
+// agy, so the two cannot drift apart.
+func TestSupervisorAccumulatesChunkedDeltas(t *testing.T) {
+	dir := t.TempDir()
+	// Long enough that chunking is meaningful, and non-ASCII so a chunk boundary
+	// landing inside a multi-byte rune would corrupt the reassembly.
+	const answer = "the quick brown fox jumps over the lazy dog, hyvää yötä, 你好世界"
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stdout: answer, StreamChunks: 7, Exit: 0})
+	writeMeta(t, dir, jobstore.Meta{ID: "j", AgyPath: agy, Args: []string{"-p", "x"}, StartedAt: time.Now()})
+
+	if err := Run(dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	out, err := os.ReadFile(jobstore.OutPath(dir))
+	if err != nil {
+		t.Fatalf("read out: %v", err)
+	}
+	if string(out) != answer {
+		t.Fatalf("out = %q, want the concatenation of every delta %q", out, answer)
+	}
+	// The terminal result carries the same text, so out matching it is the
+	// property the manager relies on when it falls back to the streamed text.
+	res, err := jobstore.ReadResultDir(dir)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	var got streamjson.Result
+	if err := json.Unmarshal(res, &got); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if got.Response != string(out) {
+		t.Fatalf("result response %q != streamed out %q", got.Response, out)
 	}
 }
 

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -92,10 +92,11 @@ func TestSupervisorCapturesOutputAndSentinel(t *testing.T) {
 // End-to-end counterpart to TestConsumeStreamAccumulatesChunksWithinOneStep:
 // the fake emits the response as several ACTIVE deltas plus a DONE tail on one
 // step, the way agy streams a long response, and the supervisor must land the
-// whole thing in the out file. The direct consumeStream test pins the decoder;
-// this pins the path a real run takes, including the fake that stands in for
-// agy, so the two cannot drift apart.
-func TestSupervisorAccumulatesChunkedDeltas(t *testing.T) {
+// whole thing in the out file with its non-ASCII runes intact. The direct
+// consumeStream test pins the decoder; this pins the path a real run takes,
+// through the fake and onto disk. It does not pin the fake's own delta emission:
+// TestFakeAgyStreamChunksEmitsManyDeltasOnOneStep does that.
+func TestSupervisorLandsWholeChunkedResponseIntact(t *testing.T) {
 	dir := t.TempDir()
 	// Long enough that chunking is meaningful, and non-ASCII so a chunk boundary
 	// landing inside a multi-byte rune would corrupt the reassembly.
@@ -113,8 +114,11 @@ func TestSupervisorAccumulatesChunkedDeltas(t *testing.T) {
 	if string(out) != answer {
 		t.Fatalf("out = %q, want the concatenation of every delta %q", out, answer)
 	}
-	// The terminal result carries the same text, so out matching it is the
-	// property the manager relies on when it falls back to the streamed text.
+	// The terminal result carries the whole answer too. Comparing it to the
+	// answer directly, not to out, keeps this check independent of the out
+	// assertion above, so a bug that corrupted both identically cannot satisfy
+	// both. Result matching the streamed text is what the manager relies on when
+	// it falls back to the streamed text.
 	res, err := jobstore.ReadResultDir(dir)
 	if err != nil {
 		t.Fatalf("read result: %v", err)
@@ -123,8 +127,8 @@ func TestSupervisorAccumulatesChunkedDeltas(t *testing.T) {
 	if err := json.Unmarshal(res, &got); err != nil {
 		t.Fatalf("decode result: %v", err)
 	}
-	if got.Response != string(out) {
-		t.Fatalf("result response %q != streamed out %q", got.Response, out)
+	if got.Response != answer {
+		t.Fatalf("result response %q != the whole answer %q", got.Response, answer)
 	}
 }
 

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -59,6 +59,23 @@ type FakeAgy struct {
 	// in for a run cut short before agy could summarize it.
 	OmitResult bool
 
+	// StreamChunks splits Stdout across that many agent_response text_delta
+	// events on a SINGLE step: the first StreamChunks-1 in ACTIVE state, the
+	// remainder as the DONE tail. It reproduces how agy streams a response long
+	// enough to chunk (MEASURED against agy 1.1.22: a 9448-byte response arrived
+	// as 38 ACTIVE deltas of 125 to 226 bytes each plus a 2248-byte DONE tail,
+	// and concatenating all 39 equalled the terminal result byte for byte).
+	//
+	// Zero or one emits the single DONE delta carrying the whole response, which
+	// is what agy does for a response short enough to fit one chunk (also
+	// MEASURED against 1.1.22) and what every existing test expects. Splitting is
+	// by rune, so a chunk boundary never lands inside a multi-byte character.
+	//
+	// Whatever the value, the deltas always concatenate to Stdout, which is also
+	// the Response the terminal result carries, so a consumer that accumulates
+	// every delta reproduces the result exactly.
+	StreamChunks int
+
 	// Version is what the script reports for `agy --version`, which the manager
 	// probes once before it will run anything. Defaults to the minimum agy-mcp
 	// accepts; set it lower to exercise the refusal.
@@ -175,6 +192,41 @@ func (cfg FakeAgy) result() streamjson.Result {
 	}
 }
 
+// splitChunks divides text into n roughly equal pieces for StreamChunks. It
+// splits on rune boundaries so a piece is never invalid UTF-8, and always
+// returns at least one piece (the whole text) so the caller emits the same
+// single DONE delta it always did for n of 0 or 1. n larger than the rune count
+// yields one piece per rune rather than empty ones, because consumeStream skips
+// an empty delta and an empty piece would silently reduce the chunk count the
+// caller asked for.
+func splitChunks(text string, n int) []string {
+	if n <= 1 {
+		return []string{text}
+	}
+	runes := []rune(text)
+	if n > len(runes) {
+		n = len(runes)
+	}
+	if n <= 1 {
+		return []string{text}
+	}
+	out := make([]string, 0, n)
+	per := len(runes) / n
+	rem := len(runes) % n
+	start := 0
+	for i := range n {
+		// Spread the remainder over the first rem pieces, so the pieces differ by
+		// at most one rune and none is empty.
+		size := per
+		if i < rem {
+			size++
+		}
+		out = append(out, string(runes[start:start+size]))
+		start += size
+	}
+	return out
+}
+
 // streamLines renders the configured run as agy's stream-json output, which
 // WriteFakeAgy stages as the script's stdout payload. It is unexported because the
 // only consumer is in this file. One candidate does exist if anyone wants it back:
@@ -187,16 +239,27 @@ func (cfg FakeAgy) streamLines(t *testing.T) string {
 		Kind:           streamjson.EventInit,
 		ConversationID: convID,
 		Init:           &streamjson.Init{Cwd: ".", PermissionMode: "request-review"},
-	}, {
-		Kind: streamjson.EventStepUpdate,
-		StepUpdate: &streamjson.StepUpdate{
-			ConversationID: convID,
-			StepIndex:      0,
-			State:          "DONE",
-			StepType:       streamjson.StepTypeAgentResponse,
-			TextDelta:      cfg.Stdout,
-		},
 	}}
+	// One step, one or more deltas. Every chunk but the last is ACTIVE; the last
+	// is the DONE tail, so a single-chunk run is byte-identical to the single
+	// DONE event this fake emitted before StreamChunks existed.
+	chunks := splitChunks(cfg.Stdout, cfg.StreamChunks)
+	for i, chunk := range chunks {
+		state := "ACTIVE"
+		if i == len(chunks)-1 {
+			state = "DONE"
+		}
+		events = append(events, streamjson.Event{
+			Kind: streamjson.EventStepUpdate,
+			StepUpdate: &streamjson.StepUpdate{
+				ConversationID: convID,
+				StepIndex:      0,
+				State:          state,
+				StepType:       streamjson.StepTypeAgentResponse,
+				TextDelta:      chunk,
+			},
+		})
+	}
 	if !cfg.OmitResult {
 		res := cfg.result()
 		events = append(events, streamjson.Event{Kind: streamjson.EventResult, Result: &res})

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -31,8 +31,9 @@ const defaultFakeConversationID = "11111111-2222-3333-4444-555555555555"
 // hand-rolling JSON escaping in shell.
 type FakeAgy struct {
 	// Stdout is the response text. It is emitted as the agent_response step's
-	// text_delta and as the terminal result's response, mirroring what real agy
-	// does for a single-turn run.
+	// text_delta (one delta, or several when StreamChunks splits it) and as the
+	// terminal result's response, mirroring what real agy does for a single-turn
+	// run.
 	Stdout string
 	Stderr string        // printed to stderr
 	Exit   int           // exit code
@@ -59,21 +60,26 @@ type FakeAgy struct {
 	// in for a run cut short before agy could summarize it.
 	OmitResult bool
 
-	// StreamChunks splits Stdout across that many agent_response text_delta
-	// events on a SINGLE step: the first StreamChunks-1 in ACTIVE state, the
-	// remainder as the DONE tail. It reproduces how agy streams a response long
-	// enough to chunk (MEASURED against agy 1.1.22: a 9448-byte response arrived
-	// as 38 ACTIVE deltas of 125 to 226 bytes each plus a 2248-byte DONE tail,
-	// and concatenating all 39 equalled the terminal result byte for byte).
+	// StreamChunks splits Stdout across up to that many agent_response text_delta
+	// events on a SINGLE step: every delta but the last in ACTIVE state, the last
+	// as the DONE tail. The count is an upper bound, clamped to one piece per rune,
+	// so a value above the rune count yields one delta per rune rather than empty
+	// ones. It reproduces the SHAPE of how agy streams a response long enough to
+	// chunk (several ACTIVE deltas on one step, then a DONE tail), not agy's own
+	// size distribution: the pieces here are roughly equal, so this tail is
+	// chunk-sized, where agy's measured tail is many times one of its chunks. See
+	// stream.go for the measured distribution.
 	//
-	// Zero or one emits the single DONE delta carrying the whole response, which
-	// is what agy does for a response short enough to fit one chunk (also
-	// MEASURED against 1.1.22) and what every existing test expects. Splitting is
-	// by rune, so a chunk boundary never lands inside a multi-byte character.
+	// Zero, one or a negative value emits the single DONE delta carrying the whole
+	// response, which is what agy does for a response short enough to fit one chunk
+	// (MEASURED against agy 1.1.22) and what every existing test expects. Splitting
+	// is by rune, so a chunk boundary never lands inside a multi-byte character.
 	//
-	// Whatever the value, the deltas always concatenate to Stdout, which is also
-	// the Response the terminal result carries, so a consumer that accumulates
-	// every delta reproduces the result exactly.
+	// Whatever the value, the deltas concatenate to Stdout as it appears on the
+	// wire, which is also the Response the terminal result carries, so a consumer
+	// that accumulates every delta reproduces the result exactly. At the Go-string
+	// level an invalid-UTF-8 Stdout differs, since the rune split substitutes
+	// U+FFFD; json.Marshal coerces both sides identically, so the wire forms match.
 	StreamChunks int
 
 	// Version is what the script reports for `agy --version`, which the manager
@@ -196,9 +202,11 @@ func (cfg FakeAgy) result() streamjson.Result {
 // splits on rune boundaries so a piece is never invalid UTF-8, and always
 // returns at least one piece (the whole text) so the caller emits the same
 // single DONE delta it always did for n of 0 or 1. n larger than the rune count
-// yields one piece per rune rather than empty ones, because consumeStream skips
-// an empty delta and an empty piece would silently reduce the chunk count the
-// caller asked for.
+// is clamped to the rune count (one piece per rune) rather than producing empty
+// pieces: unclamped, the last piece would be empty, so streamLines would emit a
+// DONE tail carrying no text, a shape real agy never produces. The second n <= 1
+// check after the clamp is load-bearing: it returns early on empty text, whose
+// rune count clamps n to 0 and would otherwise divide by zero at len(runes) / n.
 func splitChunks(text string, n int) []string {
 	if n <= 1 {
 		return []string{text}

--- a/internal/testutil/fakeagy_test.go
+++ b/internal/testutil/fakeagy_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/tphakala/agy-mcp/v2/internal/streamjson"
 )
@@ -94,5 +95,126 @@ func TestFakeAgyAppliesFractionalSleep(t *testing.T) {
 	}
 	if elapsed < 120*time.Millisecond {
 		t.Fatalf("elapsed %s, want >= ~150ms; fractional sleep not applied", elapsed)
+	}
+}
+
+// StreamChunks must actually put several deltas on the wire, all on ONE step,
+// with only the last in DONE state. Asserted here rather than downstream because
+// this is the only place the emitted stream is observable: a consumer that
+// correctly reassembles the text cannot tell one delta from many, so a fake that
+// silently ignored StreamChunks would leave every downstream test passing while
+// exercising nothing.
+func TestFakeAgyStreamChunksEmitsManyDeltasOnOneStep(t *testing.T) {
+	const answer = "one two three four five six seven eight"
+	const chunks = 4
+	path := WriteFakeAgy(t, FakeAgy{Stdout: answer, StreamChunks: chunks, Exit: 0})
+	res := runScript(t, 10*time.Second, path, "-p", "ignored")
+	if res.ExitCode != 0 {
+		t.Fatalf("exit = %d, want 0; stderr: %q", res.ExitCode, res.Stderr)
+	}
+
+	sr := streamjson.NewReader(strings.NewReader(res.Stdout))
+	var states []string
+	var assembled strings.Builder
+	indexes := map[int]bool{}
+	for {
+		ev, err := sr.Next()
+		if err != nil {
+			break
+		}
+		su := ev.StepUpdate
+		if su == nil || su.StepType != streamjson.StepTypeAgentResponse {
+			continue
+		}
+		states = append(states, su.State)
+		indexes[su.StepIndex] = true
+		assembled.WriteString(su.TextDelta)
+	}
+	if sr.Malformed() != 0 {
+		t.Fatalf("%d malformed lines in a well-formed stream", sr.Malformed())
+	}
+	if len(states) != chunks {
+		t.Fatalf("got %d agent_response deltas, want %d; StreamChunks was ignored", len(states), chunks)
+	}
+	// All on one step: that is what makes a step_index dedup drop chunks, which is
+	// the regression this fake exists to expose.
+	if len(indexes) != 1 {
+		t.Fatalf("deltas spanned step indexes %v, want exactly one step", indexes)
+	}
+	want := []string{"ACTIVE", "ACTIVE", "ACTIVE", "DONE"}
+	if !slices.Equal(states, want) {
+		t.Fatalf("delta states = %v, want %v (only the tail is DONE)", states, want)
+	}
+	if assembled.String() != answer {
+		t.Fatalf("deltas concatenated to %q, want the whole response %q", assembled.String(), answer)
+	}
+}
+
+// The default (StreamChunks unset) must stay the single DONE delta every
+// existing test was written against, which is also what agy does for a response
+// short enough to fit one chunk (MEASURED against agy 1.1.22).
+func TestFakeAgyDefaultsToOneDoneDelta(t *testing.T) {
+	path := WriteFakeAgy(t, FakeAgy{Stdout: "short answer", Exit: 0})
+	res := runScript(t, 10*time.Second, path, "-p", "ignored")
+	sr := streamjson.NewReader(strings.NewReader(res.Stdout))
+	var states []string
+	for {
+		ev, err := sr.Next()
+		if err != nil {
+			break
+		}
+		if su := ev.StepUpdate; su != nil && su.StepType == streamjson.StepTypeAgentResponse {
+			states = append(states, su.State)
+		}
+	}
+	if !slices.Equal(states, []string{"DONE"}) {
+		t.Fatalf("delta states = %v, want a single DONE delta", states)
+	}
+}
+
+// splitChunks must never lose, reorder or corrupt text, because the whole point
+// of StreamChunks is that a consumer accumulating every delta reproduces the
+// response exactly. Non-ASCII input is included because a byte-wise split would
+// cut a multi-byte rune in half and produce invalid UTF-8 that no real agy
+// delta ever carries.
+func TestSplitChunks(t *testing.T) {
+	const text = "the quick brown fox jumps over the lazy dog"
+	const unicode = "hyvää yötä \u00e4\u00f6\u00e5 \u4f60\u597d\u4e16\u754c emoji"
+
+	for _, tc := range []struct {
+		name      string
+		text      string
+		n         int
+		wantParts int
+	}{
+		{"zero keeps one piece", text, 0, 1},
+		{"one keeps one piece", text, 1, 1},
+		{"negative keeps one piece", text, -3, 1},
+		{"splits into n", text, 4, 4},
+		{"uneven split", text, 5, 5},
+		{"n equal to rune count", "abcd", 4, 4},
+		{"n above rune count clamps", "abcd", 99, 4},
+		{"unicode splits on runes", unicode, 6, 6},
+		{"empty text", "", 4, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitChunks(tc.text, tc.n)
+			if len(got) != tc.wantParts {
+				t.Errorf("len = %d, want %d (parts %q)", len(got), tc.wantParts, got)
+			}
+			if joined := strings.Join(got, ""); joined != tc.text {
+				t.Errorf("concatenation = %q, want the input back %q", joined, tc.text)
+			}
+			for i, part := range got {
+				// An empty piece would silently reduce the delta count a caller asked
+				// for, because consumeStream skips an empty text_delta.
+				if part == "" && tc.text != "" {
+					t.Errorf("piece %d is empty; every piece must carry text", i)
+				}
+				if !utf8.ValidString(part) {
+					t.Errorf("piece %d = %q is not valid UTF-8; the split must land on a rune boundary", i, part)
+				}
+			}
+		})
 	}
 }

--- a/internal/testutil/fakeagy_test.go
+++ b/internal/testutil/fakeagy_test.go
@@ -179,7 +179,10 @@ func TestFakeAgyDefaultsToOneDoneDelta(t *testing.T) {
 // delta ever carries.
 func TestSplitChunks(t *testing.T) {
 	const text = "the quick brown fox jumps over the lazy dog"
-	const unicode = "hyvää yötä \u00e4\u00f6\u00e5 \u4f60\u597d\u4e16\u754c emoji"
+	// A 4-byte rune (U+1D11E, outside the BMP) is included so a byte-wise split has
+	// a wide rune to cut through; the earlier fixture's trailing "emoji" was ASCII,
+	// so no rune above 3 bytes was ever exercised despite the naming.
+	const multibyte = "hyvää yötä \u00e4\u00f6\u00e5 \u4f60\u597d\u4e16\u754c \U0001D11E"
 
 	for _, tc := range []struct {
 		name      string
@@ -193,8 +196,11 @@ func TestSplitChunks(t *testing.T) {
 		{"splits into n", text, 4, 4},
 		{"uneven split", text, 5, 5},
 		{"n equal to rune count", "abcd", 4, 4},
-		{"n above rune count clamps", "abcd", 99, 4},
-		{"unicode splits on runes", unicode, 6, 6},
+		// A multi-byte string here, not ASCII: with rune count == byte count the
+		// clamp does not discriminate a rune split from a byte split.
+		{"n above rune count clamps", "äö", 99, 2},
+		{"unicode splits on runes", multibyte, 5, 5},
+		{"unicode splits on runes, uneven", multibyte, 7, 7},
 		{"empty text", "", 4, 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #158. Closes #152.

Three small, independent changes, one commit each.

## Windows console window on the two remaining agy spawns (#158)

#157 added `CREATE_NO_WINDOW` to `proc.ConfigureGroup`, which covers the long-running agy child the supervisor spawns. The two short-lived agy spawns the manager makes directly set no creation flags at all, so each could still allocate a console, and therefore flash a console window, whenever the manager process itself has no console to inherit (an MCP client launching it from a GUI app rather than a terminal): the `agy --version` probe in `internal/manager/manager.go`, and `agy --output-format json models` in `internal/manager/models.go`.

`ConfigureGroup` is the wrong helper for these, since neither probe wants a new process group or Job Object supervision, only the window suppression. This adds `proc.ConfigureNoWindow`, a no-op off Windows, and applies it at both sites.

All four process spawns in the repository are now accounted for: the supervisor spawn uses `StartDetached` (`DETACHED_PROCESS`), the agy child uses `ConfigureGroup`, and these two use `ConfigureNoWindow`.

Tests assert the flag is set, that pre-existing `CreationFlags` are preserved rather than overwritten, and that the helper does not quietly become an alias for `ConfigureGroup` by also setting `CREATE_NEW_PROCESS_GROUP` or `DETACHED_PROCESS`. The POSIX build asserts it stays inert. The visible-window behaviour itself still needs a manual check from a console-less parent.

## consumeStream multi-chunk delta coverage (#152)

`consumeStream` appends every `agent_response` `text_delta`, and agy streams one response as many events: successive ACTIVE chunks followed by a DONE tail, all sharing one `step_index`. Nothing pinned that. The existing `TestConsumeStreamAccumulatesDeltas` gives every delta a distinct `step_index`, so a dedup keyed on `step_index` keeps all three and passes, and the test double emitted exactly one DONE delta carrying the whole response, so no test ever saw the ACTIVE shape.

Measured against agy 1.1.22 to fix the fixtures against real behaviour: a 9448-byte response arrived as 38 ACTIVE deltas of 125 to 226 bytes each plus a 2248-byte DONE tail, and concatenating all 39 equalled the terminal result byte for byte, non-ASCII included. A response short enough to fit one chunk arrives as a single DONE delta with no ACTIVE events at all, so both shapes have to work.

- `FakeAgy` gains `StreamChunks`, splitting the response across that many deltas on one step, ACTIVE for all but the tail. Splitting is by rune, so a boundary never lands inside a multi-byte character. Unset keeps the single DONE delta every existing test was written against.
- A `consumeStream` test pins that identical-index ACTIVE chunks all accumulate, plus a companion pinning that the DONE tail alone is not the answer.
- A supervisor test carries the chunked stream end to end.
- Tests on the fake itself assert it really emits several deltas on one step with only the tail DONE, since a consumer that reassembles correctly cannot tell one delta from many, and a fake that ignored `StreamChunks` would leave everything downstream passing vacuously.

## An empty stderr is now named, not a dangling colon

`errorSummary` assembled `"exit N: " + tail` and trimmed the result, so a non-zero exit whose stderr was readable but empty rendered as a bare `exit 1:`. That is the exact string the function's own comment says to avoid one branch above, where an unreadable stderr is spelled out instead. The guard covered only the unreadable case, and a trailing colon with nothing after it reads as a message that got truncated rather than as the absence of one. It now reads `exit 1 (no stderr output)`. `errorSummary` had no direct test coverage before this.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./... -race`: all green.
- `golangci-lint run ./...`: 0 issues. `gofmt -l .`: clean.
- `GOOS=windows go build ./...`, `GOOS=freebsd go build ./...`, and `GOOS=windows go test -c ./internal/proc/` all compile, since the Windows tests cannot run on a POSIX host.
- Every new test was verified to fail against the defect it names: gating the delta append on DONE, deduplicating by `step_index`, splitting on bytes instead of runes, ignoring `StreamChunks`, and removing the empty-stderr branch.
- `splitChunks` was checked exhaustively over 9 inputs (empty, single-rune, all-multi-byte, mixed) crossed with n from -5 to 60: no data loss, no empty piece, no invalid UTF-8, expected piece count throughout.

## Review round

A review pass over the three commits above found the console-window fix was pinned by nothing, that the dangling-separator bug had two more sites, and that several new tests did not hold up. The fourth commit closes those.

The findings worth naming, because each is a test that looked fine and was not:

- Deleting both `ConfigureNoWindow` calls left the suite, `go vet` and the Windows vet green, so the whole change could be reverted silently. `probebinding_test.go` now pins that both probes go through `probeCmd`, and it runs on every platform, unlike the Windows-only test.
- `TestSplitChunks` could not catch a byte-wise split. For its fixture, n=6 was the only value in 2..12 where every byte boundary landed on a rune boundary by coincidence, and n=6 was the value it used.
- `TestConsumeStreamDoesNotKeepOnlyTheDoneTail` asserted only an inequality, so it passed when every delta was dropped. Deleted, since the test above it already covers the case.
- `TestSupervisorAccumulatesChunkedDeltas` passed with chunking disabled, and its final assertion held by construction.
- The dangling separator was in `spawnFailMessage` and `ListModels` too, so the trim moved into the shared `cleanTail`.

Several comments were corrected against measurement rather than reasoning: the no-dedup paragraph described the opposite of what a step-indexed filter does, and a claim attributing the missing console to the launcher being a GUI app was removed as uncited.

One unrelated drive-by: a stray space left `internal/manager/testhelpers_test.go` unformatted on main. `gofmt` is not in the linter config, so it went unnoticed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed-job messages by distinguishing missing, empty, unreadable, and whitespace-only error output.
  * Preserved all text, including non-ASCII content, from chunked streamed responses.
  * Prevented unwanted console windows during short-lived Windows operations.
  * Improved model-listing errors by removing misleading trailing separators.

* **Tests**
  * Added cross-platform coverage for process handling, error reporting, model listing, and streamed response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->