### PR TITLE
Add doctor preflight, list_agents tool, and harden the models listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Every job runs `agy --output-format stream-json`, and the supervisor decodes tha
 - `agy_run_sync`: start a prompt and wait for it inline (bounded, with MCP progress notifications); returns the `job_id` to wait on or poll if it outlives the wait cap.
 - `agy_wait`: block until an already-started job finishes (bounded, with MCP progress notifications); one call replaces an `agy_status` poll loop.
 - `list_models`: enumerate available `agy` models, as the ids the `model` parameter accepts plus their display labels.
+- `list_agents`: enumerate available `agy` agents, as the names the `agent` parameter accepts. Unlike `list_models` there is no id/label split, because `agy` takes an agent name verbatim; an empty list just means no agents are configured.
 - `list_sessions`: list known conversations so review threads can be continued.
 
 `agy_run` and `agy_run_sync` also take optional per-run controls, each forwarded to `agy` only when set: pick the `model`, reasoning `effort` (`low`/`medium`/`high`), execution `mode` (including a `plan`-only pass), a named `agent`, `sandbox` terminal restrictions, and a `json_schema` to constrain the result to structured output.
@@ -46,8 +47,8 @@ Session continuation rides `agy`'s own durable conversation store (`--conversati
 `cwd` and under every directory passed in `dirs`, without prompting. For a review that must
 not touch the repo, say so explicitly in the prompt. The tools declare this on the wire: `agy_run` and
 `agy_run_sync` are annotated `destructiveHint: true` / `openWorldHint: true`, `agy_cancel` is
-`destructiveHint: true` / `idempotentHint: true`, and `agy_status`, `agy_wait`, `list_models`
-and `list_sessions` are `readOnlyHint: true`. Annotations are hints, so a client is free to
+`destructiveHint: true` / `idempotentHint: true`, and `agy_status`, `agy_wait`, `list_models`,
+`list_agents` and `list_sessions` are `readOnlyHint: true`. Annotations are hints, so a client is free to
 ignore them; one that does gate confirmation on them may stop prompting for the four
 read-only tools.
 
@@ -62,7 +63,7 @@ Two transports run the same core:
 
   The version is checked once per process, the first time a tool actually needs agy, and the verdict is cached. A binary that is too old is reported as `agy 1.1.15 or newer is required ...; found 1.1.7 at /usr/local/bin/agy`. A failed check is deliberately not cached, so upgrading agy is picked up without restarting the server.
 
-  A missing `agy` does not stop the server from starting. `initialize`, `tools/list`, and `list_sessions` never exec it, so the lookup is deferred: the server starts, logs a warning to stderr, serves discovery normally, and the tools that do need the binary (`agy_run`, `agy_run_sync`, `list_models`) fail per call with `agy not found on PATH; set AGY_MCP_AGY_PATH`. An `agy` installed later is picked up without restarting the server. An explicit `AGY_MCP_AGY_PATH` is treated differently: it is a claim about one specific binary, so a typo or a non-executable target still fails fast at startup.
+  A missing `agy` does not stop the server from starting. `initialize`, `tools/list`, and `list_sessions` never exec it, so the lookup is deferred: the server starts, logs a warning to stderr, serves discovery normally, and the tools that do need the binary (`agy_run`, `agy_run_sync`, `list_models`, `list_agents`) fail per call with `agy not found on PATH; set AGY_MCP_AGY_PATH`. An `agy` installed later is picked up without restarting the server. An explicit `AGY_MCP_AGY_PATH` is treated differently: it is a claim about one specific binary, so a typo or a non-executable target still fails fast at startup.
 - Go 1.27+ to build.
 - The server builds and runs on Linux, macOS, and Windows. Job supervision (running agy as managed jobs via `agy_run` / `agy_run_sync` / `agy_status` / `agy_cancel`) is implemented on **Linux** and **macOS** (process groups, SIGTERM cancel, an advisory flock) and on **Windows** (Job Objects, `OpenProcess` + process creation time, `LockFileEx`); stdio/HTTP serving, `list_models`, and `list_sessions` work identically everywhere.
 
@@ -118,6 +119,7 @@ Or add to your MCP client config:
 - `agy_wait(job_id, wait?)` -> `{ job_id, state, elapsed, result?, error?, failure_reason?, recovery?, conversation_id?, model?, partial?, num_turns?, usage?, step_type?, note? }`
 - `agy_cancel(job_id)` -> `{ state }`
 - `list_models()` -> `{ models, model_details }`
+- `list_agents()` -> `{ agents }`
 - `list_sessions(dir?)` -> `{ sessions }`
 
 `models` holds ids alone, so its entries can be passed straight to `model`; `model_details` pairs each id with the display label `agy` prints for it, in the same order, for showing a readable name. Through v2.1.0 `models` carried each `agy models` row whole, which was a tab-joined `id<TAB>label` string that `agy` does not accept as a model at all, so a client had to split it and pick a column ([#135](https://github.com/tphakala/agy-mcp/issues/135)).
@@ -222,7 +224,13 @@ Two related subcommands, useful beyond Claude Code:
 - `agy-mcp wait-job [-timeout 1h] <job_id>` blocks until the job is terminal and prints the final state word (`done`, `failed`, or `cancelled`) to stdout. Exit codes: 0 terminal, 1 error, 2 usage, 3 timeout, 130 interrupted. It needs only the job state directory, not the agy binary, so it works in minimal environments.
 - `agy-mcp hook-wait [-timeout 1h]` is the hook entrypoint described above: it reads the PostToolUse payload from stdin, so it is not useful to invoke by hand, but it is a single self-contained binary call, no shell wrapper or jq required, and it works on Linux, macOS, and Windows. The file-based wake contract is exercised by tests on all three platforms; the signal-interrupt wake (SIGINT/SIGTERM) is a POSIX behavior and is tested there.
 
-On POSIX, both subcommands install their SIGINT/SIGTERM handler only after parsing flags, resolving the job state directory and building the wait manager (and hook-wait also reads its payload from stdin first), so a signal sent immediately after launch can land before the handler exists and kill the process outright, losing the interrupt exit code. A parent that intends to interrupt a wait can close that window by setting `AGY_MCP_WAIT_READY_FILE`: the subcommand creates that file the moment the handler is in place, so waiting for it to appear makes the signal deliverable. Leave it unset and nothing is written. Three caveats, because existence is the entire signal: the path must be absolute (a relative one resolves against each process's own working directory, and hook-wait runs from the session cwd), it must be fresh and unique per invocation (a file left from an earlier run satisfies the wait immediately and hands back the race), and the parent still needs its own timeout, since both subcommands have exit paths that return before any handler is armed. An existing file at that path is refused rather than overwritten, so pointing the variable at something that matters destroys nothing; that protects the file, not the handshake, which is why the path has to be fresh.
+## Preflight (`agy-mcp doctor`)
+
+`agy-mcp doctor` runs the read-only checks a run depends on and prints a one-line verdict for each, so a broken setup names its own cause instead of surfacing as a downstream tool error (for example `list_models` failing when `agy` is missing from PATH or not authenticated). It checks that the `agy` binary resolves, meets the version floor, and is reachable and authenticated (a model listing); that the state directory is writable; names where each effective setting came from (an environment variable or the default) without printing any secret value; and reports any stale jobs a prior crash left behind. It never starts a job or mutates job state.
+
+The exit code is meant for a setup script or CI: `0` when nothing is broken (a stale-job warning does not count, and a fresh install with no jobs passes), `1` when a check failed, `2` on a usage error. A `WARN` line (leftover jobs the periodic GC will reap) is information, not a failure.
+
+On POSIX, both wait subcommands install their SIGINT/SIGTERM handler only after parsing flags, resolving the job state directory and building the wait manager (and hook-wait also reads its payload from stdin first), so a signal sent immediately after launch can land before the handler exists and kill the process outright, losing the interrupt exit code. A parent that intends to interrupt a wait can close that window by setting `AGY_MCP_WAIT_READY_FILE`: the subcommand creates that file the moment the handler is in place, so waiting for it to appear makes the signal deliverable. Leave it unset and nothing is written. Three caveats, because existence is the entire signal: the path must be absolute (a relative one resolves against each process's own working directory, and hook-wait runs from the session cwd), it must be fresh and unique per invocation (a file left from an earlier run satisfies the wait immediately and hands back the race), and the parent still needs its own timeout, since both subcommands have exit paths that return before any handler is armed. An existing file at that path is refused rather than overwritten, so pointing the variable at something that matters destroys nothing; that protects the file, not the handshake, which is why the path has to be fresh.
 
 MCP clients other than Claude Code get the same no-polling benefit in-protocol: call `agy_wait` with a `job_id` from `agy_run` (or from an `agy_run_sync` that outlived its inline wait) and the tool blocks (bounded by `wait`, default 2m, max 10m) until the job finishes.
 

--- a/doctor.go
+++ b/doctor.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/tphakala/agy-mcp/v2/internal/config"
+	"github.com/tphakala/agy-mcp/v2/internal/manager"
+)
+
+// doctorMain runs the `agy-mcp doctor` preflight: it resolves configuration,
+// runs the read-only checks a run depends on (agy binary, version, auth,
+// state dir, config sources, stale jobs), prints one line per check, and returns
+// an exit code a setup script or CI can branch on: 0 when nothing is broken
+// (warnings included), 1 when a check failed.
+//
+// It takes its writers rather than using os.Stdout/os.Stderr directly so a test
+// can capture the report. It never starts a job or mutates job state; the only
+// write is the state-dir writability probe, which cleans up after itself.
+func doctorMain(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintln(stderr, "usage: agy-mcp doctor")
+		_, _ = fmt.Fprintln(stderr, "Run read-only preflight checks and exit non-zero if something is broken.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		_, _ = fmt.Fprintf(stderr, "doctor: unexpected argument %q; doctor takes none\n", fs.Arg(0))
+		return 2
+	}
+
+	// A bad explicit AGY_MCP_AGY_PATH (or an unresolvable state dir) fails here,
+	// before a manager exists. That is itself a preflight failure worth a clear
+	// message and a non-zero exit, so report it as one rather than panicking.
+	cfg, err := config.Resolve()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "doctor: config: %v\n", err)
+		return 1
+	}
+
+	report := manager.New(cfg).Doctor(context.Background())
+	for _, c := range report.Checks {
+		_, _ = fmt.Fprintf(stdout, "[%s] %s: %s\n", c.Status, c.Name, c.Detail)
+	}
+	if report.OK() {
+		_, _ = fmt.Fprintln(stdout, "\ndoctor: all checks passed")
+		return 0
+	}
+	_, _ = fmt.Fprintln(stdout, "\ndoctor: one or more checks failed")
+	return 1
+}

--- a/doctor.go
+++ b/doctor.go
@@ -14,7 +14,8 @@ import (
 // runs the read-only checks a run depends on (agy binary, version, auth,
 // state dir, config sources, stale jobs), prints one line per check, and returns
 // an exit code a setup script or CI can branch on: 0 when nothing is broken
-// (warnings included), 1 when a check failed.
+// (warnings included), 1 when a check failed, and 2 on a usage error (an
+// unexpected argument or a bad flag).
 //
 // It takes its writers rather than using os.Stdout/os.Stderr directly so a test
 // can capture the report. It never starts a job or mutates job state; the only

--- a/doctor_test.go
+++ b/doctor_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestDoctorMainRejectsExtraArgs: doctor takes no positional arguments, so a
+// stray one is a usage error (exit 2), not a silently ignored token.
+func TestDoctorMainRejectsExtraArgs(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := doctorMain([]string{"unexpected"}, &out, &errb); code != 2 {
+		t.Fatalf("exit = %d, want 2 for an unexpected argument", code)
+	}
+	if !strings.Contains(errb.String(), "unexpected") {
+		t.Errorf("stderr should name the rejected argument, got: %q", errb.String())
+	}
+}
+
+// TestDoctorMainFailsWithoutAgy: with no agy resolvable, the report has a failing
+// check, so the command exits non-zero and prints a FAIL line a script can see.
+func TestDoctorMainFailsWithoutAgy(t *testing.T) {
+	// Empty PATH so LookPath("agy") cannot succeed; no explicit override; a private
+	// state dir so the run never touches real state.
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("AGY_MCP_AGY_PATH", "")
+	t.Setenv("AGY_MCP_STATE_DIR", t.TempDir())
+
+	var out, errb bytes.Buffer
+	code := doctorMain(nil, &out, &errb)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 when agy is missing; stdout=%q stderr=%q", code, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), "[FAIL]") {
+		t.Errorf("stdout should carry a FAIL line, got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "all checks passed") {
+		t.Errorf("stdout must not claim success on a failing report:\n%s", out.String())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,6 @@ require (
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=

--- a/internal/manager/agents.go
+++ b/internal/manager/agents.go
@@ -1,0 +1,97 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// listAgentsTimeout bounds `agy agents`, and listAgentsKillGrace bounds how long
+// after that deadline the call waits before abandoning its output pipes. Same
+// hazard as the version probe and the models listing: agy's descendants inherit
+// those pipes, so one that outlives agy would otherwise hold the read open.
+const (
+	listAgentsTimeout   = 30 * time.Second
+	listAgentsKillGrace = time.Second
+)
+
+// ListAgents lists agy's available agents: the names accepted as --agent. It
+// decodes the JSON envelope from `agy --output-format json agents` rather than
+// splitting the plain-text rows, so the names come from a typed field.
+//
+// An agent entry is a bare name, not the {id,label} pair a model is: agy prints
+// agents as a single column and takes the name verbatim as --agent (measured
+// against agy 1.1.24), so there is no id-vs-label reduction to make here (the
+// distinction that list_models exists to preserve, issue #135). The return is a
+// plain []string for that reason.
+func (m *Manager) ListAgents(ctx context.Context) ([]string, error) {
+	out, err := m.runJSONListing(ctx, "agents", listAgentsTimeout, listAgentsKillGrace)
+	if err != nil {
+		return nil, err
+	}
+	return decodeAgentsEnvelope(out)
+}
+
+const (
+	// agentsEnvelopeStatusOK and agentsCommandName are the envelope framing
+	// decodeAgentsEnvelope requires before it trusts the listing. They are the
+	// literals agy prints, mirrored in internal/testutil/fakeagy.go.
+	agentsEnvelopeStatusOK = "SUCCESS"
+	agentsCommandName      = "agents"
+)
+
+// agentsEnvelope is the subset of agy's `--output-format json agents` output that
+// list_agents needs: the status/command framing that proves the payload is the
+// agents listing, and the name strings under command.data.agents. Fields agy also
+// emits (a redundant `response` text column plus usage and timing metadata) are
+// ignored.
+//
+// Agents is a POINTER so decodeAgentsEnvelope can tell an absent or null array
+// (nil, which a `data`/`agents` rename or drop produces) from a present-but-empty
+// one (a non-nil pointer to an empty slice, a legitimately empty catalog). A plain
+// slice collapses both to nil and would read a renamed field as an empty catalog.
+// This is the same guard modelsEnvelope carries; the payload differs only in that
+// an agent is a bare string, not an {id,label} object.
+type agentsEnvelope struct {
+	Status  string `json:"status"`
+	Command struct {
+		Name string `json:"name"`
+		Data struct {
+			Agents *[]string `json:"agents"`
+		} `json:"data"`
+	} `json:"command"`
+}
+
+// decodeAgentsEnvelope turns agy's JSON agents envelope into the list of agent
+// names, validating the framing before it trusts the list. It is an error, not a
+// silently empty catalog, when the status is not SUCCESS, the command is not
+// `agents`, or the command.data.agents array is absent or null: each is a shape
+// agy-mcp does not recognize (a future field rename or restructure, or an error
+// envelope that still exited 0), and cmd.Output() only catches a non-zero exit, so
+// a well-formed-but-renamed envelope on exit 0 would otherwise decode to zero
+// agents and mask the change. An envelope that IS the agents command and carries
+// an explicit empty array is a legitimately empty catalog (no agents configured, a
+// common state) and returns an empty, non-nil slice.
+func decodeAgentsEnvelope(raw []byte) ([]string, error) {
+	var env agentsEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("agy agents: parse json envelope: %w", err)
+	}
+	if env.Status != agentsEnvelopeStatusOK {
+		return nil, fmt.Errorf("agy agents: envelope status %q, want %q", env.Status, agentsEnvelopeStatusOK)
+	}
+	if env.Command.Name != agentsCommandName {
+		return nil, fmt.Errorf("agy agents: envelope command %q, want %q", env.Command.Name, agentsCommandName)
+	}
+	// nil, not empty: an absent or null command.data.agents (a renamed or dropped
+	// field), as opposed to a present "agents":[] which is a real empty catalog.
+	if env.Command.Data.Agents == nil {
+		return nil, errors.New("agy agents: envelope has no command.data.agents array")
+	}
+	names := *env.Command.Data.Agents
+	agents := make([]string, 0, len(names))
+	agents = append(agents, names...)
+	return agents, nil
+}

--- a/internal/manager/agents_posix_test.go
+++ b/internal/manager/agents_posix_test.go
@@ -1,0 +1,44 @@
+//go:build linux || darwin
+
+package manager
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/v2/internal/config"
+)
+
+// TestListAgentsToleratesWaitDelay mirrors TestListModelsToleratesWaitDelay for
+// the agents listing: agy printed the envelope and exited, a descendant kept
+// stdout open (ErrWaitDelay), and the already-buffered catalog must still decode.
+func TestListAgentsToleratesWaitDelay(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "sleeper.pid")
+	const envelope = `{"status":"SUCCESS","command":{"name":"agents","data":{"agents":["reviewer"]}}}`
+	body := "  printf '%s' '" + envelope + "'\n  sleep 30 &\n  echo $! > \"" + pidFile + "\"\n  exit 0\n"
+	agy := writeProbeScript(t, "agents", body)
+	reapPidFile(t, pidFile)
+
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+	got, err := m.ListAgents(t.Context())
+	if err != nil {
+		t.Fatalf("ListAgents: %v; a descendant holding the pipe must not fail the listing", err)
+	}
+	if len(got) != 1 || got[0] != "reviewer" {
+		t.Fatalf("ListAgents() = %#v, want the buffered [reviewer] catalog", got)
+	}
+}
+
+// TestListAgentsNamesCancellation: see assertListingNamesCancellation.
+func TestListAgentsNamesCancellation(t *testing.T) {
+	assertListingNamesCancellation(t, "agents", func(ctx context.Context, m *Manager) error {
+		_, err := m.ListAgents(ctx)
+		return err
+	})
+}

--- a/internal/manager/agents_test.go
+++ b/internal/manager/agents_test.go
@@ -1,0 +1,107 @@
+package manager
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tphakala/agy-mcp/v2/internal/config"
+	"github.com/tphakala/agy-mcp/v2/internal/testutil"
+)
+
+// TestListAgentsReturnsConfiguredNames: the happy path decodes the agent names
+// from command.data.agents, in order, as plain strings (no id/label reduction).
+func TestListAgentsReturnsConfiguredNames(t *testing.T) {
+	skipIfWindows(t, "Unix-specific: WriteFakeAgy emits a bash script that is not executable on Windows; ListAgents decoding is covered on Linux")
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Agents: []string{"reviewer", "researcher"}})
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	got, err := m.ListAgents(t.Context())
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if want := []string{"reviewer", "researcher"}; !slices.Equal(got, want) {
+		t.Fatalf("ListAgents() = %#v, want %#v", got, want)
+	}
+}
+
+// TestListAgentsEmptyCatalog: no agents configured is the common state and must
+// be a clean empty (non-nil) list, not an error.
+func TestListAgentsEmptyCatalog(t *testing.T) {
+	skipIfWindows(t, "Unix-specific: WriteFakeAgy emits a bash script that is not executable on Windows")
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{})
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	got, err := m.ListAgents(t.Context())
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("ListAgents() = %#v, want a non-nil empty slice", got)
+	}
+}
+
+// TestListAgentsIncludesStderrOnError: when `agy agents` fails, the error must
+// carry agy's stderr (e.g. an auth prompt) rather than a bare "exit status 1".
+func TestListAgentsIncludesStderrOnError(t *testing.T) {
+	skipIfWindows(t, "Unix-specific: WriteFakeAgy emits a bash script that is not executable on Windows")
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{Stderr: "agy: not logged in", Exit: 1})
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+
+	_, err := m.ListAgents(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "not logged in") {
+		t.Fatalf("err = %v, want it to include agy's stderr", err)
+	}
+}
+
+// TestDecodeAgentsEnvelope pins how agy's JSON agents envelope becomes the name
+// list: the names come from command.data.agents, an empty array is a valid empty
+// catalog, and a malformed or wrong-shaped envelope is an error rather than a
+// silent empty list (what keeps a future field rename loud, mirroring the models
+// decoder).
+func TestDecodeAgentsEnvelope(t *testing.T) {
+	t.Parallel()
+
+	// A normal envelope, with the extra top-level fields agy also emits (response,
+	// usage) present to prove the decoder reads command.data.agents and ignores them.
+	const twoAgents = `{"status":"SUCCESS","response":"reviewer\nresearcher\n","usage":{"total_tokens":0},` +
+		`"command":{"name":"agents","data":{"agents":["reviewer","researcher"]}}}`
+	got, err := decodeAgentsEnvelope([]byte(twoAgents))
+	if err != nil {
+		t.Fatalf("decodeAgentsEnvelope: %v", err)
+	}
+	if want := []string{"reviewer", "researcher"}; !slices.Equal(got, want) {
+		t.Fatalf("decodeAgentsEnvelope() = %#v, want %#v", got, want)
+	}
+
+	// An empty agents array is a legitimately empty catalog: no error, and a
+	// non-nil empty slice so the list_agents handler need not special-case nil.
+	const emptyCatalog = `{"status":"SUCCESS","command":{"name":"agents","data":{"agents":[]}}}`
+	got, err = decodeAgentsEnvelope([]byte(emptyCatalog))
+	if err != nil {
+		t.Fatalf("decodeAgentsEnvelope (empty): %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("decodeAgentsEnvelope (empty) = %#v, want a non-nil empty slice", got)
+	}
+
+	// Shapes that must be a loud error, not a silent empty catalog. Each pins a
+	// specific guard: without its check the payload decodes to a (possibly empty)
+	// agents list with err nil, and that case would go green. The last three cover
+	// a renamed or dropped inner array (absent data, absent agents, null agents),
+	// which must be distinguished from a present "agents":[] empty catalog above.
+	for _, tc := range []struct{ name, raw string }{
+		{"malformed json", `{"status":"SUCCESS","command":`},
+		{"status not SUCCESS", `{"status":"ERROR","command":{"name":"agents","data":{"agents":["x"]}}}`},
+		{"wrong command", `{"status":"SUCCESS","command":{"name":"run","data":{"agents":["x"]}}}`},
+		{"missing data object", `{"status":"SUCCESS","command":{"name":"agents"}}`},
+		{"missing agents array", `{"status":"SUCCESS","command":{"name":"agents","data":{}}}`},
+		{"null agents array", `{"status":"SUCCESS","command":{"name":"agents","data":{"agents":null}}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := decodeAgentsEnvelope([]byte(tc.raw)); err == nil {
+				t.Fatalf("decodeAgentsEnvelope(%s) succeeded, want an error", tc.name)
+			}
+		})
+	}
+}

--- a/internal/manager/doctor.go
+++ b/internal/manager/doctor.go
@@ -278,7 +278,13 @@ func (m *Manager) checkConfigSources() CheckResult {
 func (m *Manager) checkStaleJobs() CheckResult {
 	ids, err := m.store.List()
 	if err != nil {
-		return CheckResult{checkJobsName, CheckWarn, "cannot list job store: " + err.Error()}
+		// A List() error is not a stale-jobs warning: the store root is unreadable
+		// (permissions, IO), the same condition startup RestoreAndCollect and
+		// RestoreGate fail closed on, so the server itself would refuse to start.
+		// Fail the check so doctor exits non-zero rather than reporting a healthy
+		// exit 0 for an unusable state directory. A missing jobs dir is NOT this
+		// case: Store.List returns an empty list and no error for a fresh install.
+		return CheckResult{checkJobsName, CheckFail, "cannot list job store (state dir unreadable): " + err.Error()}
 	}
 	var stale []string
 	for _, id := range ids {

--- a/internal/manager/doctor.go
+++ b/internal/manager/doctor.go
@@ -1,0 +1,305 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/tphakala/agy-mcp/v2/internal/agyver"
+)
+
+// Check names, shared by each check and its tests (see doctor_test.go, which
+// looks checks up by these constants) so the two cannot drift, and a name is
+// written once rather than at every CheckResult it appears in. All carry the
+// Name suffix so none collides with the like-named check method.
+const (
+	checkAgyBinaryName    = "agy binary"
+	checkAgyVersionName   = "agy version"
+	checkAgyReachableName = "agy reachable (auth)"
+	checkStateDirName     = "state dir"
+	checkConfigName       = "config"
+	checkJobsName         = "jobs"
+)
+
+// CheckStatus is a preflight check's verdict. Only CheckFail makes the doctor
+// command exit non-zero; CheckWarn reports something worth seeing (stale jobs
+// from a prior crash) without calling the install broken, so a fresh install
+// with leftover state is not treated as a failure.
+type CheckStatus int
+
+const (
+	CheckPass CheckStatus = iota
+	CheckWarn
+	CheckFail
+)
+
+// String renders the status as the fixed-width label the report prints.
+func (s CheckStatus) String() string {
+	switch s {
+	case CheckPass:
+		return "PASS"
+	case CheckWarn:
+		return "WARN"
+	case CheckFail:
+		return "FAIL"
+	default:
+		return "????"
+	}
+}
+
+// CheckResult is one preflight check's outcome. Detail is a human-readable line
+// (or lines) explaining the verdict and must never carry a secret value: the
+// config check names where a setting came from, not what it is, so a token is
+// reported as set/unset and never printed.
+type CheckResult struct {
+	Name   string
+	Status CheckStatus
+	Detail string
+}
+
+// DoctorReport is the full set of preflight checks, in the order they ran.
+type DoctorReport struct {
+	Checks []CheckResult
+}
+
+// OK reports whether the install is healthy: no check failed. A warning does not
+// count as a failure, so the exit code a caller derives from this treats stale
+// leftover jobs as information, not breakage.
+func (r DoctorReport) OK() bool {
+	for _, c := range r.Checks {
+		if c.Status == CheckFail {
+			return false
+		}
+	}
+	return true
+}
+
+// Doctor runs the read-only preflight checks a run depends on and returns their
+// results. It never mutates job state or starts a job: the one write it makes is
+// a probe file in the state dir (removed immediately) to prove the dir is
+// writable, which is the only way to actually verify that rather than guess from
+// the mode bits.
+//
+// Every check runs regardless of earlier ones, so a report names every problem at
+// once rather than stopping at the first: an operator fixing an install wants the
+// whole list, not one error per re-run.
+func (m *Manager) Doctor(ctx context.Context) DoctorReport {
+	return DoctorReport{Checks: []CheckResult{
+		m.checkAgyBinary(),
+		m.checkAgyVersion(ctx),
+		m.checkAgyReachable(ctx),
+		m.checkStateDir(),
+		m.checkConfigSources(),
+		m.checkStaleJobs(),
+	}}
+}
+
+// checkAgyBinary resolves the agy binary the same way every run does, so a PATH
+// miss or a relative-only entry is reported here with the same guidance a job
+// would get.
+func (m *Manager) checkAgyBinary() CheckResult {
+	agy, err := m.cfg.AgyBinary()
+	if err != nil {
+		return CheckResult{checkAgyBinaryName, CheckFail, err.Error()}
+	}
+	return CheckResult{checkAgyBinaryName, CheckPass, "found at " + agy}
+}
+
+// checkAgyVersion probes the version through the manager's own readAgyVersion
+// seam (WaitDelay'd and ctx-checked) and compares it against the tracked floor,
+// reusing agyver rather than duplicating the comparison. It reports the version
+// it found so an operator sees how far off an outdated binary is, not just that
+// it is outdated.
+func (m *Manager) checkAgyVersion(ctx context.Context) CheckResult {
+	agy, err := m.cfg.AgyBinary()
+	if err != nil {
+		return CheckResult{checkAgyVersionName, CheckFail, "cannot check: agy binary not resolved"}
+	}
+	ctx, cancel := context.WithTimeout(ctx, versionCheckTimeout)
+	defer cancel()
+	raw, err := m.readAgyVersion(ctx, agy)
+	if err != nil {
+		return CheckResult{checkAgyVersionName, CheckFail, err.Error()}
+	}
+	v, err := agyver.Parse(raw)
+	if err != nil {
+		return CheckResult{checkAgyVersionName, CheckFail, fmt.Sprintf("cannot parse version %q: %v", strings.TrimSpace(raw), err)}
+	}
+	if !v.AtLeast(agyver.Required) {
+		return CheckResult{checkAgyVersionName, CheckFail, fmt.Sprintf("%s is below the required %s; upgrade agy", v, agyver.Required)}
+	}
+	return CheckResult{checkAgyVersionName, CheckPass, fmt.Sprintf("%s (>= required %s)", v, agyver.Required)}
+}
+
+// checkAgyReachable lists models, which is the cheapest call that requires a
+// working, authenticated agy: it execs the real binary and fails if agy is
+// missing, too old, or not logged in, so it doubles as the auth and reachability
+// check. The error agy prints (an auth prompt, say) is surfaced in the detail.
+func (m *Manager) checkAgyReachable(ctx context.Context) CheckResult {
+	models, err := m.ListModels(ctx)
+	if err != nil {
+		return CheckResult{checkAgyReachableName, CheckFail, err.Error()}
+	}
+	return CheckResult{checkAgyReachableName, CheckPass, fmt.Sprintf("model listing reachable (%d model(s))", len(models))}
+}
+
+// checkStateDir verifies the job-store root is usable. An existing dir is proven
+// writable by a probe file that is removed at once; a not-yet-created dir (a fresh
+// install that has run no job) is healthy as long as the nearest existing
+// ancestor is a writable directory, since the server creates the state dir on
+// first use. Only a state dir that exists but cannot be written, or whose parent
+// cannot be created into, is a failure.
+func (m *Manager) checkStateDir() CheckResult {
+	dir := m.cfg.StateDir
+	if dir == "" {
+		return CheckResult{checkStateDirName, CheckFail, "no state directory configured"}
+	}
+	info, err := os.Stat(dir)
+	switch {
+	case err == nil && info.IsDir():
+		if perr := probeWritable(dir); perr != nil {
+			return CheckResult{checkStateDirName, CheckFail, fmt.Sprintf("%s exists but is not writable: %v", dir, perr)}
+		}
+		return CheckResult{checkStateDirName, CheckPass, "writable at " + dir}
+	case err == nil:
+		return CheckResult{checkStateDirName, CheckFail, dir + " exists but is not a directory"}
+	case os.IsNotExist(err):
+		// Fresh install: the dir will be created on first use. Confirm the nearest
+		// existing ancestor is a writable directory so that creation will succeed.
+		anc, aerr := nearestExistingDir(dir)
+		if aerr != nil {
+			return CheckResult{checkStateDirName, CheckFail, fmt.Sprintf("cannot resolve a parent of %s: %v", dir, aerr)}
+		}
+		if perr := probeWritable(anc); perr != nil {
+			return CheckResult{checkStateDirName, CheckFail, fmt.Sprintf("%s does not exist and its parent %s is not writable: %v", dir, anc, perr)}
+		}
+		return CheckResult{checkStateDirName, CheckPass, dir + " will be created on first run (parent writable)"}
+	default:
+		return CheckResult{checkStateDirName, CheckFail, fmt.Sprintf("cannot stat %s: %v", dir, err)}
+	}
+}
+
+// probeWritable proves a directory is writable by creating and removing a uniquely
+// named file in it. Statting the mode bits is not enough: a dir can be mode 0755
+// and still unwritable to this user, and a read-only mount reports writable bits.
+func probeWritable(dir string) error {
+	f, err := os.CreateTemp(dir, ".agy-mcp-doctor-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	_ = f.Close()
+	return os.Remove(name)
+}
+
+// nearestExistingDir walks up from a non-existent path to the first ancestor that
+// exists, returning an error if it is not a directory. It stops at the filesystem
+// root, which always exists.
+func nearestExistingDir(dir string) (string, error) {
+	for {
+		parent := filepath.Dir(dir)
+		info, err := os.Stat(parent)
+		if err == nil {
+			if !info.IsDir() {
+				return "", fmt.Errorf("%s is not a directory", parent)
+			}
+			return parent, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		if parent == dir {
+			// filepath.Dir is idempotent at the root; guard against an infinite loop.
+			return "", fmt.Errorf("reached filesystem root without finding an existing ancestor of %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// checkConfigSources names where each effective setting came from (an env var or
+// the built-in default) without printing any secret value. The HTTP token in
+// particular is reported as set or unset only, never echoed.
+func (m *Manager) checkConfigSources() CheckResult {
+	var b strings.Builder
+	line := func(setting, source, value string) {
+		fmt.Fprintf(&b, "\n    %-16s %s", setting+":", source)
+		if value != "" {
+			fmt.Fprintf(&b, " (%s)", value)
+		}
+	}
+	// agy path: an explicit override vs a PATH lookup.
+	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {
+		line("agy path", "AGY_MCP_AGY_PATH", m.cfg.AgyPath)
+	} else {
+		line("agy path", "PATH lookup", m.cfg.AgyPath)
+	}
+	// default model: env override vs agy's own default (an empty DefaultModel).
+	if os.Getenv("AGY_MCP_DEFAULT_MODEL") != "" {
+		line("default model", "AGY_MCP_DEFAULT_MODEL", m.cfg.DefaultModel)
+	} else {
+		line("default model", "agy default (unset)", "")
+	}
+	// state dir: env override vs the XDG fallback.
+	if os.Getenv("AGY_MCP_STATE_DIR") != "" {
+		line("state dir", "AGY_MCP_STATE_DIR", m.cfg.StateDir)
+	} else {
+		line("state dir", "XDG default", m.cfg.StateDir)
+	}
+	// HTTP token: reported as set/unset only, never the value.
+	if m.cfg.HTTPToken != "" {
+		line("http token", "AGY_MCP_HTTP_TOKEN", "set")
+	} else {
+		line("http token", "unset (HTTP mode unauthenticated)", "")
+	}
+	return CheckResult{checkConfigName, CheckPass, strings.TrimPrefix(b.String(), "\n")}
+}
+
+// checkStaleJobs reports jobs the store still holds whose supervisor process is
+// gone and that never recorded an exit code: orphans a prior crash left behind,
+// which the periodic GC reaps on its own schedule but which are exactly what
+// someone debugging odd behaviour wants to see now. It is a warning, not a
+// failure: a healthy server GCs these in time, and a fresh install has none.
+//
+// It is strictly read-only, unlike GarbageCollect: it lists and inspects, and
+// removes nothing.
+//
+// The staleness predicate here is deliberately simpler than gcEvaluate's, and the
+// difference is intentional because this only REPORTS. gcEvaluate re-reads the
+// exit code once after finding the supervisor dead (a race guard against a job
+// that finished between the two reads) and separates a transient meta read error
+// from a genuinely missing meta, because it is deciding whether to DELETE. A
+// read-only WARN pays for neither: at worst it names a job that just finished, or
+// a dir it momentarily could not read, and an operator eyeballing the list loses
+// nothing by seeing it. Do not converge the two into a shared predicate on the
+// strength of this: gcEvaluate's extra care exists for the deletion it drives.
+func (m *Manager) checkStaleJobs() CheckResult {
+	ids, err := m.store.List()
+	if err != nil {
+		return CheckResult{checkJobsName, CheckWarn, "cannot list job store: " + err.Error()}
+	}
+	var stale []string
+	for _, id := range ids {
+		meta, err := m.store.Load(id)
+		if err != nil {
+			// A dir with no readable meta.json is itself an orphan (a crash between
+			// mkdir and the first meta write); count it as stale by id.
+			stale = append(stale, id)
+			continue
+		}
+		if _, done := m.store.ExitCode(id); done {
+			continue // finished cleanly; not stale
+		}
+		if m.processAlive(meta) {
+			continue // still running under a live supervisor
+		}
+		stale = append(stale, id)
+	}
+	if len(stale) == 0 {
+		return CheckResult{checkJobsName, CheckPass, fmt.Sprintf("no stale jobs (%d total in store)", len(ids))}
+	}
+	slices.Sort(stale)
+	return CheckResult{checkJobsName, CheckWarn, fmt.Sprintf("%d stale job(s) from a prior crash (GC reaps them): %s", len(stale), strings.Join(stale, ", "))}
+}

--- a/internal/manager/doctor_posix_test.go
+++ b/internal/manager/doctor_posix_test.go
@@ -1,0 +1,34 @@
+//go:build linux || darwin
+
+package manager
+
+import (
+	"testing"
+
+	"github.com/tphakala/agy-mcp/v2/internal/testutil"
+)
+
+// TestDoctorHealthy: a resolvable, current, reachable agy and a writable state
+// dir yield an all-passing report that exits zero. It execs the fake agy for the
+// model listing (the auth/reachability check), so it is posix-gated like the
+// other WriteFakeAgy tests.
+func TestDoctorHealthy(t *testing.T) {
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{
+		Models: []testutil.FakeModel{{ID: "gemini-3.1-pro-high", Label: "Gemini 3.1 Pro (High)"}},
+	})
+	m := newManager(t, managerOpts{agyPath: agy})
+
+	report := m.Doctor(t.Context())
+	if !report.OK() {
+		for _, c := range report.Checks {
+			t.Logf("[%s] %s: %s", c.Status, c.Name, c.Detail)
+		}
+		t.Fatal("Doctor should report OK for a healthy install")
+	}
+	// The reachability check must actually have listed the fake's model, proving it
+	// execed agy rather than passing vacuously.
+	reach := findCheck(t, report, checkAgyReachableName)
+	if reach.Status != CheckPass {
+		t.Errorf("reachability check = %v (%s), want PASS", reach.Status, reach.Detail)
+	}
+}

--- a/internal/manager/doctor_posix_test.go
+++ b/internal/manager/doctor_posix_test.go
@@ -3,8 +3,12 @@
 package manager
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/tphakala/agy-mcp/v2/internal/config"
 	"github.com/tphakala/agy-mcp/v2/internal/testutil"
 )
 
@@ -30,5 +34,83 @@ func TestDoctorHealthy(t *testing.T) {
 	reach := findCheck(t, report, checkAgyReachableName)
 	if reach.Status != CheckPass {
 		t.Errorf("reachability check = %v (%s), want PASS", reach.Status, reach.Detail)
+	}
+}
+
+// TestDoctorStaleJobsFailsWhenStoreUnreadable: a List() error is an unreadable
+// store root, the fail-closed condition the server itself refuses to start on, so
+// the jobs check must FAIL (not merely WARN) and drag the exit code non-zero.
+//
+// Posix-only and root-guarded: it makes the jobs dir unreadable with mode 0o000,
+// which only denies access to a non-root user on a POSIX filesystem.
+func TestDoctorStaleJobsFailsWhenStoreUnreadable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory read permissions, so List would succeed")
+	}
+	stateDir := t.TempDir()
+	jobsDir := filepath.Join(stateDir, "jobs") // Store.List reads <stateDir>/jobs
+	if err := os.Mkdir(jobsDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// Restore a mode t.TempDir()'s cleanup can traverse and remove.
+	t.Cleanup(func() { _ = os.Chmod(jobsDir, 0o700) })
+
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: stateDir})
+	got := m.checkStaleJobs()
+	if got.Status != CheckFail {
+		t.Fatalf("jobs check = %v (%s), want FAIL when the store root is unreadable", got.Status, got.Detail)
+	}
+}
+
+// TestDoctorStateDirFreshInstallParentUnwritable: the fresh-install path FAILs when
+// the nearest existing ancestor cannot be written, because creation would fail. It
+// reaches the same os.IsNotExist arm as the passing case but takes the probe-fails
+// branch.
+//
+// Posix-only: it relies on a 0o500 directory actually denying writes, which Windows
+// does not enforce through Unix mode bits (there the probe would succeed and the
+// check would PASS). Skipped as root, which bypasses the mode bits too.
+func TestDoctorStateDirFreshInstallParentUnwritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions, so the probe would succeed")
+	}
+	parent := filepath.Join(t.TempDir(), "ro")
+	if err := os.Mkdir(parent, 0o500); err != nil { // r-x, not writable
+		t.Fatal(err)
+	}
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: filepath.Join(parent, "jobs")})
+	got := m.checkStateDir()
+	if got.Status != CheckFail {
+		t.Fatalf("state dir check = %v (%s), want FAIL when the parent is not writable", got.Status, got.Detail)
+	}
+	// Pin the branch: this must be the fresh-install (IsNotExist) arm reporting an
+	// unwritable parent, not some other FAIL.
+	if !strings.Contains(got.Detail, "not writable") {
+		t.Errorf("detail should name the unwritable parent, got: %s", got.Detail)
+	}
+}
+
+// TestDoctorStateDirStatError: a state dir path whose parent is a regular file lands
+// on the catch-all stat-error arm and fails. This pins that arm separately from the
+// fresh-install one.
+//
+// Posix-only: it relies on os.Stat returning ENOTDIR for a path under a regular file,
+// which os.IsNotExist does NOT treat as "not exist", so the code reaches the default
+// arm. Windows instead reports a path-not-found error that os.IsNotExist treats as
+// true, routing the same input through the fresh-install arm rather than this one.
+func TestDoctorStateDirStatError(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: filepath.Join(blocker, "agy-mcp", "jobs")})
+	got := m.checkStateDir()
+	if got.Status != CheckFail {
+		t.Fatalf("state dir check = %v (%s), want FAIL when the path's parent is a file", got.Status, got.Detail)
+	}
+	// Pin the branch: a stat error that is NOT os.IsNotExist lands on the catch-all
+	// "cannot stat" arm, distinct from the fresh-install arm.
+	if !strings.Contains(got.Detail, "cannot stat") {
+		t.Errorf("detail should come from the stat-error arm, got: %s", got.Detail)
 	}
 }

--- a/internal/manager/doctor_test.go
+++ b/internal/manager/doctor_test.go
@@ -1,0 +1,173 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/v2/internal/config"
+	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
+)
+
+// TestDoctorReportsMissingAgy: with no agy resolvable, the binary check fails and
+// the whole report is not OK, so the command exits non-zero. Other checks still
+// run (the report names every problem at once), which is why this asserts on the
+// binary check specifically rather than just report.OK().
+func TestDoctorReportsMissingAgy(t *testing.T) {
+	noAgyOnPath(t)
+	m := newManager(t, managerOpts{})
+
+	report := m.Doctor(t.Context())
+	if report.OK() {
+		t.Fatal("Doctor reported OK with no agy resolvable")
+	}
+	bin := findCheck(t, report, checkAgyBinaryName)
+	if bin.Status != CheckFail {
+		t.Errorf("agy binary check = %v, want FAIL when agy cannot be resolved", bin.Status)
+	}
+}
+
+// TestDoctorConfigNamesSourcesWithoutSecret: the config check must name where the
+// HTTP token came from without ever printing its value.
+func TestDoctorConfigNamesSourcesWithoutSecret(t *testing.T) {
+	const secret = "super-secret-token-value"
+	m := New(config.Config{
+		AgyPath:      "/nonexistent/agy",
+		StateDir:     t.TempDir(),
+		HTTPToken:    secret,
+		DefaultModel: "gemini-3.1-pro-high",
+	})
+	got := m.checkConfigSources()
+	if got.Status != CheckPass {
+		t.Fatalf("config check status = %v, want PASS", got.Status)
+	}
+	if strings.Contains(got.Detail, secret) {
+		t.Fatalf("config detail leaked the token value:\n%s", got.Detail)
+	}
+	// It must still report that a token IS set, so a reader can tell auth is on.
+	// Assert on the source label AGY_MCP_HTTP_TOKEN, which the set branch emits and
+	// the unset branch does not: a bare "set" would also match the "agy default
+	// (unset)" line this same output carries, so it could not tell set from unset.
+	if !strings.Contains(got.Detail, "http token") || !strings.Contains(got.Detail, "AGY_MCP_HTTP_TOKEN") {
+		t.Fatalf("config detail should report the token as set via its source label (without the value):\n%s", got.Detail)
+	}
+}
+
+// TestDoctorStaleJobsWarn: a job whose supervisor is gone and that recorded no
+// exit code is an orphan a prior crash left; the jobs check must WARN and name
+// it, while a cleanly finished job (an exit code present) is not counted.
+func TestDoctorStaleJobsWarn(t *testing.T) {
+	m := newManager(t, managerOpts{})
+	// A dead supervisor: PID that is not this process, under a boot id that cannot
+	// match, and no exit code written, so processAlive is false and ExitCode absent.
+	if _, err := m.store.Create(jobstore.Meta{ID: "orphan", StartedAt: time.Now(), PID: 999999, BootID: "old-boot"}); err != nil {
+		t.Fatal(err)
+	}
+	// A finished job: same shape but with an exit code, so it is NOT stale.
+	if _, err := m.store.Create(jobstore.Meta{ID: "done", StartedAt: time.Now(), PID: 999999, BootID: "old-boot"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.store.WriteExitCode("done", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	got := m.checkStaleJobs()
+	if got.Status != CheckWarn {
+		t.Fatalf("jobs check = %v (%s), want WARN", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "orphan") {
+		t.Errorf("jobs detail should name the orphan id, got: %s", got.Detail)
+	}
+	if strings.Contains(got.Detail, "done") {
+		t.Errorf("jobs detail must not list the cleanly finished job, got: %s", got.Detail)
+	}
+}
+
+// TestDoctorStaleJobsPassWhenClean: a store with only finished jobs (or none) is
+// healthy, so the check passes and cannot flip the exit code. A WARN does not
+// fail the report, but a PASS is what a fresh install should see.
+func TestDoctorStaleJobsPassWhenClean(t *testing.T) {
+	m := newManager(t, managerOpts{})
+	got := m.checkStaleJobs()
+	if got.Status != CheckPass {
+		t.Fatalf("jobs check on an empty store = %v (%s), want PASS", got.Status, got.Detail)
+	}
+}
+
+// TestDoctorStateDirFreshInstallPasses: a state dir that does not exist yet but
+// sits under a real writable directory is healthy, because the server creates it
+// on first use. This is the fresh-install path, and it is the one that exercises
+// the os.IsNotExist arm and nearestExistingDir (walking up past the missing
+// intermediate segments to the writable temp root).
+func TestDoctorStateDirFreshInstallPasses(t *testing.T) {
+	// Two missing segments so nearestExistingDir actually has to walk up, not just
+	// stat the immediate parent.
+	missing := filepath.Join(t.TempDir(), "not-yet", "jobs")
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: missing})
+	got := m.checkStateDir()
+	if got.Status != CheckPass {
+		t.Fatalf("state dir check = %v (%s), want PASS for a not-yet-created dir under a writable parent", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "will be created") {
+		t.Errorf("detail should say the dir will be created on first run, got: %s", got.Detail)
+	}
+}
+
+// TestDoctorStateDirFreshInstallParentUnwritable: the fresh-install path FAILs when
+// the nearest existing ancestor cannot be written, because creation would fail. It
+// reaches the same os.IsNotExist arm as the passing case but takes the probe-fails
+// branch. Skipped as root, which bypasses the mode bits the probe relies on.
+func TestDoctorStateDirFreshInstallParentUnwritable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions, so the probe would succeed")
+	}
+	parent := filepath.Join(t.TempDir(), "ro")
+	if err := os.Mkdir(parent, 0o500); err != nil { // r-x, not writable
+		t.Fatal(err)
+	}
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: filepath.Join(parent, "jobs")})
+	got := m.checkStateDir()
+	if got.Status != CheckFail {
+		t.Fatalf("state dir check = %v (%s), want FAIL when the parent is not writable", got.Status, got.Detail)
+	}
+	// Pin the branch: this must be the fresh-install (IsNotExist) arm reporting an
+	// unwritable parent, not some other FAIL.
+	if !strings.Contains(got.Detail, "not writable") {
+		t.Errorf("detail should name the unwritable parent, got: %s", got.Detail)
+	}
+}
+
+// TestDoctorStateDirStatError: a state dir path whose parent is a regular file (so
+// os.Stat returns ENOTDIR, which os.IsNotExist does NOT treat as "not exist") lands
+// on the catch-all stat-error arm and fails. This pins that arm separately from the
+// fresh-install one above.
+func TestDoctorStateDirStatError(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: filepath.Join(blocker, "agy-mcp", "jobs")})
+	got := m.checkStateDir()
+	if got.Status != CheckFail {
+		t.Fatalf("state dir check = %v (%s), want FAIL when the path's parent is a file", got.Status, got.Detail)
+	}
+	// Pin the branch: a stat error that is NOT os.IsNotExist lands on the catch-all
+	// "cannot stat" arm, distinct from the fresh-install arm above.
+	if !strings.Contains(got.Detail, "cannot stat") {
+		t.Errorf("detail should come from the stat-error arm, got: %s", got.Detail)
+	}
+}
+
+// findCheck returns the named check or fails the test if the report lacks it.
+func findCheck(t *testing.T, r DoctorReport, name string) CheckResult {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("report has no %q check; checks: %v", name, r.Checks)
+	return CheckResult{}
+}

--- a/internal/manager/doctor_test.go
+++ b/internal/manager/doctor_test.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -115,50 +114,10 @@ func TestDoctorStateDirFreshInstallPasses(t *testing.T) {
 	}
 }
 
-// TestDoctorStateDirFreshInstallParentUnwritable: the fresh-install path FAILs when
-// the nearest existing ancestor cannot be written, because creation would fail. It
-// reaches the same os.IsNotExist arm as the passing case but takes the probe-fails
-// branch. Skipped as root, which bypasses the mode bits the probe relies on.
-func TestDoctorStateDirFreshInstallParentUnwritable(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("root bypasses directory write permissions, so the probe would succeed")
-	}
-	parent := filepath.Join(t.TempDir(), "ro")
-	if err := os.Mkdir(parent, 0o500); err != nil { // r-x, not writable
-		t.Fatal(err)
-	}
-	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: filepath.Join(parent, "jobs")})
-	got := m.checkStateDir()
-	if got.Status != CheckFail {
-		t.Fatalf("state dir check = %v (%s), want FAIL when the parent is not writable", got.Status, got.Detail)
-	}
-	// Pin the branch: this must be the fresh-install (IsNotExist) arm reporting an
-	// unwritable parent, not some other FAIL.
-	if !strings.Contains(got.Detail, "not writable") {
-		t.Errorf("detail should name the unwritable parent, got: %s", got.Detail)
-	}
-}
-
-// TestDoctorStateDirStatError: a state dir path whose parent is a regular file (so
-// os.Stat returns ENOTDIR, which os.IsNotExist does NOT treat as "not exist") lands
-// on the catch-all stat-error arm and fails. This pins that arm separately from the
-// fresh-install one above.
-func TestDoctorStateDirStatError(t *testing.T) {
-	blocker := filepath.Join(t.TempDir(), "not-a-dir")
-	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: filepath.Join(blocker, "agy-mcp", "jobs")})
-	got := m.checkStateDir()
-	if got.Status != CheckFail {
-		t.Fatalf("state dir check = %v (%s), want FAIL when the path's parent is a file", got.Status, got.Detail)
-	}
-	// Pin the branch: a stat error that is NOT os.IsNotExist lands on the catch-all
-	// "cannot stat" arm, distinct from the fresh-install arm above.
-	if !strings.Contains(got.Detail, "cannot stat") {
-		t.Errorf("detail should come from the stat-error arm, got: %s", got.Detail)
-	}
-}
+// The FAIL branches of checkStateDir (an unwritable parent on the fresh-install
+// arm, and a stat error under a regular file on the catch-all arm) depend on Unix
+// filesystem semantics that Windows does not share, so they live in
+// doctor_posix_test.go. The cross-platform healthy fresh-install case is above.
 
 // findCheck returns the named check or fails the test if the report lacks it.
 func findCheck(t *testing.T, r DoctorReport, name string) CheckResult {

--- a/internal/manager/doctor_test.go
+++ b/internal/manager/doctor_test.go
@@ -119,6 +119,49 @@ func TestDoctorStateDirFreshInstallPasses(t *testing.T) {
 // filesystem semantics that Windows does not share, so they live in
 // doctor_posix_test.go. The cross-platform healthy fresh-install case is above.
 
+// TestCheckStatusString pins the label each status renders, including the
+// out-of-range default that guards against a new CheckStatus printed as a bare
+// integer in the report.
+func TestCheckStatusString(t *testing.T) {
+	for _, tc := range []struct {
+		s    CheckStatus
+		want string
+	}{
+		{CheckPass, "PASS"},
+		{CheckWarn, "WARN"},
+		{CheckFail, "FAIL"},
+		{CheckStatus(99), "????"},
+	} {
+		if got := tc.s.String(); got != tc.want {
+			t.Errorf("CheckStatus(%d).String() = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}
+
+// TestDoctorConfigSourcesFromEnv covers the env-override branches of
+// checkConfigSources: when the AGY_MCP_* variables are set, each setting's source
+// is named by its variable rather than the default label, still without a value
+// for the token.
+func TestDoctorConfigSourcesFromEnv(t *testing.T) {
+	t.Setenv("AGY_MCP_AGY_PATH", "/env/agy")
+	t.Setenv("AGY_MCP_STATE_DIR", "/env/state")
+	t.Setenv("AGY_MCP_DEFAULT_MODEL", "gemini-x")
+	const secret = "s3cr3t-http-value"
+	m := New(config.Config{AgyPath: "/env/agy", StateDir: "/env/state", DefaultModel: "gemini-x", HTTPToken: secret})
+	got := m.checkConfigSources()
+	if got.Status != CheckPass {
+		t.Fatalf("status = %v (%s), want PASS", got.Status, got.Detail)
+	}
+	for _, want := range []string{"AGY_MCP_AGY_PATH", "AGY_MCP_STATE_DIR", "AGY_MCP_DEFAULT_MODEL"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Errorf("detail should name source %s, got: %s", want, got.Detail)
+		}
+	}
+	if strings.Contains(got.Detail, secret) {
+		t.Errorf("detail leaked the token value:\n%s", got.Detail)
+	}
+}
+
 // findCheck returns the named check or fails the test if the report lacks it.
 func findCheck(t *testing.T, r DoctorReport, name string) CheckResult {
 	t.Helper()

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -361,7 +361,7 @@ func (m *Manager) StartJob(req StartRequest) (Job, error) {
 	// Job supervision is implemented on Linux (process groups, /proc) and Windows
 	// (Job Objects, OpenProcess). On other platforms refuse before doing any work, so
 	// the failure is a clear error rather than a half-spawned job. stdio/HTTP serve,
-	// list_models, and list_sessions still work everywhere.
+	// list_models, list_agents, and list_sessions still work everywhere.
 	if !proc.Supported {
 		return Job{}, proc.ErrUnsupported
 	}

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -71,15 +71,23 @@ func modelID(v string) string {
 	return v
 }
 
-// ListModels lists agy's available models. It decodes the JSON envelope from
-// `agy --output-format json models` (agy 1.1.12+) rather than tab-splitting the
-// text rows, so the ids and labels come from a typed field instead of a guessed
-// column.
-func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
-	// Version-gated like the job path even though the models listing itself does
-	// not need stream-json: an agy too old to drive is a configuration problem,
-	// and one clear message about it beats a model list from a binary that cannot
-	// actually run a job.
+// runJSONListing execs `agy --output-format json <sub>` and returns its stdout,
+// applying the version gate, a bounded timeout, and the WaitDelay tolerance that
+// list_models and list_agents share. Only the subcommand, its timeout pair, and
+// (at the caller) the decoder differ between the two, so they run through here
+// rather than each carrying its own copy of this delicate ctx-and-error handling.
+//
+// This is NOT the sharing issue #160 item 7 weighed and rejected: that was about
+// folding the VERSION probe together with a listing, and the two genuinely differ
+// (readAgyVersion uses CombinedOutput and tolerates a non-zero exit because
+// --version's exit status is not a contract, while a listing uses Output and
+// treats any non-zero exit as a failure). The two JSON listings share every one
+// of those decisions, so nothing delicate is being generalized across a real
+// difference here; the version probe stays separate, as that note intends.
+func (m *Manager) runJSONListing(ctx context.Context, sub string, timeout, killGrace time.Duration) ([]byte, error) {
+	// Version-gated like the job path even though a listing itself does not need
+	// stream-json: an agy too old to drive is a configuration problem, and one
+	// clear message about it beats a listing from a binary that cannot run a job.
 	agy, err := m.agyBinaryChecked(ctx)
 	if err != nil {
 		return nil, err
@@ -89,25 +97,62 @@ func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
 	// agy holds the read open and parks this call for as long as the client keeps
 	// it. The caller's ctx alone is not a bound, since it is the raw request
 	// context and a client may hold that open indefinitely.
-	ctx, cancel := context.WithTimeout(ctx, listModelsTimeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	// --output-format is agy's global print-mode flag, so it must precede the
-	// `models` subcommand; agy rejects `models --output-format json` outright
-	// (the subcommand flagset does not define it). The listing banner stays on
-	// stderr, so stdout is the envelope alone.
-	cmd := probeCmd(ctx, agy, outputFormatFlag, jsonOutputFormat, "models")
-	cmd.WaitDelay = listModelsKillGrace
+	// subcommand; agy rejects `<sub> --output-format json` outright (the subcommand
+	// flagset does not define it). The listing banner stays on stderr, so stdout is
+	// the envelope alone.
+	cmd := probeCmd(ctx, agy, outputFormatFlag, jsonOutputFormat, sub)
+	cmd.WaitDelay = killGrace
 	out, err := cmd.Output()
 	if err != nil {
-		// Output() captures stderr into (*exec.ExitError).Stderr; include it so a
-		// real cause (an auth prompt, a usage error) is visible instead of a bare
-		// "exit status 1".
-		if ee, ok := errors.AsType[*exec.ExitError](err); ok {
-			if stderr := strings.TrimSpace(string(ee.Stderr)); stderr != "" {
-				return nil, fmt.Errorf("agy models: %w: %s", err, stderr)
+		// Check the deadline BEFORE classifying the exec error, exactly as
+		// readAgyVersion does. A ctx-killed process surfaces as *exec.ExitError,
+		// indistinguishable from a binary that merely exited non-zero, so without
+		// this a timeout this call imposed would surface as "agy <sub>: signal:
+		// killed" and blame agy for a deadline it set (issue #160). Name the real
+		// cause instead.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.Canceled) {
+				// The caller gave up; say so rather than blaming a binary that was
+				// answering fine.
+				return nil, fmt.Errorf("agy %s was cancelled: %w", sub, ctxErr)
 			}
+			return nil, fmt.Errorf("agy %s did not complete within %s: %w", sub, timeout, ctxErr)
 		}
-		return nil, fmt.Errorf("agy models: %w", err)
+		// WaitDelay fired while the deadline had NOT: agy answered and exited, but a
+		// descendant kept the output pipe open, so exec abandoned the copy. The
+		// envelope it printed is already buffered in out, and it is the whole point
+		// of the call. Refusing here would reject a working agy for the exact reason
+		// WaitDelay was set, so return the buffer and let the caller's decoder decide;
+		// a genuinely truncated envelope then fails at the parse with a message that
+		// says so. This mirrors readAgyVersion, which carries the same reasoning for
+		// the version probe (issue #161). Unlike --version, a non-zero exit is still
+		// a failure here, so every other error (ExitError included) is returned.
+		if !errors.Is(err, exec.ErrWaitDelay) {
+			// Output() captures stderr into (*exec.ExitError).Stderr; include it so a
+			// real cause (an auth prompt, a usage error) is visible instead of a bare
+			// "exit status 1".
+			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
+				if stderr := strings.TrimSpace(string(ee.Stderr)); stderr != "" {
+					return nil, fmt.Errorf("agy %s: %w: %s", sub, err, stderr)
+				}
+			}
+			return nil, fmt.Errorf("agy %s: %w", sub, err)
+		}
+	}
+	return out, nil
+}
+
+// ListModels lists agy's available models. It decodes the JSON envelope from
+// `agy --output-format json models` (agy 1.1.12+) rather than tab-splitting the
+// text rows, so the ids and labels come from a typed field instead of a guessed
+// column.
+func (m *Manager) ListModels(ctx context.Context) ([]Model, error) {
+	out, err := m.runJSONListing(ctx, "models", listModelsTimeout, listModelsKillGrace)
+	if err != nil {
+		return nil, err
 	}
 	return decodeModelsEnvelope(out)
 }

--- a/internal/manager/models_posix_test.go
+++ b/internal/manager/models_posix_test.go
@@ -1,0 +1,125 @@
+//go:build linux || darwin
+
+package manager
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tphakala/agy-mcp/v2/internal/agyver"
+	"github.com/tphakala/agy-mcp/v2/internal/config"
+)
+
+// writeProbeScript writes a fake agy that answers `--version` cleanly and serves
+// the given body for the `--output-format json <cmd>` invocation, exiting 1 for
+// anything else. It returns the script path. The models/agents listing paths are
+// the two ListModels/ListAgents exercise, and both go through the version gate
+// first, so the version answer is mandatory.
+func writeProbeScript(t *testing.T, cmd, listingBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-agy")
+	body := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo " + agyver.Required.String() + "; exit 0; fi\n" +
+		"if [ \"$1\" = \"--output-format\" ] && [ \"$2\" = \"json\" ] && [ \"$3\" = \"" + cmd + "\" ]; then\n" +
+		listingBody +
+		"fi\nexit 1\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+// reapPidFile kills the descendant whose pid the fake script recorded, so a
+// deliberately-orphaned sleep does not linger past the test.
+func reapPidFile(t *testing.T, pidFile string) {
+	t.Helper()
+	t.Cleanup(func() {
+		b, err := os.ReadFile(pidFile)
+		if err != nil {
+			return
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+		if err != nil {
+			return
+		}
+		if p, err := os.FindProcess(pid); err == nil {
+			_ = p.Kill()
+		}
+	})
+}
+
+// TestListModelsToleratesWaitDelay is the ListModels sibling of
+// TestReadAgyVersionToleratesWaitDelay (issue #161): agy printed the envelope and
+// exited, but a descendant kept stdout open, so exec reports ErrWaitDelay. That is
+// not an *exec.ExitError, so before the fix any Output() error was wrapped and
+// returned; the catalog was already buffered and must still decode.
+func TestListModelsToleratesWaitDelay(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "sleeper.pid")
+	const envelope = `{"status":"SUCCESS","command":{"name":"models","data":{"models":[{"id":"m1","label":"M1"}]}}}`
+	// Print the envelope, leave a descendant holding stdout, exit cleanly.
+	body := "  printf '%s' '" + envelope + "'\n  sleep 30 &\n  echo $! > \"" + pidFile + "\"\n  exit 0\n"
+	agy := writeProbeScript(t, "models", body)
+	reapPidFile(t, pidFile)
+
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+	got, err := m.ListModels(t.Context())
+	if err != nil {
+		t.Fatalf("ListModels: %v; a descendant holding the pipe must not fail the listing", err)
+	}
+	if len(got) != 1 || got[0].ID != "m1" {
+		t.Fatalf("ListModels() = %#v, want the buffered [m1] catalog", got)
+	}
+}
+
+// assertListingNamesCancellation drives one JSON listing to cancellation and
+// asserts the error names it rather than blaming agy. A ctx-killed listing
+// surfaces as an *exec.ExitError just like a non-zero exit, so without the
+// ctx.Err() check the message would read "agy <sub>: signal: killed" (issue
+// #160). It is shared by the models and agents cases, which differ only in the
+// subcommand and the list call.
+func assertListingNamesCancellation(t *testing.T, sub string, list func(context.Context, *Manager) error) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("sh unavailable: %v", err)
+	}
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "sleeper.pid")
+	// The listing branch blocks well past the cancel, so the exec is still running
+	// when ctx is cancelled. Record the pid so the sleep is reaped.
+	body := "  echo $$ > \"" + pidFile + "\"\n  sleep 30\n  exit 0\n"
+	agy := writeProbeScript(t, sub, body)
+	reapPidFile(t, pidFile)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+	m := New(config.Config{AgyPath: agy, StateDir: t.TempDir(), MaxConcurrency: 4})
+	err := list(ctx, m)
+	if err == nil {
+		t.Fatalf("agy %s must fail when the caller cancels", sub)
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("err = %v, want it to name the cancellation rather than blame agy", err)
+	}
+}
+
+// TestListModelsNamesCancellation: see assertListingNamesCancellation.
+func TestListModelsNamesCancellation(t *testing.T) {
+	assertListingNamesCancellation(t, "models", func(ctx context.Context, m *Manager) error {
+		_, err := m.ListModels(ctx)
+		return err
+	})
+}

--- a/internal/manager/status_test.go
+++ b/internal/manager/status_test.go
@@ -94,10 +94,10 @@ func TestClassifyAgyError(t *testing.T) {
 // to a valid UTF-8 boundary rather than emitting a split multi-byte rune.
 func TestErrorSummaryTruncatesOnUTF8Boundary(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	dir := createJob(t, m, "j")
 	// 3-byte runes so the last errTailBytes window starts mid-rune (2000 % 3 != 0).
 	content := strings.Repeat("€", 1000) // 3000 bytes
-	if err := os.WriteFile(filepath.Join(dir, "err"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(jobstore.ErrPath(dir), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	_ = m.store.WriteExitCode("j", 5)
@@ -147,10 +147,7 @@ func TestErrorSummaryDistinguishesEmptyStderr(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			m := newManager(t, managerOpts{})
-			dir, err := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
-			if err != nil {
-				t.Fatalf("Create: %v", err)
-			}
+			dir := createJob(t, m, "j")
 			switch {
 			case tc.errIsDir:
 				// A directory reads as an error on POSIX, but not on Windows: there a
@@ -190,7 +187,7 @@ func TestErrorSummaryDistinguishesEmptyStderr(t *testing.T) {
 // matters while the unit test above still passes.
 func TestStatusFailedWithMissingStderrNamesTheAbsence(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	_, _ = m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	createJob(t, m, "j")
 	_ = m.store.WriteExitCode("j", 1)
 
 	st, err := m.Status("j")
@@ -207,7 +204,7 @@ func TestStatusFailedWithMissingStderrNamesTheAbsence(t *testing.T) {
 
 func TestStatusDone(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	dir := createJob(t, m, "j")
 	writeResultPayload(t, dir, streamjson.Result{
 		ConversationID: "cid-1",
 		Status:         streamjson.StatusSuccess,
@@ -584,7 +581,7 @@ func TestStatusTerminalContract(t *testing.T) {
 // thread it started can still be continued.
 func TestStatusCancelledKeepsConversationID(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	dir := createJob(t, m, "j")
 	if err := jobstore.WriteProgressDir(dir, jobstore.Progress{ConversationID: "cid-mid-run"}); err != nil {
 		t.Fatal(err)
 	}
@@ -604,8 +601,8 @@ func TestStatusCancelledKeepsConversationID(t *testing.T) {
 
 func TestStatusFailed(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
-	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("boom"), 0o644)
+	dir := createJob(t, m, "j")
+	_ = os.WriteFile(jobstore.ErrPath(dir), []byte("boom"), 0o644)
 	_ = m.store.WriteExitCode("j", 5)
 
 	st, _ := m.Status("j")
@@ -616,8 +613,8 @@ func TestStatusFailed(t *testing.T) {
 
 func TestStatusTimedOut(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
-	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("partial"), 0o644)
+	dir := createJob(t, m, "j")
+	_ = os.WriteFile(jobstore.ErrPath(dir), []byte("partial"), 0o644)
 	_ = m.store.WriteExitCode("j", jobstore.ExitTimeout)
 
 	st, _ := m.Status("j")
@@ -666,7 +663,7 @@ func TestTailFileShorterThanRequested(t *testing.T) {
 // readFile that collapsed every IO error into "".
 func TestStatusDoneButOutputUnreadable(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	dir := createJob(t, m, "j")
 	if err := os.Mkdir(filepath.Join(dir, "out"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -713,8 +710,8 @@ func TestStatusInterruptedOutputUnreadable(t *testing.T) {
 // gets a dedicated message instead of a bare "exit 127:".
 func TestStatusSpawnFail(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
-	_ = os.WriteFile(filepath.Join(dir, "err"), []byte(""), 0o644)
+	dir := createJob(t, m, "j")
+	_ = os.WriteFile(jobstore.ErrPath(dir), []byte(""), 0o644)
 	_ = m.store.WriteExitCode("j", jobstore.ExitSpawnFail)
 
 	st, _ := m.Status("j")
@@ -742,10 +739,7 @@ func TestStatusSpawnFailNamesUnreadableStderr(t *testing.T) {
 		t.Skip("a directory does not make tailFile's read fail on Windows")
 	}
 	m := newManager(t, managerOpts{})
-	dir, err := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
+	dir := createJob(t, m, "j")
 	if err := os.Mkdir(jobstore.ErrPath(dir), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -769,8 +763,8 @@ func TestStatusSpawnFailNamesUnreadableStderr(t *testing.T) {
 
 func TestStatusExit127SurfacesStderr(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
-	_ = os.WriteFile(filepath.Join(dir, "err"), []byte("agy: internal tool not found\n"), 0o644)
+	dir := createJob(t, m, "j")
+	_ = os.WriteFile(jobstore.ErrPath(dir), []byte("agy: internal tool not found\n"), 0o644)
 	_ = m.store.WriteExitCode("j", jobstore.ExitSpawnFail)
 
 	st, _ := m.Status("j")
@@ -916,7 +910,7 @@ func TestStateMatchesStatusState(t *testing.T) {
 // Making out a directory lets os.Open succeed while the read fails.
 func TestStateMatchesStatusOnUnreadableCleanExit(t *testing.T) {
 	m := newManager(t, managerOpts{})
-	dir, _ := m.store.Create(jobstore.Meta{ID: "j", StartedAt: time.Now(), BootID: readBootID()})
+	dir := createJob(t, m, "j")
 	if err := os.Mkdir(filepath.Join(dir, "out"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/manager/testhelpers_test.go
+++ b/internal/manager/testhelpers_test.go
@@ -7,8 +7,24 @@ import (
 
 	"github.com/tphakala/agy-mcp/v2/internal/agyver"
 	"github.com/tphakala/agy-mcp/v2/internal/config"
+	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
 	"github.com/tphakala/agy-mcp/v2/internal/testutil"
 )
+
+// createJob stages a job dir the ordinary way: a live-boot meta this process's
+// boot id matches, started now. It returns the job dir and fails the test on a
+// store error rather than discarding it, which is what the dozen ad hoc
+// `dir, _ := m.store.Create(jobstore.Meta{ID: "j", ...})` sites did. Callers that
+// need a specific meta shape (a dead supervisor: PID 999999 under "old-boot")
+// still build it inline; this covers only the common healthy case.
+func createJob(t *testing.T, m *Manager, id string) string {
+	t.Helper()
+	dir, err := m.store.Create(jobstore.Meta{ID: id, StartedAt: time.Now(), BootID: readBootID()})
+	if err != nil {
+		t.Fatalf("create job %q: %v", id, err)
+	}
+	return dir
+}
 
 // managerOpts configures newManager's config.Config beyond its sensible
 // zero-value defaults (StateDir: t.TempDir(), MaxConcurrency: 4).

--- a/internal/mcptools/serve_http_test.go
+++ b/internal/mcptools/serve_http_test.go
@@ -168,7 +168,7 @@ func TestHTTPServeListsTools(t *testing.T) {
 	for _, tool := range tools.Tools {
 		got[tool.Name] = true
 	}
-	want := []string{"agy_run", "agy_status", "agy_cancel", "agy_run_sync", "agy_wait", "list_models", "list_sessions"}
+	want := []string{"agy_run", "agy_status", "agy_cancel", "agy_run_sync", "agy_wait", "list_models", "list_agents", "list_sessions"}
 	if len(tools.Tools) != len(want) {
 		t.Fatalf("registered %d tools, want %d (%v)", len(tools.Tools), len(want), want)
 	}

--- a/internal/mcptools/toolquality_test.go
+++ b/internal/mcptools/toolquality_test.go
@@ -34,6 +34,7 @@ var wantAnnotations = map[string]mcp.ToolAnnotations{
 	toolAgyWait:      {ReadOnlyHint: true, OpenWorldHint: new(false)},
 	toolListSessions: {ReadOnlyHint: true, OpenWorldHint: new(false)},
 	toolListModels:   {ReadOnlyHint: true, OpenWorldHint: new(true)},
+	toolListAgents:   {ReadOnlyHint: true, OpenWorldHint: new(true)},
 }
 
 // eqBoolPtr compares two optional hints. Nil is distinct from false: the MCP
@@ -117,6 +118,7 @@ var wantSiblings = map[string][]string{
 	// pays for the same work twice.
 	toolAgyCancel:    {toolAgyRun, toolAgyStatus},
 	toolListModels:   {toolAgyRun, toolAgyRunSync},
+	toolListAgents:   {toolAgyRun, toolAgyRunSync},
 	toolListSessions: {toolAgyRun, toolAgyRunSync},
 }
 

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -69,6 +69,7 @@ const (
 	toolAgyRunSync   = ToolAgyRunSync
 	toolAgyWait      = "agy_wait"
 	toolListModels   = "list_models"
+	toolListAgents   = "list_agents"
 	toolListSessions = "list_sessions"
 )
 
@@ -297,6 +298,14 @@ type modelsOutput struct {
 	ModelDetails []modelDetail `json:"model_details" jsonschema:"the same models paired with their display labels, in the same order as models. Use it to show a readable name; keep passing the id"`
 }
 
+// agentsOutput is the list_agents result: the agent names accepted by the agent
+// parameter of agy_run and agy_run_sync. Unlike modelsOutput there is no
+// id-vs-label split, because agy prints an agent as a single name and takes it
+// verbatim as --agent.
+type agentsOutput struct {
+	Agents []string `json:"agents" jsonschema:"agent names accepted by the agent parameter of agy_run and agy_run_sync, e.g. reviewer. Pass one verbatim. Empty when no agents are configured, which is a common state, not an error"`
+}
+
 type sessionsInput struct {
 	Dir string `json:"dir,omitempty" jsonschema:"absolute path of a workspace directory to filter to; omit to list every known conversation. The filter is canonicalized (made absolute against the server's working directory, symlinks resolved) before matching, so a path agy cached in some other spelling may not match"`
 }
@@ -333,7 +342,7 @@ Choosing a tool:
 - agy_run_sync starts a run and waits inline (bounded by the wait argument). Use it when you need the answer before your next step and the task is bounded enough to finish within that wait.
 - agy_run returns a job_id in under a couple of seconds (it waits briefly for agy to name the conversation); block on it with agy_wait or poll it with agy_status. Use these for long runs, for open-ended work that routinely outlives an inline wait (web research, a large review), or to fan several tasks out in parallel.
 - Outliving the inline wait is not a failure: the job keeps running under its own supervisor and the returned job_id still resolves to its outcome. Wait on it or poll it; do not re-send the prompt.
-- list_models enumerates models; call it only if you want to override the default. list_sessions lists known conversations.
+- list_models enumerates models and list_agents enumerates agents; call them only if you want to override the default model or pick a specific agent. list_sessions lists known conversations.
 
 Notes:
 - Continue a prior thread with conversation_id or continue_latest instead of restating context.
@@ -428,6 +437,24 @@ func NewServer(mgr *manager.Manager) *mcp.Server {
 			out.ModelDetails = append(out.ModelDetails, modelDetail{ID: mo.ID, Label: mo.Label})
 		}
 		return nil, out, nil
+	})
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        toolListAgents,
+		Title:       "List agy agents",
+		Annotations: annReadExternal,
+		Description: "List the agy agent names accepted by the agent parameter of agy_run and agy_run_sync. Pass a value from agents verbatim; there is no separate id and label, unlike list_models, because agy takes an agent name directly. Call it only when you intend to select a specific agent; omitting agent uses agy's default, so most runs need no call here. An empty list means no agents are configured, which is common and not an error. Shells out to the agy CLI, so it fails if agy is missing from PATH or not authenticated.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ emptyInput) (*mcp.CallToolResult, agentsOutput, error) {
+		agents, err := mgr.ListAgents(ctx)
+		if err != nil {
+			return nil, agentsOutput{}, err
+		}
+		// Always an array, never null: a client that indexes the result should see
+		// an empty list rather than have to special-case null.
+		if agents == nil {
+			agents = []string{}
+		}
+		return nil, agentsOutput{Agents: agents}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{

--- a/internal/mcptools/tools_posix_test.go
+++ b/internal/mcptools/tools_posix_test.go
@@ -97,6 +97,53 @@ func TestListModelsEmptyCatalogReturnsArrays(t *testing.T) {
 	}
 }
 
+// TestListAgentsOverMCP exercises the list_agents tool end to end: the handler
+// decodes the JSON envelope from `agy --output-format json agents` (the fake
+// renders two plain names) and returns them on the wire, in order. Unlike models
+// there is no id/label split, because agy takes an agent name verbatim.
+func TestListAgentsOverMCP(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{Agents: []string{"reviewer", "researcher"}})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: "list_agents"})
+	if err != nil || res.IsError {
+		t.Fatalf("list_agents: err=%v res=%+v", err, res)
+	}
+	out := structMap(t, res.StructuredContent)
+	want := []string{"reviewer", "researcher"}
+	agents, _ := out["agents"].([]any)
+	if len(agents) != len(want) {
+		t.Fatalf("agents = %v, want %d names", agents, len(want))
+	}
+	for i := range want {
+		if agents[i] != want[i] {
+			t.Errorf("agents[%d] = %v, want %q", i, agents[i], want[i])
+		}
+	}
+}
+
+// TestListAgentsEmptyCatalogReturnsArray: no agents configured is the common
+// state, so the field must be an empty JSON array rather than null, letting a
+// client index the result without a null check. The handler forces a non-nil
+// slice; dropping that marshals the field as null and breaks such a client.
+func TestListAgentsEmptyCatalogReturnsArray(t *testing.T) {
+	mgr, _ := newTestManager(t, testutil.FakeAgy{})
+	cs := connect(t, mgr, nil)
+
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: "list_agents"})
+	if err != nil || res.IsError {
+		t.Fatalf("list_agents: err=%v res=%+v", err, res)
+	}
+	out := structMap(t, res.StructuredContent)
+	got, ok := out["agents"].([]any)
+	if !ok {
+		t.Fatalf("agents = %v, want an empty array, not null", out["agents"])
+	}
+	if len(got) != 0 {
+		t.Errorf("agents = %v, want empty for an empty catalog", got)
+	}
+}
+
 // TestListSessionsOverMCP exercises the list_sessions tool: with an empty cache
 // the handler must return a non-nil empty array on the wire (not null), and the
 // tool must be registered and wired. This handler had no MCP-layer test.

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -31,6 +31,19 @@ const (
 // progress information but do not contribute to the response text.
 const StepTypeAgentResponse = "agent_response"
 
+// Step lifecycle states carried on StepUpdate.State: agy reports ACTIVE for each
+// successive update of a step as it runs and DONE on the final one. For an
+// agent_response step that marks its intermediate text_delta chunks (ACTIVE) apart
+// from the completing one (DONE). agy-mcp's own stream reader does not branch on
+// this (internal/supervisor/stream.go accumulates every agent_response delta by
+// step type, in arrival order, regardless of state); the constants are named beside
+// the other stream vocabulary so the fixtures and the fake agy carry the values as
+// a shared constant rather than a bare literal.
+const (
+	StateActive = "ACTIVE"
+	StateDone   = "DONE"
+)
+
 // Usage is the token accounting agy attaches to steps and to the result.
 type Usage struct {
 	InputTokens     int `json:"input_tokens"`

--- a/internal/testutil/fakeagy.go
+++ b/internal/testutil/fakeagy.go
@@ -80,6 +80,12 @@ type FakeAgy struct {
 	// that accumulates every delta reproduces the result exactly. At the Go-string
 	// level an invalid-UTF-8 Stdout differs, since the rune split substitutes
 	// U+FFFD; json.Marshal coerces both sides identically, so the wire forms match.
+	//
+	// Only WriteFakeAgy honors this, so it must be set on a FakeAgy driven directly
+	// (through WriteFakeAgy), not on a FakeSupervisor.Agy: WriteFakeSupervisor stages
+	// the terminal result and progress files itself and never replays the fake's
+	// stdout, so through that path the chunking is inert and a test relying on it
+	// would silently exercise none.
 	StreamChunks int
 
 	// Version is what the script reports for `agy --version`, which the manager
@@ -93,6 +99,14 @@ type FakeAgy struct {
 	// array, so the empty-catalog path can be exercised. It is independent of
 	// Stdout, which is the run response text and no longer doubles as the listing.
 	Models []FakeModel
+
+	// Agents is the catalog the fake reports for `agy --output-format json agents`,
+	// one plain name string per entry in the envelope's command.data.agents array.
+	// Unlike Models these are bare names, not {id,label} objects, matching what real
+	// agy prints (measured against agy 1.1.24). An empty Agents yields a well-formed
+	// envelope with an empty (non-null) agents array, so the empty-catalog path can
+	// be exercised.
+	Agents []string
 }
 
 // FakeModel is one {id,label} entry the fake reports for the models listing.
@@ -125,9 +139,15 @@ func (cfg FakeAgy) version() string {
 //     exercised too. The real binary prints its progress banner on stderr, which
 //     is why ListModels reads stdout alone. A run invocation never matches: it
 //     leads with --dangerously-skip-permissions, not --output-format.
-func (cfg FakeAgy) subcommandPreamble(modelsPath, errPath string) string {
+//   - `agy --output-format json agents`, the invocation ListAgents makes: same
+//     three-token match with `agents` in place of `models`, served from
+//     agentsPath. agy's agents listing carries plain name strings, not the
+//     {id,label} objects models does, which is why the two envelopes are rendered
+//     apart.
+func (cfg FakeAgy) subcommandPreamble(modelsPath, agentsPath, errPath string) string {
 	return fmt.Sprintf("if [ \"$1\" = \"--version\" ]; then printf '%%s\\n' %q; exit 0; fi\n", cfg.version()) +
-		fmt.Sprintf("if [ \"$1\" = \"--output-format\" ] && [ \"$2\" = \"json\" ] && [ \"$3\" = \"models\" ]; then cat %q; cat %q 1>&2; exit %d; fi\n", modelsPath, errPath, cfg.Exit)
+		fmt.Sprintf("if [ \"$1\" = \"--output-format\" ] && [ \"$2\" = \"json\" ] && [ \"$3\" = \"models\" ]; then cat %q; cat %q 1>&2; exit %d; fi\n", modelsPath, errPath, cfg.Exit) +
+		fmt.Sprintf("if [ \"$1\" = \"--output-format\" ] && [ \"$2\" = \"json\" ] && [ \"$3\" = \"agents\" ]; then cat %q; cat %q 1>&2; exit %d; fi\n", agentsPath, errPath, cfg.Exit)
 }
 
 // modelsEnvelopeJSON renders the JSON envelope agy 1.1.12+ prints for
@@ -160,6 +180,35 @@ func (cfg FakeAgy) modelsEnvelopeJSON(t *testing.T) string {
 	b, err := json.Marshal(env)
 	if err != nil {
 		t.Fatalf("marshal fake agy models envelope: %v", err)
+	}
+	return string(b)
+}
+
+// agentsEnvelopeJSON renders the JSON envelope agy prints for
+// `agy --output-format json agents`: a SUCCESS `agents` command whose
+// command.data.agents carries one plain name string per configured agent
+// (measured against agy 1.1.24). The inner slice is always non-nil so an empty
+// catalog marshals as "agents":[] rather than "agents":null, matching what the
+// real binary emits.
+func (cfg FakeAgy) agentsEnvelopeJSON(t *testing.T) string {
+	t.Helper()
+	agents := make([]string, 0, len(cfg.Agents))
+	agents = append(agents, cfg.Agents...)
+	var env struct {
+		Status  string `json:"status"`
+		Command struct {
+			Name string `json:"name"`
+			Data struct {
+				Agents []string `json:"agents"`
+			} `json:"data"`
+		} `json:"command"`
+	}
+	env.Status = "SUCCESS"
+	env.Command.Name = "agents"
+	env.Command.Data.Agents = agents
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal fake agy agents envelope: %v", err)
 	}
 	return string(b)
 }
@@ -253,9 +302,9 @@ func (cfg FakeAgy) streamLines(t *testing.T) string {
 	// DONE event this fake emitted before StreamChunks existed.
 	chunks := splitChunks(cfg.Stdout, cfg.StreamChunks)
 	for i, chunk := range chunks {
-		state := "ACTIVE"
+		state := streamjson.StateActive
 		if i == len(chunks)-1 {
-			state = "DONE"
+			state = streamjson.StateDone
 		}
 		events = append(events, streamjson.Event{
 			Kind: streamjson.EventStepUpdate,
@@ -322,14 +371,24 @@ func WriteFakeAgy(t *testing.T, cfg FakeAgy) string {
 	path := filepath.Join(dir, "fake-agy")
 
 	if cfg.IgnoreSIGTERM {
+		// IgnoreSIGTERM loops forever before ever reaching the print-mode output, so
+		// the output fields have no effect. The struct doc says they are mutually
+		// exclusive; enforce it here (as WriteFakeSupervisor does for its own
+		// combinations) so a test that sets both fails loudly rather than passing
+		// while silently exercising none of the output it staged.
+		if cfg.Stdout != "" || cfg.Stderr != "" || cfg.Status != "" || cfg.ResultError != "" ||
+			cfg.OmitResult || cfg.StreamChunks != 0 || len(cfg.Models) != 0 || len(cfg.Agents) != 0 {
+			t.Fatal("FakeAgy.IgnoreSIGTERM is mutually exclusive with the output fields (Stdout, Stderr, Status, ResultError, OmitResult, StreamChunks, Models, Agents): the hang-forever script never reaches them")
+		}
 		// Trap and ignore SIGTERM, then loop forever. The inner sleep is killed by
 		// the supervisor's group SIGTERM, but bash ignores it and restarts the
 		// loop, so the process survives until the supervisor escalates to SIGKILL.
 		// The version probe still has to answer, or the job never starts. There is
 		// no listing or stderr to serve in this mode, so point those at paths that
-		// do not exist: `agy models` is never called on a hang-forever fake.
+		// do not exist: `agy models` and `agy agents` are never called on a
+		// hang-forever fake.
 		script := "#!/usr/bin/env bash\n" +
-			cfg.subcommandPreamble(filepath.Join(dir, "no-models"), filepath.Join(dir, "no-stderr")) +
+			cfg.subcommandPreamble(filepath.Join(dir, "no-models"), filepath.Join(dir, "no-agents"), filepath.Join(dir, "no-stderr")) +
 			"trap '' TERM\nwhile :; do sleep 1; done\n"
 		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 			t.Fatalf("write fake agy: %v", err)
@@ -340,6 +399,7 @@ func WriteFakeAgy(t *testing.T, cfg FakeAgy) string {
 	outPath := filepath.Join(dir, "fake-agy.out")
 	errPath := filepath.Join(dir, "fake-agy.err")
 	modelsPath := filepath.Join(dir, "fake-agy.models")
+	agentsPath := filepath.Join(dir, "fake-agy.agents")
 	if err := os.WriteFile(outPath, []byte(cfg.streamLines(t)), 0o644); err != nil {
 		t.Fatalf("write fake agy stdout: %v", err)
 	}
@@ -349,12 +409,15 @@ func WriteFakeAgy(t *testing.T, cfg FakeAgy) string {
 	if err := os.WriteFile(modelsPath, []byte(cfg.modelsEnvelopeJSON(t)), 0o644); err != nil {
 		t.Fatalf("write fake agy models envelope: %v", err)
 	}
+	if err := os.WriteFile(agentsPath, []byte(cfg.agentsEnvelopeJSON(t)), 0o644); err != nil {
+		t.Fatalf("write fake agy agents envelope: %v", err)
+	}
 	script := fmt.Sprintf(`#!/usr/bin/env bash
 %ssleep %.3f
 cat %q
 cat %q 1>&2
 exit %d
-`, cfg.subcommandPreamble(modelsPath, errPath), cfg.Sleep.Seconds(), outPath, errPath, cfg.Exit)
+`, cfg.subcommandPreamble(modelsPath, agentsPath, errPath), cfg.Sleep.Seconds(), outPath, errPath, cfg.Exit)
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake agy: %v", err)
 	}

--- a/internal/testutil/fakeagy_split_test.go
+++ b/internal/testutil/fakeagy_split_test.go
@@ -1,0 +1,65 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// splitChunks must never lose, reorder or corrupt text, because the whole point
+// of StreamChunks is that a consumer accumulating every delta reproduces the
+// response exactly. Non-ASCII input is included because a byte-wise split would
+// cut a multi-byte rune in half and produce invalid UTF-8 that no real agy
+// delta ever carries.
+//
+// This test is deliberately NOT build-tagged, unlike the rest of the fakeagy
+// tests: splitChunks is a pure function needing no bash subprocess, so its
+// rune-boundary property is worth covering on Windows too, where the fake agy
+// script itself cannot run.
+func TestSplitChunks(t *testing.T) {
+	const text = "the quick brown fox jumps over the lazy dog"
+	// A 4-byte rune (U+1D11E, outside the BMP) is included so a byte-wise split has
+	// a wide rune to cut through; the earlier fixture's trailing "emoji" was ASCII,
+	// so no rune above 3 bytes was ever exercised despite the naming.
+	const multibyte = "hyvää yötä äöå 你好世界 \U0001D11E"
+
+	for _, tc := range []struct {
+		name      string
+		text      string
+		n         int
+		wantParts int
+	}{
+		{"zero keeps one piece", text, 0, 1},
+		{"one keeps one piece", text, 1, 1},
+		{"negative keeps one piece", text, -3, 1},
+		{"splits into n", text, 4, 4},
+		{"uneven split", text, 5, 5},
+		{"n equal to rune count", "abcd", 4, 4},
+		// A multi-byte string here, not ASCII: with rune count == byte count the
+		// clamp does not discriminate a rune split from a byte split.
+		{"n above rune count clamps", "äö", 99, 2},
+		{"unicode splits on runes", multibyte, 5, 5},
+		{"unicode splits on runes, uneven", multibyte, 7, 7},
+		{"empty text", "", 4, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitChunks(tc.text, tc.n)
+			if len(got) != tc.wantParts {
+				t.Errorf("len = %d, want %d (parts %q)", len(got), tc.wantParts, got)
+			}
+			if joined := strings.Join(got, ""); joined != tc.text {
+				t.Errorf("concatenation = %q, want the input back %q", joined, tc.text)
+			}
+			for i, part := range got {
+				// An empty piece would silently reduce the delta count a caller asked
+				// for, because consumeStream skips an empty text_delta.
+				if part == "" && tc.text != "" {
+					t.Errorf("piece %d is empty; every piece must carry text", i)
+				}
+				if !utf8.ValidString(part) {
+					t.Errorf("piece %d = %q is not valid UTF-8; the split must land on a rune boundary", i, part)
+				}
+			}
+		})
+	}
+}

--- a/internal/testutil/fakeagy_test.go
+++ b/internal/testutil/fakeagy_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unicode/utf8"
 
 	"github.com/tphakala/agy-mcp/v2/internal/streamjson"
 )
@@ -141,7 +140,7 @@ func TestFakeAgyStreamChunksEmitsManyDeltasOnOneStep(t *testing.T) {
 	if len(indexes) != 1 {
 		t.Fatalf("deltas spanned step indexes %v, want exactly one step", indexes)
 	}
-	want := []string{"ACTIVE", "ACTIVE", "ACTIVE", "DONE"}
+	want := []string{streamjson.StateActive, streamjson.StateActive, streamjson.StateActive, streamjson.StateDone}
 	if !slices.Equal(states, want) {
 		t.Fatalf("delta states = %v, want %v (only the tail is DONE)", states, want)
 	}
@@ -167,60 +166,7 @@ func TestFakeAgyDefaultsToOneDoneDelta(t *testing.T) {
 			states = append(states, su.State)
 		}
 	}
-	if !slices.Equal(states, []string{"DONE"}) {
+	if !slices.Equal(states, []string{streamjson.StateDone}) {
 		t.Fatalf("delta states = %v, want a single DONE delta", states)
-	}
-}
-
-// splitChunks must never lose, reorder or corrupt text, because the whole point
-// of StreamChunks is that a consumer accumulating every delta reproduces the
-// response exactly. Non-ASCII input is included because a byte-wise split would
-// cut a multi-byte rune in half and produce invalid UTF-8 that no real agy
-// delta ever carries.
-func TestSplitChunks(t *testing.T) {
-	const text = "the quick brown fox jumps over the lazy dog"
-	// A 4-byte rune (U+1D11E, outside the BMP) is included so a byte-wise split has
-	// a wide rune to cut through; the earlier fixture's trailing "emoji" was ASCII,
-	// so no rune above 3 bytes was ever exercised despite the naming.
-	const multibyte = "hyvää yötä \u00e4\u00f6\u00e5 \u4f60\u597d\u4e16\u754c \U0001D11E"
-
-	for _, tc := range []struct {
-		name      string
-		text      string
-		n         int
-		wantParts int
-	}{
-		{"zero keeps one piece", text, 0, 1},
-		{"one keeps one piece", text, 1, 1},
-		{"negative keeps one piece", text, -3, 1},
-		{"splits into n", text, 4, 4},
-		{"uneven split", text, 5, 5},
-		{"n equal to rune count", "abcd", 4, 4},
-		// A multi-byte string here, not ASCII: with rune count == byte count the
-		// clamp does not discriminate a rune split from a byte split.
-		{"n above rune count clamps", "äö", 99, 2},
-		{"unicode splits on runes", multibyte, 5, 5},
-		{"unicode splits on runes, uneven", multibyte, 7, 7},
-		{"empty text", "", 4, 1},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := splitChunks(tc.text, tc.n)
-			if len(got) != tc.wantParts {
-				t.Errorf("len = %d, want %d (parts %q)", len(got), tc.wantParts, got)
-			}
-			if joined := strings.Join(got, ""); joined != tc.text {
-				t.Errorf("concatenation = %q, want the input back %q", joined, tc.text)
-			}
-			for i, part := range got {
-				// An empty piece would silently reduce the delta count a caller asked
-				// for, because consumeStream skips an empty text_delta.
-				if part == "" && tc.text != "" {
-					t.Errorf("piece %d is empty; every piece must carry text", i)
-				}
-				if !utf8.ValidString(part) {
-					t.Errorf("piece %d = %q is not valid UTF-8; the split must land on a rune boundary", i, part)
-				}
-			}
-		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -50,6 +50,10 @@ func main() {
 		os.Exit(hookWaitMain(os.Args[2:], os.Stdin, os.Stderr))
 	}
 
+	if len(os.Args) >= 2 && os.Args[1] == "doctor" {
+		os.Exit(doctorMain(os.Args[2:], os.Stdout, os.Stderr))
+	}
+
 	if err := serve(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
@@ -84,7 +88,7 @@ func serve() error {
 		// that means. Without this the server looks healthy and every run fails, which
 		// is a worse diagnostic than the startup refusal this replaced. log goes to
 		// stderr; stdout is the JSON-RPC stream in stdio mode and must stay clean.
-		log.Print("agy not found on PATH: the server will serve tool discovery, but agy_run, agy_run_sync, and list_models fail until agy is installed or AGY_MCP_AGY_PATH is set")
+		log.Print("agy not found on PATH: the server will serve tool discovery, but agy_run, agy_run_sync, list_models, and list_agents fail until agy is installed or AGY_MCP_AGY_PATH is set")
 	}
 	mgr := manager.New(cfg)
 	// Run startup garbage collection and concurrency-gate restoration in one

--- a/serve_noagy_test.go
+++ b/serve_noagy_test.go
@@ -54,7 +54,7 @@ func TestServeIntrospectsWithoutAgy(t *testing.T) {
 	for _, tool := range tools.Tools {
 		got[tool.Name] = true
 	}
-	for _, name := range []string{"agy_run", "agy_run_sync", "agy_status", "agy_wait", "agy_cancel", "list_models", "list_sessions"} {
+	for _, name := range []string{"agy_run", "agy_run_sync", "agy_status", "agy_wait", "agy_cancel", "list_models", "list_agents", "list_sessions"} {
 		if !got[name] {
 			t.Errorf("tool %q missing from a server started without agy", name)
 		}
@@ -108,8 +108,10 @@ func TestServeWarnsWhenAgyMissing(t *testing.T) {
 }
 
 // TestRunWithoutAgyFailsPerCall is the other half of the contract: tolerating a
-// missing agy at startup must not turn into a silent no-op later. The tool call
-// that actually needs the binary has to say so, and name the way to fix it.
+// missing agy at startup must not turn into a silent no-op later. Every tool that
+// actually needs the binary has to say so, and name the way to fix it. Both
+// agy-shelling read tools (list_models and list_agents) are exercised, since they
+// share the same deferred-lookup failure path.
 func TestRunWithoutAgyFailsPerCall(t *testing.T) {
 	bin, err := buildBinary()
 	if err != nil {
@@ -134,23 +136,27 @@ func TestRunWithoutAgyFailsPerCall(t *testing.T) {
 	}
 	defer func() { _ = cs.Close() }()
 
-	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
-		Name:      "list_models",
-		Arguments: map[string]any{},
-	})
-	if err != nil {
-		t.Fatalf("call list_models: %v", err)
-	}
-	if !res.IsError {
-		t.Fatal("list_models must report an error when agy cannot be resolved")
-	}
-	var text strings.Builder
-	for _, c := range res.Content {
-		if tc, ok := c.(*mcp.TextContent); ok {
-			text.WriteString(tc.Text)
-		}
-	}
-	if !strings.Contains(text.String(), "AGY_MCP_AGY_PATH") {
-		t.Errorf("error should point at the fix, got: %s", text.String())
+	for _, tool := range []string{"list_models", "list_agents"} {
+		t.Run(tool, func(t *testing.T) {
+			res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name:      tool,
+				Arguments: map[string]any{},
+			})
+			if err != nil {
+				t.Fatalf("call %s: %v", tool, err)
+			}
+			if !res.IsError {
+				t.Fatalf("%s must report an error when agy cannot be resolved", tool)
+			}
+			var text strings.Builder
+			for _, c := range res.Content {
+				if tc, ok := c.(*mcp.TextContent); ok {
+					text.WriteString(tc.Text)
+				}
+			}
+			if !strings.Contains(text.String(), "AGY_MCP_AGY_PATH") {
+				t.Errorf("error should point at the fix, got: %s", text.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

This folds four issues plus a dependency bump into one change.

`list_models` error handling now checks `ctx.Err()` before classifying an exec error and tolerates `exec.ErrWaitDelay`, mirroring the version probe. A descendant that keeps the output pipe open after agy exits no longer fails a listing whose envelope already arrived, and a cancel or timeout the server imposed is named as such rather than reported as "signal: killed" against agy. The `ListModels` and new `ListAgents` exec paths are consolidated into a shared `runJSONListing` helper; the version probe stays separate because it genuinely differs (it uses `CombinedOutput` and tolerates a non-zero exit, which a listing does not).

A new `list_agents` MCP tool and `Manager.ListAgents` decode the `agy --output-format json agents` envelope. agy prints an agent as a plain name, not the id/label pair a model is, so the result is a `[]string` with no id-vs-label reduction and none of the ambiguity #135 was about; an empty list just means no agents are configured.

A new `agy-mcp doctor` preflight command runs the read-only checks a run depends on (agy binary resolves, meets the version floor, is reachable and authenticated via the model listing, the state directory is writable, each effective setting's source is named without printing secrets, and any stale jobs a prior crash left are reported) and exits non-zero when something is genuinely broken, so a setup script or CI gets a clear signal. It never starts a job or mutates state; a stale-job warning does not fail the exit code, and a fresh install passes.

The rest is the batched low-severity cleanup: named `StateActive`/`StateDone` stream constants, `TestSplitChunks` moved off the Windows build tag so the pure-function test runs everywhere, a documented and enforced mutual-exclusivity guard on the test fake's `IgnoreSIGTERM`, and the job-staging duplication in `status_test.go` consolidated into a helper. The indirect `golang.org/x/sync` dependency is bumped to v0.22.0.

## Related Issues

Closes #161, closes #145, closes #142, closes #160.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean
- [x] `go test ./...` green (82.6% coverage); new tests cover ListAgents decode + envelope framing, the ErrWaitDelay tolerance and cancellation-naming for both listings, and every doctor check including the state-dir arms and secret redaction
- [x] Cross-compiles for `windows/amd64` and `darwin/arm64`
- [x] `agy-mcp doctor` smoke-tested against a live agy (all checks pass, exit 0); `list_agents` verified against a configured agy agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `list_agents` tool to discover available agents.
  * Added the `agy-mcp doctor` command for read-only preflight checks covering configuration, connectivity, state storage, and stale jobs.
  * Added clear doctor results, warnings, details, and exit codes for automation.
* **Bug Fixes**
  * Improved command cancellation, timeout handling, and error reporting for listing operations.
  * Missing `agy` diagnostics now identify all affected tools, including `list_agents`.
* **Documentation**
  * Documented `list_agents` and the new `agy-mcp doctor` command, including checks and wait behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->