### PR TITLE
refactor: doctor/listing reuse polish and test coverage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,18 @@ import (
 	"time"
 )
 
+// Environment variable names agy-mcp reads for its runtime configuration. They
+// are exported so other packages (the doctor command, which names where each
+// setting came from) reference the same identifier config resolves the setting
+// from, rather than a second copy of the literal that could drift out of sync on
+// a rename with no compile error.
+const (
+	EnvAgyPath      = "AGY_MCP_AGY_PATH"
+	EnvDefaultModel = "AGY_MCP_DEFAULT_MODEL"
+	EnvStateDir     = "AGY_MCP_STATE_DIR"
+	EnvHTTPToken    = "AGY_MCP_HTTP_TOKEN"
+)
+
 // Config holds resolved runtime settings.
 type Config struct {
 	AgyPath        string        // path to the agy binary
@@ -57,8 +69,8 @@ const DefaultConversationIDWait = 2 * time.Second
 // Resolve builds a Config from environment variables and defaults.
 func Resolve() (Config, error) {
 	c := baseConfig()
-	c.DefaultModel = os.Getenv("AGY_MCP_DEFAULT_MODEL")
-	c.HTTPToken = os.Getenv("AGY_MCP_HTTP_TOKEN")
+	c.DefaultModel = os.Getenv(EnvDefaultModel)
+	c.HTTPToken = os.Getenv(EnvHTTPToken)
 
 	// The two lookup branches fail differently, on purpose.
 	//
@@ -72,10 +84,10 @@ func Resolve() (Config, error) {
 	// would make the server unrunnable in a container that has no agy at all.
 	// AgyPath is left empty and AgyBinary retries the lookup at exec time, where a
 	// genuinely missing agy becomes a clear per-call error instead.
-	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {
+	if p := os.Getenv(EnvAgyPath); p != "" {
 		resolved, err := lookupAgy(p)
 		if err != nil {
-			return Config{}, fmt.Errorf("AGY_MCP_AGY_PATH %q: %w", p, err)
+			return Config{}, fmt.Errorf("%s %q: %w", EnvAgyPath, p, err)
 		}
 		c.AgyPath = resolved
 	} else if resolved, err := lookupAgy("agy"); err == nil {
@@ -153,16 +165,16 @@ func lookupAgy(name string) (string, error) {
 // an installation that is already there.
 func pathLookupGuidance(err error) error {
 	if errors.Is(err, exec.ErrDot) {
-		return fmt.Errorf("agy is on PATH only through a relative entry, which cannot be used because each job runs in its own working directory; set AGY_MCP_AGY_PATH to an absolute path: %w", err)
+		return fmt.Errorf("agy is on PATH only through a relative entry, which cannot be used because each job runs in its own working directory; set %s to an absolute path: %w", EnvAgyPath, err)
 	}
-	return fmt.Errorf("agy not found on PATH; set AGY_MCP_AGY_PATH: %w", err)
+	return fmt.Errorf("agy not found on PATH; set %s: %w", EnvAgyPath, err)
 }
 
 // resolveStateDir returns the job-state root: AGY_MCP_STATE_DIR (made absolute)
 // or the XDG state-home fallback. Shared by Resolve and ResolveWait so the two
 // cannot drift.
 func resolveStateDir() (string, error) {
-	stateRoot := os.Getenv("AGY_MCP_STATE_DIR")
+	stateRoot := os.Getenv(EnvStateDir)
 	if stateRoot == "" {
 		xdg := os.Getenv("XDG_STATE_HOME")
 		if xdg == "" {
@@ -220,8 +232,8 @@ func ResolveWait() (Config, error) {
 	c.SupervisorExe = self
 	// Cheap env reads carried for uniformity with Resolve; the wait paths do not
 	// consume them today.
-	c.DefaultModel = os.Getenv("AGY_MCP_DEFAULT_MODEL")
-	c.HTTPToken = os.Getenv("AGY_MCP_HTTP_TOKEN")
+	c.DefaultModel = os.Getenv(EnvDefaultModel)
+	c.HTTPToken = os.Getenv(EnvHTTPToken)
 	// One AGY_MCP_ variable is read nowhere in this package at all:
 	// AGY_MCP_WAIT_READY_FILE, which the wait subcommands read in package main (see
 	// waitReadyFileEnv). It is consumed at the instant their signal handler is

--- a/internal/config/config_wait_test.go
+++ b/internal/config/config_wait_test.go
@@ -42,3 +42,24 @@ func TestResolveWaitNeedsNoAgy(t *testing.T) {
 		t.Fatal("SupervisorExe = \"\", want the wait config's own executable path")
 	}
 }
+
+// TestEnvVarNameConstants pins the exported environment-variable names to their
+// wire values. They are the user-facing configuration contract, now shared with
+// the doctor command's source labels, so a rename is a deliberate change a user
+// would feel, not an incidental refactor: this test forces renaming one to be a
+// conscious edit here rather than a silent break. Pinning each to a distinct
+// reviewed literal also rules out a copy-paste that aimed two settings at the same
+// variable, since two equal constants cannot both match their distinct wants.
+func TestEnvVarNameConstants(t *testing.T) {
+	cases := []struct{ got, want string }{
+		{EnvAgyPath, "AGY_MCP_AGY_PATH"},
+		{EnvDefaultModel, "AGY_MCP_DEFAULT_MODEL"},
+		{EnvStateDir, "AGY_MCP_STATE_DIR"},
+		{EnvHTTPToken, "AGY_MCP_HTTP_TOKEN"},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("env var constant = %q, want %q", tc.got, tc.want)
+		}
+	}
+}

--- a/internal/manager/agents.go
+++ b/internal/manager/agents.go
@@ -34,13 +34,10 @@ func (m *Manager) ListAgents(ctx context.Context) ([]string, error) {
 	return decodeAgentsEnvelope(out)
 }
 
-const (
-	// agentsEnvelopeStatusOK and agentsCommandName are the envelope framing
-	// decodeAgentsEnvelope requires before it trusts the listing. They are the
-	// literals agy prints, mirrored in internal/testutil/fakeagy.go.
-	agentsEnvelopeStatusOK = "SUCCESS"
-	agentsCommandName      = "agents"
-)
+// agentsCommandName is the command name decodeAgentsEnvelope requires before it
+// trusts the listing (see validateListingFraming). It is the literal agy prints,
+// mirrored in internal/testutil/fakeagy.go.
+const agentsCommandName = "agents"
 
 // agentsEnvelope is the subset of agy's `--output-format json agents` output that
 // list_agents needs: the status/command framing that proves the payload is the
@@ -79,11 +76,8 @@ func decodeAgentsEnvelope(raw []byte) ([]string, error) {
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return nil, fmt.Errorf("agy agents: parse json envelope: %w", err)
 	}
-	if env.Status != agentsEnvelopeStatusOK {
-		return nil, fmt.Errorf("agy agents: envelope status %q, want %q", env.Status, agentsEnvelopeStatusOK)
-	}
-	if env.Command.Name != agentsCommandName {
-		return nil, fmt.Errorf("agy agents: envelope command %q, want %q", env.Command.Name, agentsCommandName)
+	if err := validateListingFraming(agentsCommandName, env.Status, env.Command.Name); err != nil {
+		return nil, err
 	}
 	// nil, not empty: an absent or null command.data.agents (a renamed or dropped
 	// field), as opposed to a present "agents":[] which is a real empty catalog.

--- a/internal/manager/doctor.go
+++ b/internal/manager/doctor.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/tphakala/agy-mcp/v2/internal/agyver"
+	"github.com/tphakala/agy-mcp/v2/internal/config"
 )
 
 // Check names, shared by each check and its tests (see doctor_test.go, which
@@ -113,6 +114,12 @@ func (m *Manager) checkAgyBinary() CheckResult {
 // reusing agyver rather than duplicating the comparison. It reports the version
 // it found so an operator sees how far off an outdated binary is, not just that
 // it is outdated.
+//
+// On success it primes the version cache (markAgyVerified): this ran the same
+// read+parse+floor check agyBinaryChecked would, so the checkAgyReachable that
+// follows in the same Doctor run reuses the verdict instead of spawning a second
+// `agy --version`. It primes only on the PASS branch, so a binary below the floor
+// is never marked verified and checkAgyReachable re-probes and fails the same way.
 func (m *Manager) checkAgyVersion(ctx context.Context) CheckResult {
 	agy, err := m.cfg.AgyBinary()
 	if err != nil {
@@ -131,6 +138,7 @@ func (m *Manager) checkAgyVersion(ctx context.Context) CheckResult {
 	if !v.AtLeast(agyver.Required) {
 		return CheckResult{checkAgyVersionName, CheckFail, fmt.Sprintf("%s is below the required %s; upgrade agy", v, agyver.Required)}
 	}
+	m.markAgyVerified(agy)
 	return CheckResult{checkAgyVersionName, CheckPass, fmt.Sprintf("%s (>= required %s)", v, agyver.Required)}
 }
 
@@ -230,27 +238,31 @@ func (m *Manager) checkConfigSources() CheckResult {
 			fmt.Fprintf(&b, " (%s)", value)
 		}
 	}
+	// The AGY_MCP_* labels come from config's exported constants, the same
+	// identifiers config reads each setting from, so a rename cannot leave doctor
+	// naming a variable config no longer honours.
+	//
 	// agy path: an explicit override vs a PATH lookup.
-	if p := os.Getenv("AGY_MCP_AGY_PATH"); p != "" {
-		line("agy path", "AGY_MCP_AGY_PATH", m.cfg.AgyPath)
+	if p := os.Getenv(config.EnvAgyPath); p != "" {
+		line("agy path", config.EnvAgyPath, m.cfg.AgyPath)
 	} else {
 		line("agy path", "PATH lookup", m.cfg.AgyPath)
 	}
 	// default model: env override vs agy's own default (an empty DefaultModel).
-	if os.Getenv("AGY_MCP_DEFAULT_MODEL") != "" {
-		line("default model", "AGY_MCP_DEFAULT_MODEL", m.cfg.DefaultModel)
+	if os.Getenv(config.EnvDefaultModel) != "" {
+		line("default model", config.EnvDefaultModel, m.cfg.DefaultModel)
 	} else {
 		line("default model", "agy default (unset)", "")
 	}
 	// state dir: env override vs the XDG fallback.
-	if os.Getenv("AGY_MCP_STATE_DIR") != "" {
-		line("state dir", "AGY_MCP_STATE_DIR", m.cfg.StateDir)
+	if os.Getenv(config.EnvStateDir) != "" {
+		line("state dir", config.EnvStateDir, m.cfg.StateDir)
 	} else {
 		line("state dir", "XDG default", m.cfg.StateDir)
 	}
 	// HTTP token: reported as set/unset only, never the value.
 	if m.cfg.HTTPToken != "" {
-		line("http token", "AGY_MCP_HTTP_TOKEN", "set")
+		line("http token", config.EnvHTTPToken, "set")
 	} else {
 		line("http token", "unset (HTTP mode unauthenticated)", "")
 	}

--- a/internal/manager/doctor_posix_test.go
+++ b/internal/manager/doctor_posix_test.go
@@ -3,11 +3,14 @@
 package manager
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/tphakala/agy-mcp/v2/internal/agyver"
 	"github.com/tphakala/agy-mcp/v2/internal/config"
 	"github.com/tphakala/agy-mcp/v2/internal/testutil"
 )
@@ -34,6 +37,42 @@ func TestDoctorHealthy(t *testing.T) {
 	reach := findCheck(t, report, checkAgyReachableName)
 	if reach.Status != CheckPass {
 		t.Errorf("reachability check = %v (%s), want PASS", reach.Status, reach.Detail)
+	}
+}
+
+// TestDoctorProbesAgyVersionOnce: a healthy Doctor run probes `agy --version`
+// exactly once. checkAgyVersion primes the version cache on success, so the
+// checkAgyReachable that follows reuses the verdict instead of spawning a second
+// probe. Without the priming the two checks would probe independently (count 2),
+// so the count-of-one assertion pins the optimization, and the two PASS assertions
+// prove both checks actually ran the happy path rather than the count passing
+// vacuously. Posix-gated because checkAgyReachable execs the fake agy for the
+// model listing, like the other WriteFakeAgy tests.
+func TestDoctorProbesAgyVersionOnce(t *testing.T) {
+	agy := testutil.WriteFakeAgy(t, testutil.FakeAgy{
+		Models: []testutil.FakeModel{{ID: "gemini-3.1-pro-high", Label: "Gemini 3.1 Pro (High)"}},
+	})
+	m := newManager(t, managerOpts{agyPath: agy})
+	// Count probes through the seam. newManager installs a plain FakeVersion stub;
+	// replace it with one that both satisfies the floor and tallies each call. The
+	// model listing still execs the real fake binary, so checkAgyReachable is
+	// unaffected by the swap.
+	var probes atomic.Int32
+	m.readAgyVersion = func(context.Context, string) (string, error) {
+		probes.Add(1)
+		return agyver.Required.String(), nil
+	}
+
+	report := m.Doctor(t.Context())
+
+	if c := findCheck(t, report, checkAgyVersionName); c.Status != CheckPass {
+		t.Fatalf("version check = %v (%s), want PASS", c.Status, c.Detail)
+	}
+	if c := findCheck(t, report, checkAgyReachableName); c.Status != CheckPass {
+		t.Fatalf("reachable check = %v (%s), want PASS", c.Status, c.Detail)
+	}
+	if n := probes.Load(); n != 1 {
+		t.Fatalf("agy --version probed %d times in one Doctor run, want 1 (checkAgyVersion should prime the cache checkAgyReachable reuses)", n)
 	}
 }
 

--- a/internal/manager/doctor_test.go
+++ b/internal/manager/doctor_test.go
@@ -1,11 +1,13 @@
 package manager
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/tphakala/agy-mcp/v2/internal/agyver"
 	"github.com/tphakala/agy-mcp/v2/internal/config"
 	"github.com/tphakala/agy-mcp/v2/internal/jobstore"
 )
@@ -159,6 +161,66 @@ func TestDoctorConfigSourcesFromEnv(t *testing.T) {
 	}
 	if strings.Contains(got.Detail, secret) {
 		t.Errorf("detail leaked the token value:\n%s", got.Detail)
+	}
+}
+
+// TestDoctorVersionCheckFailsBelowFloor: an agy whose version parses cleanly but
+// sits below the required floor makes the version check FAIL and drags the whole
+// report non-OK, even though the binary itself resolves. Driven through the
+// readAgyVersion seam so no real outdated agy is needed. This covers a branch of
+// checkAgyVersion that previously had no test.
+func TestDoctorVersionCheckFailsBelowFloor(t *testing.T) {
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: t.TempDir(), MaxConcurrency: 4})
+	m.readAgyVersion = func(context.Context, string) (string, error) {
+		return "1.1.7", nil // well-formed, but below the floor
+	}
+
+	report := m.Doctor(t.Context())
+	ver := findCheck(t, report, checkAgyVersionName)
+	if ver.Status != CheckFail {
+		t.Fatalf("version check = %v (%s), want FAIL for an agy below the floor", ver.Status, ver.Detail)
+	}
+	// The detail must name both the found and required versions so the reader can
+	// tell which half of the mismatch to act on.
+	if !strings.Contains(ver.Detail, "1.1.7") || !strings.Contains(ver.Detail, agyver.Required.String()) {
+		t.Errorf("version detail should name the found and required versions, got: %s", ver.Detail)
+	}
+	if report.OK() {
+		t.Fatal("report is OK despite a below-floor version; the command would wrongly exit zero")
+	}
+}
+
+// TestDoctorReachableFailsWhenListingUnavailable: the version gate passes but the
+// model listing (checkAgyReachable) fails because the binary cannot be execed.
+// This covers checkAgyReachable's FAIL branch, previously untested. The version
+// probe is stubbed to a current version, so the failure can only come from the
+// models exec against the unresolvable path, which the detail assertion pins.
+// (The single-probe cache hit is TestDoctorProbesAgyVersionOnce's job; this test
+// does not pin it, since it fails identically whether checkAgyReachable re-probes
+// the version or reuses a primed cache.)
+func TestDoctorReachableFailsWhenListingUnavailable(t *testing.T) {
+	m := New(config.Config{AgyPath: "/nonexistent/agy", StateDir: t.TempDir(), MaxConcurrency: 4})
+	m.readAgyVersion = func(context.Context, string) (string, error) {
+		return agyver.Required.String(), nil // version gate passes; the models exec is what fails
+	}
+
+	report := m.Doctor(t.Context())
+	if ver := findCheck(t, report, checkAgyVersionName); ver.Status != CheckPass {
+		t.Fatalf("version check = %v (%s), want PASS (the seam reports a current version)", ver.Status, ver.Detail)
+	}
+	reach := findCheck(t, report, checkAgyReachableName)
+	if reach.Status != CheckFail {
+		t.Fatalf("reachable check = %v (%s), want FAIL when agy cannot be listed", reach.Status, reach.Detail)
+	}
+	// Pin the failure reason to the models exec against the unresolvable binary,
+	// not some other reachable failure: the exec error names the path, whereas a
+	// decode failure would name the envelope. This keeps the test from passing on
+	// a future change that made checkAgyReachable fail for a different reason.
+	if !strings.Contains(reach.Detail, "/nonexistent/agy") {
+		t.Errorf("reachable detail should name the unresolvable binary, got: %s", reach.Detail)
+	}
+	if report.OK() {
+		t.Fatal("report is OK despite an unreachable agy")
 	}
 }
 

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -168,6 +168,19 @@ func (m *Manager) agyBinaryChecked(ctx context.Context) (string, error) {
 	return agy, nil
 }
 
+// markAgyVerified records that the agy at path has already passed the version
+// floor in this process, so the next agyBinaryChecked returns it without a fresh
+// `agy --version` probe. Doctor uses it: checkAgyVersion runs the same
+// read+parse+floor check agyBinaryChecked would, so priming the cache after it
+// passes collapses the two probes one Doctor run would otherwise make into one.
+// Priming a path that a later AgyBinary resolves differently is harmless:
+// agyBinaryChecked re-probes on a cache miss.
+func (m *Manager) markAgyVerified(agy string) {
+	m.verifyMu.Lock()
+	defer m.verifyMu.Unlock()
+	m.verifiedAgy = agy
+}
+
 // probeCmd builds the command for one of the manager's short-lived agy probes.
 // It exists so the console-window suppression both probes need is applied in one
 // place a test can inspect, rather than being remembered separately at each site.

--- a/internal/manager/models.go
+++ b/internal/manager/models.go
@@ -162,11 +162,10 @@ const (
 	// models listing: the single-object envelope, distinct from the stream-json
 	// format the job pipeline drives (streamJSONFormat).
 	jsonOutputFormat = "json"
-	// modelsEnvelopeStatusOK and modelsCommandName are the envelope framing
-	// decodeModelsEnvelope requires before it trusts the listing. They are the
-	// literals agy prints, mirrored in internal/testutil/fakeagy.go.
-	modelsEnvelopeStatusOK = "SUCCESS"
-	modelsCommandName      = "models"
+	// modelsCommandName is the command name decodeModelsEnvelope requires before it
+	// trusts the listing (see validateListingFraming). It is the literal agy prints,
+	// mirrored in internal/testutil/fakeagy.go.
+	modelsCommandName = "models"
 )
 
 // modelsEnvelope is the subset of agy's `--output-format json models` output that
@@ -192,6 +191,28 @@ type modelsEnvelope struct {
 	} `json:"command"`
 }
 
+// listingEnvelopeStatusOK is the status agy stamps on a successful listing
+// envelope (models or agents); both decoders require it before trusting the
+// payload. It is the literal agy prints, mirrored in internal/testutil/fakeagy.go.
+const listingEnvelopeStatusOK = "SUCCESS"
+
+// validateListingFraming checks the status and command framing shared by agy's
+// `--output-format json <command>` listing envelopes, so decodeModelsEnvelope and
+// decodeAgentsEnvelope cannot describe the same framing failure two different
+// ways. command is both the expected command.name and the error prefix. The
+// per-decoder json.Unmarshal and the absent-array nil check stay in each decoder,
+// since the payload types differ (a []Model vs a []string), which is the one part
+// the two genuinely do not share.
+func validateListingFraming(command, status, name string) error {
+	if status != listingEnvelopeStatusOK {
+		return fmt.Errorf("agy %s: envelope status %q, want %q", command, status, listingEnvelopeStatusOK)
+	}
+	if name != command {
+		return fmt.Errorf("agy %s: envelope command %q, want %q", command, name, command)
+	}
+	return nil
+}
+
 // decodeModelsEnvelope turns agy's JSON models envelope into Models, validating
 // the framing before it trusts the list. It is an error, not a silently empty
 // catalog, when the status is not SUCCESS, the command is not `models`, or the
@@ -207,11 +228,8 @@ func decodeModelsEnvelope(raw []byte) ([]Model, error) {
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return nil, fmt.Errorf("agy models: parse json envelope: %w", err)
 	}
-	if env.Status != modelsEnvelopeStatusOK {
-		return nil, fmt.Errorf("agy models: envelope status %q, want %q", env.Status, modelsEnvelopeStatusOK)
-	}
-	if env.Command.Name != modelsCommandName {
-		return nil, fmt.Errorf("agy models: envelope command %q, want %q", env.Command.Name, modelsCommandName)
+	if err := validateListingFraming(modelsCommandName, env.Status, env.Command.Name); err != nil {
+		return nil, err
 	}
 	// nil, not empty: an absent or null command.data.models (a renamed or dropped
 	// field), as opposed to a present "models":[] which is a real empty catalog.

--- a/internal/manager/models_test.go
+++ b/internal/manager/models_test.go
@@ -114,6 +114,25 @@ func TestDecodeModelsEnvelope(t *testing.T) {
 	}
 }
 
+// TestValidateListingFraming pins the shared framing validator that both listing
+// decoders delegate to: a matching SUCCESS envelope passes, while a non-SUCCESS
+// status and a mismatched command name each error with the command as the message
+// prefix (so a failure names the listing it came from). decodeModelsEnvelope and
+// decodeAgentsEnvelope exercise it through real payloads; this pins it directly.
+func TestValidateListingFraming(t *testing.T) {
+	if err := validateListingFraming("models", "SUCCESS", "models"); err != nil {
+		t.Fatalf("a SUCCESS models envelope must validate, got: %v", err)
+	}
+	if err := validateListingFraming("agents", "ERROR", "agents"); err == nil ||
+		!strings.Contains(err.Error(), "agy agents:") || !strings.Contains(err.Error(), "status") {
+		t.Fatalf("a non-SUCCESS status must error with the command prefix, got: %v", err)
+	}
+	if err := validateListingFraming("models", "SUCCESS", "run"); err == nil ||
+		!strings.Contains(err.Error(), "agy models:") || !strings.Contains(err.Error(), "command") {
+		t.Fatalf("a mismatched command name must error with the command prefix, got: %v", err)
+	}
+}
+
 // TestModelID pins which part of a model value reaches agy: the id column only,
 // with anything that is not a whole `agy models` row forwarded untouched because
 // agy owns the model namespace (issue #135).

--- a/internal/manager/wait_posix_test.go
+++ b/internal/manager/wait_posix_test.go
@@ -36,19 +36,6 @@ func waitManager(t *testing.T, fake testutil.FakeAgy) *Manager {
 	return m
 }
 
-// drainJob waits for a still-running job to finish, so the test's TempDir
-// StateDir is not removed out from under a supervisor still writing into it.
-func drainJob(t *testing.T, m *Manager, id string) {
-	t.Helper()
-	testutil.WaitFor(t, 5*time.Second, func() bool {
-		st, err := m.Status(id)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return st.State == StateDone
-	}, "job never finished")
-}
-
 // A job that is already done when WaitTerminal is called must return its
 // terminal status without waiting.
 func TestWaitTerminalReturnsDoneJob(t *testing.T) {
@@ -114,6 +101,13 @@ func TestWaitTerminalDeadlineOverrun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
+	// Kill the job's process group at cleanup instead of draining it to
+	// completion. The fake sleeps 2s, and polling for that under a loaded -race
+	// run raced the old 5s drain budget (issue #163). killJob only registers a
+	// t.Cleanup, so the job keeps running through the deadline assertion below; by
+	// the time that cleanup fires the still-running job only needs to stop writing
+	// into the TempDir state dir before it is removed, which SIGKILL does.
+	killJob(t, m, job.ID)
 	st, terminal, err := m.WaitTerminal(t.Context(), job.ID, time.Now().Add(100*time.Millisecond), nil)
 	if err != nil {
 		t.Fatalf("WaitTerminal: %v", err)
@@ -124,7 +118,6 @@ func TestWaitTerminalDeadlineOverrun(t *testing.T) {
 	if st.State != StateRunning {
 		t.Fatalf("state = %q, want running", st.State)
 	}
-	drainJob(t, m, job.ID)
 }
 
 // A cancelled context must end the wait with context.Canceled and a
@@ -135,6 +128,12 @@ func TestWaitTerminalContextCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartJob: %v", err)
 	}
+	// Kill the job's process group at cleanup rather than draining it. The fake
+	// sleeps 2s, and polling for that under a loaded -race run raced the old 5s
+	// drain budget (issue #163). The cancel assertion below is what the test is
+	// about; the still-running job only needs to stop writing into the TempDir
+	// state dir before it is removed, which SIGKILL does.
+	killJob(t, m, job.ID)
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	// Cancel only once WaitTerminal is observably polling, so the cancellation
@@ -148,7 +147,6 @@ func TestWaitTerminalContextCancel(t *testing.T) {
 	if terminal {
 		t.Fatal("terminal = true, want false on cancel")
 	}
-	drainJob(t, m, job.ID)
 }
 
 // An unknown job id must surface the store load failure, not a terminal result.


### PR DESCRIPTION
## Summary

Clears the four deferred low-severity reuse and maintainability items from the #162 review (issue #163), and adds test coverage for the branches they touch. None of the items is a correctness bug; they are all in code #162 introduced or pre-existing.

- Share the `AGY_MCP_*` environment-variable names between config and doctor. `internal/config` now exports `EnvAgyPath`, `EnvDefaultModel`, `EnvStateDir`, and `EnvHTTPToken`, and both `config` and the doctor command's `checkConfigSources` reference those constants instead of separate copies of the literal, so a rename fails to compile in both places rather than drifting silently.
- Probe `agy --version` once per `doctor` run. `checkAgyVersion` now primes the version cache (a new `Manager.markAgyVerified`) on its PASS branch, so the `checkAgyReachable` that follows reuses the verdict instead of spawning a second probe. It primes only on PASS, so a binary below the floor is never marked verified and the reachable check re-probes and fails the same way.
- Share the listing-envelope framing check. `decodeModelsEnvelope` and `decodeAgentsEnvelope` now delegate the identical status/command validation to a single `validateListingFraming`, keeping only the payload decode and the absent-array nil check (whose types genuinely differ) per decoder. The error text is byte-identical.
- Fix the `TestWaitTerminal*` flake. `TestWaitTerminalDeadlineOverrun` and `TestWaitTerminalContextCancel` used a 5s drain poll that raced the fake's 2s sleep under a loaded `-race` run. They now kill the job's process group at cleanup (the pattern the sibling multi-second-sleep tests already use), which removes the timing race rather than widening the budget.

New tests: a single-probe assertion for `doctor` (negative-control verified: without the priming it counts two probes and fails), FAIL-branch coverage for `checkAgyVersion` (below floor) and `checkAgyReachable` (unreachable, pinned to the exec failure), a direct unit test for `validateListingFraming`, and a contract lock on the exported env-var names.

## Related Issues

Closes #163.

## Test Plan

- [x] `go build ./...`, `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./...` (all packages pass)
- [x] Previously-flaky `TestWaitTerminal{DeadlineOverrun,ContextCancel}` pass 20x under `-race`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostic checks so validated tool versions are reused during reachability checks.
  - Doctor now more accurately reports outdated tool versions and unavailable models.

- **Refactor**
  - Standardized environment-variable handling and listing validation for more consistent configuration and command responses.

- **Tests**
  - Added coverage for environment-variable names, diagnostic failures, successful checks, and listing response validation.
  - Improved cleanup for interrupted or timed-out operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->